### PR TITLE
fix: prevent users from messaging themselves

### DIFF
--- a/backend/app/services/conversation_service.py
+++ b/backend/app/services/conversation_service.py
@@ -123,6 +123,7 @@ class ConversationService:
 
             # Direct conversations cannot have more than 2 members
             from sqlalchemy import func
+
             member_count = db.scalar(
                 select(func.count(ConversationMember.id)).where(
                     ConversationMember.conversation_id == conversation_id

--- a/backend/app/services/conversation_service.py
+++ b/backend/app/services/conversation_service.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import uuid
 
+from fastapi import HTTPException, status
 from sqlalchemy import and_, or_, select
 from sqlalchemy.orm import Session
 
-from app.models.conversation import Conversation
-from app.models.conversation_member import ConversationMember
+from app.models.conversation import Conversation, ConversationType
+from app.models.conversation_member import ConversationMember, ConversationRole
 from app.schemas.conversation import (
     ConversationCreate,
     ConversationUpdate,
@@ -28,12 +29,20 @@ class ConversationService:
         db_conversation = Conversation(
             title=conversation.title,
             type=conversation.type,
-            description=conversation.description,
             project_id=conversation.project_id,
             created_by=owner_id,
         )
 
         db.add(db_conversation)
+        db.flush()
+
+        # Automatically add the owner/creator as a member of the conversation
+        owner_member = ConversationMember(
+            conversation_id=db_conversation.id,
+            user_id=owner_id,
+            role=ConversationRole.OWNER,
+        )
+        db.add(owner_member)
         db.commit()
         db.refresh(db_conversation)
 
@@ -95,6 +104,50 @@ class ConversationService:
         conversation_id: uuid.UUID,
         user_id: uuid.UUID,
     ) -> ConversationMember:
+
+        # Fetch conversation
+        conversation = db.get(Conversation, conversation_id)
+        if not conversation:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Conversation not found",
+            )
+
+        # Prevent self-messaging in direct conversations
+        if conversation.type == ConversationType.DIRECT:
+            if user_id == conversation.created_by:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="You cannot add yourself to a direct conversation",
+                )
+
+            # Direct conversations cannot have more than 2 members
+            from sqlalchemy import func
+            member_count = db.scalar(
+                select(func.count(ConversationMember.id)).where(
+                    ConversationMember.conversation_id == conversation_id
+                )
+            )
+            if member_count >= 2:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Direct conversations cannot have more than 2 members",
+                )
+
+        # Check if user is already a member
+        existing_member = db.scalar(
+            select(ConversationMember).where(
+                and_(
+                    ConversationMember.conversation_id == conversation_id,
+                    ConversationMember.user_id == user_id,
+                )
+            )
+        )
+        if existing_member:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="User is already a member of this conversation",
+            )
 
         member = ConversationMember(
             conversation_id=conversation_id,

--- a/backend/tests/test_conversations.py
+++ b/backend/tests/test_conversations.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import pytest
+import uuid
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from fastapi import HTTPException
+
+from app.database.base import Base
+from app.dependencies import get_database
+from app.main import app
+from app.models.user import User
+from app.models.conversation import Conversation, ConversationType
+from app.models.conversation_member import ConversationMember, ConversationRole
+from app.schemas.conversation import ConversationCreate
+from app.services.conversation_service import ConversationService
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    app.dependency_overrides[get_database] = override_get_db
+    Base.metadata.create_all(bind=engine)
+
+    yield
+
+    Base.metadata.drop_all(bind=engine)
+    app.dependency_overrides.clear()
+
+
+def _create_user(db, email: str, username: str) -> User:
+    user = User(
+        email=email,
+        username=username,
+        first_name=username.capitalize(),
+        last_name="Test",
+        password_hash="fakehash",
+        is_active=True,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def test_create_conversation_auto_adds_owner():
+    db = TestingSessionLocal()
+    user = _create_user(db, "owner@example.com", "owner")
+
+    conv_in = ConversationCreate(
+        type=ConversationType.DIRECT,
+        title="Direct Chat",
+    )
+
+    conv = ConversationService.create_conversation(db, user.id, conv_in)
+
+    assert conv.id is not None
+    assert conv.created_by == user.id
+
+    # Verify owner is a member
+    members = db.query(ConversationMember).filter_by(conversation_id=conv.id).all()
+    assert len(members) == 1
+    assert members[0].user_id == user.id
+    assert members[0].role == ConversationRole.OWNER
+
+    db.close()
+
+
+def test_add_creator_to_direct_fails():
+    db = TestingSessionLocal()
+    user = _create_user(db, "owner@example.com", "owner")
+
+    conv_in = ConversationCreate(
+        type=ConversationType.DIRECT,
+        title="Direct Chat",
+    )
+
+    conv = ConversationService.create_conversation(db, user.id, conv_in)
+
+    # Adding the creator to their own direct conversation should fail
+    with pytest.raises(HTTPException) as exc_info:
+        ConversationService.add_member(db, conv.id, user.id)
+
+    assert exc_info.value.status_code == 400
+    assert "cannot add yourself" in exc_info.value.detail.lower()
+
+    db.close()
+
+
+def test_add_duplicate_member_fails():
+    db = TestingSessionLocal()
+    user1 = _create_user(db, "user1@example.com", "user1")
+    user2 = _create_user(db, "user2@example.com", "user2")
+
+    conv_in = ConversationCreate(
+        type=ConversationType.GROUP,
+        title="Group Chat",
+    )
+
+    conv = ConversationService.create_conversation(db, user1.id, conv_in)
+    # Creator user1 is auto-added as member. Let's add user2.
+    ConversationService.add_member(db, conv.id, user2.id)
+
+    # Adding user2 again should fail
+    with pytest.raises(HTTPException) as exc_info:
+        ConversationService.add_member(db, conv.id, user2.id)
+
+    assert exc_info.value.status_code == 400
+    assert "already a member" in exc_info.value.detail.lower()
+
+    db.close()
+
+
+def test_add_third_member_to_direct_fails():
+    db = TestingSessionLocal()
+    user1 = _create_user(db, "user1@example.com", "user1")
+    user2 = _create_user(db, "user2@example.com", "user2")
+    user3 = _create_user(db, "user3@example.com", "user3")
+
+    conv_in = ConversationCreate(
+        type=ConversationType.DIRECT,
+        title="Direct Chat",
+    )
+
+    conv = ConversationService.create_conversation(db, user1.id, conv_in)
+    # user1 is creator/member. Adding user2.
+    ConversationService.add_member(db, conv.id, user2.id)
+
+    # Adding user3 should fail because direct conversation is full (has 2 members already)
+    with pytest.raises(HTTPException) as exc_info:
+        ConversationService.add_member(db, conv.id, user3.id)
+
+    assert exc_info.value.status_code == 400
+    assert "cannot have more than 2 members" in exc_info.value.detail.lower()
+
+    db.close()
+
+
+def test_router_prevent_self_messaging_integration():
+    client = TestClient(app)
+
+    # Register and login a user
+    client.post(
+        "/api/auth/register",
+        json={
+            "first_name": "Charlie",
+            "last_name": "Test",
+            "email": "charlie@example.com",
+            "username": "charlie",
+            "password": "Passw0rd!",
+        },
+    )
+
+    login_resp = client.post(
+        "/api/auth/login",
+        json={
+            "email": "charlie@example.com",
+            "password": "Passw0rd!",
+        },
+    )
+    token = login_resp.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    # Create direct conversation via router
+    conv_resp = client.post(
+        "/conversations/",
+        json={
+            "type": "direct",
+        },
+        headers=headers,
+    )
+    assert conv_resp.status_code == 201
+    conv_id = conv_resp.json()["id"]
+    creator_id = conv_resp.json()["created_by"]
+
+    # Try to add creator as member (which represents self-messaging)
+    add_resp = client.post(
+        f"/conversations/{conv_id}/members/{creator_id}",
+        headers=headers,
+    )
+    assert add_resp.status_code == 400
+    assert "cannot add yourself" in add_resp.json()["detail"].lower()

--- a/frontend/src/routes/_app.settings.tsx
+++ b/frontend/src/routes/_app.settings.tsx
@@ -26,7 +26,8 @@ function SettingsPage() {
   const [tab, setTab] = useState<Tab>("Account");
   const [showCurrentPassword, setShowCurrentPassword] = useState(false);
   const [showNewPassword, setShowNewPassword] = useState(false);
-  const inp = "w-full rounded-md border border-border bg-surface px-3 py-[8px] text-[14px] text-foreground outline-none focus:border-primary focus:ring-2 focus:ring-primary/20";
+  const inp =
+    "w-full rounded-md border border-border bg-surface px-3 py-[8px] text-[14px] text-foreground outline-none focus:border-primary focus:ring-2 focus:ring-primary/20";
   const lbl = "mb-1 block text-[13px] font-semibold text-foreground";
 
   return (
@@ -118,48 +119,48 @@ function SettingsPage() {
               </div>
             )}
             {tab === "Security" && (
-  <div className="space-y-4">
-    <div>
-      <label className={lbl}>Current password</label>
-      <div className="relative">
-        <input
-          type={showCurrentPassword ? "text" : "password"}
-          className={`${inp} pr-10`}
-        />
-        <button
-          type="button"
-          onClick={() => setShowCurrentPassword(!showCurrentPassword)}
-          className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-          aria-label={showCurrentPassword ? "Hide password" : "Show password"}
-        >
-          {showCurrentPassword ? <EyeOff size={18} /> : <Eye size={18} />}
-        </button>
-      </div>
-    </div>
+              <div className="space-y-4">
+                <div>
+                  <label className={lbl}>Current password</label>
+                  <div className="relative">
+                    <input
+                      type={showCurrentPassword ? "text" : "password"}
+                      className={`${inp} pr-10`}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowCurrentPassword(!showCurrentPassword)}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                      aria-label={showCurrentPassword ? "Hide password" : "Show password"}
+                    >
+                      {showCurrentPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+                    </button>
+                  </div>
+                </div>
 
-    <div>
-      <label className={lbl}>New password</label>
-      <div className="relative">
-        <input
-          type={showNewPassword ? "text" : "password"}
-          className={`${inp} pr-10`}
-        />
-        <button
-          type="button"
-          onClick={() => setShowNewPassword(!showNewPassword)}
-          className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-          aria-label={showNewPassword ? "Hide password" : "Show password"}
-        >
-          {showNewPassword ? <EyeOff size={18} /> : <Eye size={18} />}
-        </button>
-      </div>
-    </div>
+                <div>
+                  <label className={lbl}>New password</label>
+                  <div className="relative">
+                    <input
+                      type={showNewPassword ? "text" : "password"}
+                      className={`${inp} pr-10`}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowNewPassword(!showNewPassword)}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                      aria-label={showNewPassword ? "Hide password" : "Show password"}
+                    >
+                      {showNewPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+                    </button>
+                  </div>
+                </div>
 
-    <button className="rounded-md bg-primary px-4 py-2 text-[13px] font-semibold text-primary-foreground hover:opacity-90">
-      Update password
-    </button>
-  </div>
-)}
+                <button className="rounded-md bg-primary px-4 py-2 text-[13px] font-semibold text-primary-foreground hover:opacity-90">
+                  Update password
+                </button>
+              </div>
+            )}
             {tab === "Billing" && (
               <div className="rounded-md border border-primary/30 bg-primary-soft p-4 text-[13px] text-foreground">
                 You're on the <span className="font-semibold">Pro</span> plan. Next invoice on Nov


### PR DESCRIPTION
## Summary

This PR prevents users from initiating conversations with themselves by adding validation at the service layer and includes tests to verify the new behavior.

## Changes Made

- Updated `create_conversation` to automatically register the creator as a conversation member.
- Fixed the `create_conversation` mapping by removing the invalid `description` field reference.
- Added validation in `add_member` to return **400 Bad Request** when:
  - A user attempts to add themselves to a direct conversation.
  - A user is already a member of the conversation.
  - A direct conversation already contains two members.
- Added comprehensive tests for the new validation and conversation behavior.

## Testing

- ✅ Added `test_conversations.py` covering the new validation rules.
- ✅ Verified that all **15 tests pass** successfully.
- ✅ Confirmed existing conversation functionality remains unaffected.

## Issue

Closes #230 