### PR TITLE
feat(search): add clear button to search input

### DIFF
--- a/frontend/src/routes/_app.search.tsx
+++ b/frontend/src/routes/_app.search.tsx
@@ -3,7 +3,7 @@ import { Card, TagChip, Avatar } from "@/components/shared/primitives";
 import { builders, projects, flares } from "@/mocks/seed";
 import { useState } from "react";
 import { cn } from "@/lib/utils";
-import { Search } from "lucide-react";
+import { Search, X } from "lucide-react";
 
 const tabs = ["Developers", "Projects", "Skills", "Flares"] as const;
 type Tab = (typeof tabs)[number];
@@ -30,15 +30,30 @@ function SearchPage() {
   return (
     <div className="space-y-4">
       <div className="relative">
-        <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
-        <input
-          value={q}
-          onChange={(e) => setQ(e.target.value)}
-          placeholder="Search DevLink…"
-          className="w-full rounded-md border border-border bg-surface py-2.5 pl-10 pr-3 text-[14px] outline-none focus:border-primary focus:ring-2 focus:ring-primary/20"
-          autoFocus
-        />
-      </div>
+  <Search
+    size={16}
+    className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+  />
+
+  <input
+    value={q}
+    onChange={(e) => setQ(e.target.value)}
+    placeholder="Search DevLink…"
+    className="w-full rounded-md border border-border bg-surface py-2.5 pl-10 pr-10 text-[14px] outline-none focus:border-primary focus:ring-2 focus:ring-primary/20"
+    autoFocus
+  />
+
+  {q && (
+    <button
+      type="button"
+      onClick={() => setQ("")}
+      className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+      aria-label="Clear search"
+    >
+      <X size={16} />
+    </button>
+  )}
+</div>
       <div className="flex items-center gap-1 rounded-md border border-border bg-surface p-0.5">
         {tabs.map((t) => (
           <button


### PR DESCRIPTION
# Pull Request

## Summary

Adds a clear ("X") button to the Search page input, allowing users to quickly clear the current search query.

---

## Related Issue

Closes #179

---

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [x] UI/UX enhancement
- [ ] Tests
- [ ] Other

---

## Changes Made

- Added a clear ("X") button to the Search page search input.
- Display the clear button only when the search field contains text.
- Clear the search query instantly when the button is clicked while preserving the existing search functionality.

---

## Screenshots (if applicable)

<!-- Add screenshots or a short screen recording showing the clear button appearing and clearing the search input. -->

---

## Testing

Describe how you tested your changes.

- [x] Tested locally
- [ ] Existing tests pass
- [ ] Added new tests
- [x] UI verified
- [ ] Cross-browser tested (if applicable)

Additional testing notes:

- Verified that the clear button appears only when the search input contains text.
- Verified that clicking the button clears the search input and restores the full results list.
- Verified that the search icon and layout remain unchanged.

---

## Checklist

- [x] My code follows the project's coding standards.
- [x] I have tested my changes locally.
- [ ] I have updated the documentation where necessary.
- [x] My changes do not introduce new warnings or errors.
- [x] I have reviewed my own code.
- [x] This pull request focuses on a single feature or fix.
- [x] I have linked the related issue.

---

## Screenshot
<img width="1587" height="427" alt="image" src="https://github.com/user-attachments/assets/0b6225de-b6f3-40c1-b5a8-73f90f26b4cd" />


## Additional Notes

This change is limited to the dedicated Search page (`_app.search.tsx`) and does not modify other search inputs in the application due to confusion in issue.