### PR TITLE
feat(projects): add project statistics endpoint

### DIFF
--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -14,6 +14,7 @@ from app.models.user import User
 from app.schemas.project import (
     ProjectCreate,
     ProjectResponse,
+    ProjectStatsResponse,
     ProjectUpdate,
 )
 from app.services.project_service import ProjectService
@@ -284,6 +285,26 @@ def star_project(
     return {
         "message": "Project starred",
     }
+
+
+@router.get(
+    "/{project_id}/stats",
+    response_model=ProjectStatsResponse,
+)
+def get_project_stats(
+    project_id: uuid.UUID,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
+):
+    project = ProjectService.get_project(db, project_id)
+
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    if project.owner_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Permission denied")
+
+    return ProjectService.get_project_stats(db, project_id)
 
 
 @router.delete(

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -49,6 +49,16 @@ class ProjectUpdate(BaseModel):
     banner_url: Optional[str] = None
 
 
+class ProjectStatsResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    project_id: uuid.UUID
+    views: int
+    applicants: int
+    accepted_members: int
+    bookmark_count: int
+
+
 class ProjectResponse(ProjectBase):
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/services/project_service.py
+++ b/backend/app/services/project_service.py
@@ -6,7 +6,11 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.models.project import Project
-from app.schemas.project import ProjectCreate, ProjectUpdate
+from app.schemas.project import (
+    ProjectCreate,
+    ProjectStatsResponse,
+    ProjectUpdate,
+)
 
 
 class ProjectService:
@@ -166,6 +170,47 @@ class ProjectService:
             db_project.stars -= 1
 
         db.commit()
+
+    @staticmethod
+    def get_project_stats(
+        db: Session,
+        project_id: uuid.UUID,
+    ) -> ProjectStatsResponse:
+        from sqlalchemy import func, select
+        from app.models.application import Application
+        from app.models.bookmark import Bookmark
+        from app.models.project_member import ProjectMember, MemberRole
+
+        project = db.get(Project, project_id)
+        assert project is not None
+
+        applicants = db.scalar(
+            select(func.count()).select_from(Application).where(
+                Application.project_id == project_id
+            )
+        ) or 0
+
+        accepted_members = db.scalar(
+            select(func.count()).select_from(ProjectMember).where(
+                ProjectMember.project_id == project_id,
+                ProjectMember.is_active.is_(True),
+                ProjectMember.role != MemberRole.OWNER,
+            )
+        ) or 0
+
+        bookmark_count = db.scalar(
+            select(func.count()).select_from(Bookmark).where(
+                Bookmark.project_id == project_id
+            )
+        ) or 0
+
+        return ProjectStatsResponse(
+            project_id=project_id,
+            views=project.views,
+            applicants=applicants,
+            accepted_members=accepted_members,
+            bookmark_count=bookmark_count,
+        )
 
     @staticmethod
     def delete_project(

--- a/backend/app/services/project_service.py
+++ b/backend/app/services/project_service.py
@@ -184,25 +184,36 @@ class ProjectService:
         project = db.get(Project, project_id)
         assert project is not None
 
-        applicants = db.scalar(
-            select(func.count()).select_from(Application).where(
-                Application.project_id == project_id
+        applicants = (
+            db.scalar(
+                select(func.count())
+                .select_from(Application)
+                .where(Application.project_id == project_id)
             )
-        ) or 0
+            or 0
+        )
 
-        accepted_members = db.scalar(
-            select(func.count()).select_from(ProjectMember).where(
-                ProjectMember.project_id == project_id,
-                ProjectMember.is_active.is_(True),
-                ProjectMember.role != MemberRole.OWNER,
+        accepted_members = (
+            db.scalar(
+                select(func.count())
+                .select_from(ProjectMember)
+                .where(
+                    ProjectMember.project_id == project_id,
+                    ProjectMember.is_active.is_(True),
+                    ProjectMember.role != MemberRole.OWNER,
+                )
             )
-        ) or 0
+            or 0
+        )
 
-        bookmark_count = db.scalar(
-            select(func.count()).select_from(Bookmark).where(
-                Bookmark.project_id == project_id
+        bookmark_count = (
+            db.scalar(
+                select(func.count())
+                .select_from(Bookmark)
+                .where(Bookmark.project_id == project_id)
             )
-        ) or 0
+            or 0
+        )
 
         return ProjectStatsResponse(
             project_id=project_id,


### PR DESCRIPTION
## Summary

Adds a project statistics endpoint for project owners.

## Changes

- Add `GET /projects/{project_id}/stats`
- Return:
  - Project views
  - Applicant count
  - Accepted member count
  - Bookmark count
- Restrict access to project owners
- Add `ProjectStatsResponse` schema
- Implement project statistics service method

## Notes

Returns:
- `404` if the project does not exist.
- `403` if the authenticated user is not the project owner.

Closes: #265 