### PR TITLE
feat(security): make security headers configurable

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,10 @@
+### Configurable Security Headers
+
+The following response headers can be enabled or disabled through environment settings:
+
+- ENABLE_X_FRAME_OPTIONS
+- ENABLE_X_CONTENT_TYPE_OPTIONS
+- ENABLE_HSTS
+- ENABLE_CSP
+- ENABLE_DNS_PREFETCH_CONTROL
+- ENABLE_CROSS_DOMAIN_POLICIES

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -127,6 +127,8 @@ class Settings(BaseSettings):
     ENABLE_CSP: bool = True
     ENABLE_X_FRAME_OPTIONS: bool = True
     ENABLE_X_CONTENT_TYPE_OPTIONS: bool = True
+    ENABLE_DNS_PREFETCH_CONTROL: bool = True
+    ENABLE_CROSS_DOMAIN_POLICIES: bool = True
 
     # ==========================================================
     # Celery

--- a/backend/app/middleware/security_headers.py
+++ b/backend/app/middleware/security_headers.py
@@ -18,8 +18,11 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
         response = await call_next(request)
 
-        response.headers["X-Content-Type-Options"] = "nosniff"
-        response.headers["X-Frame-Options"] = "DENY"
+        if settings.ENABLE_X_CONTENT_TYPE_OPTIONS:
+            response.headers["X-Content-Type-Options"] = "nosniff"
+
+        if settings.ENABLE_X_FRAME_OPTIONS:
+            response.headers["X-Frame-Options"] = "DENY"
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
 
         response.headers["Permissions-Policy"] = (
@@ -31,6 +34,12 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response.headers["Cross-Origin-Resource-Policy"] = "same-origin"
 
         response.headers["Cross-Origin-Embedder-Policy"] = "require-corp"
+
+        if settings.ENABLE_CROSS_DOMAIN_POLICIES:
+            response.headers["X-Permitted-Cross-Domain-Policies"] = "none"
+
+        if settings.ENABLE_DNS_PREFETCH_CONTROL:
+            response.headers["X-DNS-Prefetch-Control"] = "off"
 
         if settings.ENABLE_HSTS:
             response.headers["Strict-Transport-Security"] = (


### PR DESCRIPTION
## Description

This PR improves the configurability of backend security headers while preserving the existing default behavior.

### Changes
- Made `X-Content-Type-Options` configurable using `ENABLE_X_CONTENT_TYPE_OPTIONS`.
- Made `X-Frame-Options` configurable using `ENABLE_X_FRAME_OPTIONS`.
- Added configurable support for `X-Permitted-Cross-Domain-Policies`.
- Added configurable support for `X-DNS-Prefetch-Control`.
- Added documentation for configurable security header settings in the backend README.

### Why

The project already includes core security mechanisms such as CSP, HSTS, CORS, and rate limiting. This PR enhances flexibility by allowing additional security headers to be enabled or disabled through configuration without changing the default behavior.

Closes #105