### PR TITLE
feat(notifications): trigger notifications on follow, message, and ap…

### DIFF
--- a/backend/app/routers/applications.py
+++ b/backend/app/routers/applications.py
@@ -14,6 +14,9 @@ from app.schemas.application import (
     ApplicationUpdate,
 )
 from app.services.application_service import ApplicationService
+from app.models.notification import NotificationType
+from app.models.project import Project
+from app.services.notification_service import NotificationService
 
 router = APIRouter(
     prefix="/applications",
@@ -32,13 +35,32 @@ def create_application(
     current_user: User = Depends(get_current_user),
 ):
 
-    return ApplicationService.create_application(
+    created = ApplicationService.create_application(
         db=db,
         applicant_id=current_user.id,
         project_id=application.project_id,
         flare_id=application.flare_id,
         application=application,
     )
+
+    try:
+        project = db.get(Project, created.project_id)
+        if project is not None:
+            NotificationService.notify(
+                db,
+                recipient_id=project.owner_id,
+                sender_id=current_user.id,
+                type=NotificationType.APPLICATION,
+                title="New application",
+                message=f"{current_user.username} applied to your project.",
+                project_id=created.project_id,
+                application_id=created.id,
+                action_url=f"/applications/{created.id}",
+            )
+    except Exception:
+        db.rollback()
+
+    return created
 
 
 @router.get(
@@ -129,6 +151,7 @@ def update_application(
 def accept_application(
     application_id: uuid.UUID,
     db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
 ):
 
     db_application = ApplicationService.get_application(
@@ -142,10 +165,27 @@ def accept_application(
             detail="Application not found",
         )
 
-    return ApplicationService.accept_application(
+    accepted = ApplicationService.accept_application(
         db,
         db_application,
     )
+
+    try:
+        NotificationService.notify(
+            db,
+            recipient_id=db_application.applicant_id,
+            sender_id=current_user.id,
+            type=NotificationType.APPLICATION_ACCEPTED,
+            title="Application accepted",
+            message="Your application was accepted. 🎉",
+            project_id=db_application.project_id,
+            application_id=db_application.id,
+            action_url=f"/applications/{db_application.id}",
+        )
+    except Exception:
+        db.rollback()
+
+    return accepted
 
 
 @router.patch(
@@ -155,6 +195,7 @@ def accept_application(
 def reject_application(
     application_id: uuid.UUID,
     db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
 ):
 
     db_application = ApplicationService.get_application(
@@ -168,10 +209,27 @@ def reject_application(
             detail="Application not found",
         )
 
-    return ApplicationService.reject_application(
+    rejected = ApplicationService.reject_application(
         db,
         db_application,
     )
+
+    try:
+        NotificationService.notify(
+            db,
+            recipient_id=db_application.applicant_id,
+            sender_id=current_user.id,
+            type=NotificationType.APPLICATION_REJECTED,
+            title="Application rejected",
+            message="Your application was not accepted this time.",
+            project_id=db_application.project_id,
+            application_id=db_application.id,
+            action_url=f"/applications/{db_application.id}",
+        )
+    except Exception:
+        db.rollback()
+
+    return rejected
 
 
 @router.patch(

--- a/backend/app/routers/followers.py
+++ b/backend/app/routers/followers.py
@@ -10,6 +10,8 @@ from app.dependencies import get_current_user
 from app.models.user import User
 from app.schemas.follower import FollowerResponse
 from app.services.follower_service import FollowerService
+from app.models.notification import NotificationType
+from app.services.notification_service import NotificationService
 
 router = APIRouter(
     prefix="/followers",
@@ -46,11 +48,26 @@ def follow_user(
             detail="Already following this user",
         )
 
-    return FollowerService.follow_user(
+    follow = FollowerService.follow_user(
         db,
         current_user.id,
         user_id,
     )
+
+    try:
+        NotificationService.notify(
+            db,
+            recipient_id=user_id,
+            sender_id=current_user.id,
+            type=NotificationType.FOLLOW,
+            title="New follower",
+            message=f"{current_user.username} started following you.",
+            action_url=f"/users/{current_user.id}",
+        )
+    except Exception:
+        db.rollback()
+
+    return follow
 
 
 @router.delete(

--- a/backend/app/routers/messages.py
+++ b/backend/app/routers/messages.py
@@ -14,6 +14,11 @@ from app.schemas.message import (
     MessageUpdate,
 )
 from app.services.message_service import MessageService
+from sqlalchemy import select
+
+from app.models.conversation_member import ConversationMember
+from app.models.notification import NotificationType
+from app.services.notification_service import NotificationService
 
 router = APIRouter(
     prefix="/messages",
@@ -32,12 +37,37 @@ def send_message(
     current_user: User = Depends(get_current_user),
 ):
 
-    return MessageService.send_message(
+    sent = MessageService.send_message(
         db=db,
         conversation_id=message.conversation_id,
         sender_id=current_user.id,
         message=message,
     )
+
+    try:
+        recipient_ids = db.scalars(
+            select(ConversationMember.user_id).where(
+                ConversationMember.conversation_id == message.conversation_id,
+                ConversationMember.user_id != current_user.id,
+            )
+        ).all()
+
+        for recipient_id in recipient_ids:
+            NotificationService.notify(
+                db,
+                recipient_id=recipient_id,
+                sender_id=current_user.id,
+                type=NotificationType.MESSAGE,
+                title="New message",
+                message=f"{current_user.username} sent you a message.",
+                conversation_id=message.conversation_id,
+                message_id=sent.id,
+                action_url=f"/conversations/{message.conversation_id}",
+            )
+    except Exception:
+        db.rollback()
+
+    return sent
 
 
 @router.get(

--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+from app.models.notification import NotificationType
+
+
+# ==========================================================
+# Base
+# ==========================================================
+
+
+class NotificationBase(BaseModel):
+    type: NotificationType
+    title: str
+    message: str
+
+    action_url: Optional[str] = None
+    image_url: Optional[str] = None
+
+    project_id: Optional[uuid.UUID] = None
+    conversation_id: Optional[uuid.UUID] = None
+    message_id: Optional[uuid.UUID] = None
+    application_id: Optional[uuid.UUID] = None
+
+
+# ==========================================================
+# Create  (the existing test endpoint reads notification.recipient_id)
+# ==========================================================
+
+
+class NotificationCreate(NotificationBase):
+    recipient_id: uuid.UUID
+
+
+# ==========================================================
+# Update
+# ==========================================================
+
+
+class NotificationUpdate(BaseModel):
+    is_read: Optional[bool] = None
+    title: Optional[str] = None
+    message: Optional[str] = None
+    action_url: Optional[str] = None
+    image_url: Optional[str] = None
+
+
+# ==========================================================
+# Response
+# ==========================================================
+
+
+class NotificationResponse(NotificationBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    recipient_id: uuid.UUID
+    sender_id: Optional[uuid.UUID] = None
+
+    is_read: bool
+    read_at: Optional[datetime] = None
+
+    created_at: datetime
+    updated_at: datetime

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.models.notification import Notification
+from app.models.notification import Notification, NotificationType
 from app.schemas.notification import (
     NotificationCreate,
     NotificationUpdate,
@@ -38,6 +38,45 @@ class NotificationService:
             conversation_id=notification.conversation_id,
             message_id=notification.message_id,
             application_id=notification.application_id,
+        )
+
+        db.add(db_notification)
+        db.commit()
+        db.refresh(db_notification)
+
+        return db_notification
+
+    @staticmethod
+    def notify(
+        db: Session,
+        *,
+        recipient_id: uuid.UUID,
+        sender_id: uuid.UUID | None,
+        type: NotificationType,
+        title: str,
+        message: str,
+        action_url: str | None = None,
+        image_url: str | None = None,
+        project_id: uuid.UUID | None = None,
+        conversation_id: uuid.UUID | None = None,
+        message_id: uuid.UUID | None = None,
+        application_id: uuid.UUID | None = None,
+    ) -> Notification | None:
+        if sender_id is not None and recipient_id == sender_id:
+            return None
+
+        db_notification = Notification(
+            recipient_id=recipient_id,
+            sender_id=sender_id,
+            type=type,
+            title=title,
+            message=message,
+            action_url=action_url,
+            image_url=image_url,
+            project_id=project_id,
+            conversation_id=conversation_id,
+            message_id=message_id,
+            application_id=application_id,
         )
 
         db.add(db_notification)

--- a/backend/tests/test_notifications_events.py
+++ b/backend/tests/test_notifications_events.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.database.base import Base
+from app.database.session import get_db
+from app.main import app
+
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = override_get_db
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+def _register_and_login(client: TestClient, email: str, username: str) -> tuple[str, str]:
+    client.post("/api/auth/register", json={
+        "first_name": username.capitalize(),
+        "last_name": "User",
+        "email": email,
+        "username": username,
+        "password": "Passw0rd!",
+    })
+    r = client.post("/api/auth/login", json={"email": email, "password": "Passw0rd!"})
+    token = r.json()["access_token"]
+    me = client.get("/api/users/me", headers={"Authorization": f"Bearer {token}"})
+    return me.json()["id"], token
+
+
+def test_follow_creates_notification():
+    client = TestClient(app)
+    a_id, a_tok = _register_and_login(client, "a@x.com", "alice")
+    b_id, b_tok = _register_and_login(client, "b@x.com", "bob")
+
+    r = client.post(f"/followers/{a_id}", headers={"Authorization": f"Bearer {b_tok}"})
+    assert r.status_code == 201
+
+    notifs = client.get("/api/notifications/", headers={"Authorization": f"Bearer {a_tok}"}).json()
+    assert any(n["type"] == "follow" for n in notifs)
+
+    b_notifs = client.get("/api/notifications/", headers={"Authorization": f"Bearer {b_tok}"}).json()
+    assert all(n["type"] != "follow" for n in b_notifs)
+
+
+def test_no_self_notification():
+    client = TestClient(app)
+    a_id, a_tok = _register_and_login(client, "c@x.com", "charlie")
+
+    r = client.post(f"/followers/{a_id}", headers={"Authorization": f"Bearer {a_tok}"})
+    assert r.status_code == 400
+
+
+def test_notify_returns_none_when_recipient_is_sender():
+    from app.services.notification_service import NotificationService
+    from app.models.notification import NotificationType
+    db = TestingSessionLocal()
+    result = NotificationService.notify(
+        db,
+        recipient_id="00000000-0000-0000-0000-000000000001",
+        sender_id="00000000-0000-0000-0000-000000000001",
+        type=NotificationType.FOLLOW,
+        title="Self test",
+        message="Should not be created.",
+    )
+    assert result is None
+    db.close()


### PR DESCRIPTION
# Pull Request

## Summary

Wire the existing `create_notification` service into real application events (follow, message, application create/accept/reject) so notifications work end-to-end, synchronously. Adds the missing notification Pydantic schema and a `NotificationService.notify` helper with a self-notification guard.

---

## Related Issue

Part of #161 (ECSoC 2026)

---

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [ ] UI/UX enhancement
- [x] Tests
- [ ] Other

---

## Changes Made

- **Create** `backend/app/schemas/notification.py` — was missing, imported by existing router and service
- **Add** `notify()` static method to `NotificationService` — never notifies the actor, never breaks the primary action
- **Wire** `follow_user` → `FOLLOW` notification to the followed user
- **Wire** `send_message` → `MESSAGE` notification to all other conversation members
- **Wire** `create_application` → `APPLICATION` notification to the project owner
- **Wire** `accept_application` / `reject_application` → `APPLICATION_ACCEPTED` / `APPLICATION_REJECTED` to the applicant (added `current_user` dependency to both endpoints)
- **Create** `backend/tests/test_notifications_events.py` — 3 tests

---

## Screenshots (if applicable)

N/A — backend-only change.

---

## Testing

- [x] Tested locally
- [x] Existing tests pass
- [x] Added new tests
- [ ] UI verified
- [ ] Cross-browser tested (if applicable)

Additional testing notes: Tested with SQLite in-memory via `TestClient`. Celery/Redis async delivery is explicitly deferred to PR 2.

---

## Checklist

- [x] My code follows the project's coding standards.
- [x] I have tested my changes locally.
- [x] I have updated the documentation where necessary.
- [x] My changes do not introduce new warnings or errors.
- [x] I have reviewed my own code.
- [x] This pull request focuses on a single feature or fix.
- [x] I have linked the related issue.

---

## Additional Notes

**Pre-existing breakage (out of scope):** `main.py` imports three routers that don't exist on disk (`builders`, `builder_flare`—singular mismatch, `ai`). Local stubs were used for testing. Flagged in issue #161.

**Event → Notification type map:**

| Event | Endpoint | Recipient | Type |
|-------|----------|-----------|------|
| New follower | `POST /followers/{user_id}` | followed user | `FOLLOW` |
| Message sent | `POST /messages/` | other conversation members | `MESSAGE` |
| New application | `POST /applications/` | project owner | `APPLICATION` |
| Application accepted | `PATCH /applications/{id}/accept` | applicant | `APPLICATION_ACCEPTED` |
| Application rejected | `PATCH /applications/{id}/reject` | applicant | `APPLICATION_REJECTED` |