### PR TITLE
feat(health): add readiness health endpoint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -34,6 +34,7 @@ from app.routers import (
     builder_flares,
     conversations,
     followers,
+    health,
     messages,
     notifications,
     organizations,
@@ -129,7 +130,7 @@ async def root():
 
 
 @app.get("/health", tags=["Health"])
-async def health():
+async def health_simple():
     return {
         "status": "healthy",
         "environment": settings.ENVIRONMENT,
@@ -175,3 +176,4 @@ app.include_router(repositories.router)
 app.include_router(organizations.router)
 app.include_router(applications.router)
 app.include_router(skills.router)
+app.include_router(health.router)

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -16,7 +16,10 @@ def _check_database() -> dict:
         start = time.monotonic()
         with engine.connect() as conn:
             conn.execute(text("SELECT 1"))
-        return {"status": "healthy", "latency_ms": round((time.monotonic() - start) * 1000, 2)}
+        return {
+            "status": "healthy",
+            "latency_ms": round((time.monotonic() - start) * 1000, 2),
+        }
     except Exception:
         return {"status": "unhealthy", "error": "Database connection failed"}
 
@@ -27,7 +30,10 @@ def _check_redis() -> dict:
         try:
             start = time.monotonic()
             r.ping()
-            return {"status": "healthy", "latency_ms": round((time.monotonic() - start) * 1000, 2)}
+            return {
+                "status": "healthy",
+                "latency_ms": round((time.monotonic() - start) * 1000, 2),
+            }
         finally:
             r.close()
     except Exception:
@@ -57,7 +63,9 @@ async def health_ready():
     celery = _check_celery()
 
     all_healthy = db["status"] == "healthy" and redis["status"] == "healthy"
-    http_status = status.HTTP_200_OK if all_healthy else status.HTTP_503_SERVICE_UNAVAILABLE
+    http_status = (
+        status.HTTP_200_OK if all_healthy else status.HTTP_503_SERVICE_UNAVAILABLE
+    )
 
     return JSONResponse(
         status_code=http_status,

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -1,0 +1,73 @@
+import time
+
+from fastapi import APIRouter, status
+from fastapi.responses import JSONResponse
+from sqlalchemy import text
+import redis as redis_lib
+
+from app.core.config import settings
+from app.database.database import engine
+
+router = APIRouter(prefix="/health", tags=["Health"])
+
+
+def _check_database() -> dict:
+    try:
+        start = time.monotonic()
+        with engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+        return {"status": "healthy", "latency_ms": round((time.monotonic() - start) * 1000, 2)}
+    except Exception:
+        return {"status": "unhealthy", "error": "Database connection failed"}
+
+
+def _check_redis() -> dict:
+    try:
+        r = redis_lib.from_url(settings.REDIS_URL, socket_connect_timeout=2)
+        try:
+            start = time.monotonic()
+            r.ping()
+            return {"status": "healthy", "latency_ms": round((time.monotonic() - start) * 1000, 2)}
+        finally:
+            r.close()
+    except Exception:
+        return {"status": "unhealthy", "error": "Redis connection failed"}
+
+
+def _check_celery() -> dict:
+    try:
+        from app.core.celery_app import celery_app
+    except ImportError:
+        return {"status": "disabled"}
+
+    try:
+        inspect = celery_app.control.inspect(timeout=2)
+        active = inspect.active()
+        if active is None:
+            return {"status": "no_workers"}
+        return {"status": "healthy", "workers": len(active)}
+    except Exception:
+        return {"status": "unhealthy", "error": "Celery unable to connect to workers"}
+
+
+@router.get("/ready", summary="Readiness health check")
+async def health_ready():
+    db = _check_database()
+    redis = _check_redis()
+    celery = _check_celery()
+
+    all_healthy = db["status"] == "healthy" and redis["status"] == "healthy"
+    http_status = status.HTTP_200_OK if all_healthy else status.HTTP_503_SERVICE_UNAVAILABLE
+
+    return JSONResponse(
+        status_code=http_status,
+        content={
+            "status": "healthy" if all_healthy else "degraded",
+            "environment": settings.ENVIRONMENT,
+            "services": {
+                "database": db,
+                "redis": redis,
+                "celery": celery,
+            },
+        },
+    )


### PR DESCRIPTION
## Summary

Adds a readiness health endpoint that verifies the status of core backend services.

### Changes

- Added a new `/health/ready` endpoint.
- Added database connectivity check using `SELECT 1`.
- Added Redis connectivity check with latency measurement.
- Added Celery worker status check (when enabled).
- Returns `200 OK` when required services are healthy.
- Returns `503 Service Unavailable` when database or Redis is unavailable.
- Added service-specific status information to the response.
- Registered the health router in the application.

### Example Response

```json
{
  "status": "healthy",
  "environment": "development",
  "services": {
    "database": {
      "status": "healthy",
      "latency_ms": 2.4
    },
    "redis": {
      "status": "healthy",
      "latency_ms": 1.8
    },
    "celery": {
      "status": "healthy",
      "workers": 1
    }
  }
}
```

Closes:#272