### PR TITLE
feat(api): add user statistics endpoint

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -14,6 +14,7 @@ from app.models.user import User
 from app.schemas.user import (
     UserCreate,
     UserResponse,
+    UserStats,
     UserUpdate,
 )
 from app.services.auth_service import AuthService
@@ -106,6 +107,23 @@ def list_users(
         skip,
         limit,
     )
+
+
+@router.get(
+    "/{user_id}/stats",
+    response_model=UserStats,
+)
+def get_user_stats(
+    user_id: uuid.UUID,
+    db: Session = Depends(get_database),
+):
+    if UserService.get_user(db, user_id) is None:
+        raise HTTPException(
+            status_code=404, 
+            detail="User not found"
+            )
+
+    return UserService.get_user_stats(db, user_id)
 
 
 @router.put(

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -118,10 +118,7 @@ def get_user_stats(
     db: Session = Depends(get_database),
 ):
     if UserService.get_user(db, user_id) is None:
-        raise HTTPException(
-            status_code=404, 
-            detail="User not found"
-            )
+        raise HTTPException(status_code=404, detail="User not found")
 
     return UserService.get_user_stats(db, user_id)
 

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -127,10 +127,10 @@ class CurrentUser(UserResponse):
 
 class UserStats(BaseModel):
     projects: int = 0
-    contributions: int = 0
     followers: int = 0
     following: int = 0
-    reputation: int = 0
+    applications: int = 0
+    accepted: int = 0
 
 
 # ==========================================================

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -118,28 +118,53 @@ class UserService:
         db: Session,
         user_id: uuid.UUID,
     ) -> UserStats:
-        projects = db.scalar(
-            select(func.count()).select_from(Project).where(Project.owner_id == user_id)
-        ) or 0
-
-        followers = db.scalar(
-            select(func.count()).select_from(Follower).where(Follower.following_id == user_id)
-        ) or 0
-
-        following = db.scalar(
-            select(func.count()).select_from(Follower).where(Follower.follower_id == user_id)
-        ) or 0
-
-        applications = db.scalar(
-            select(func.count()).select_from(Application).where(Application.applicant_id == user_id)
-        ) or 0
-
-        accepted = db.scalar(
-            select(func.count()).select_from(Application).where(
-                Application.applicant_id == user_id,
-                Application.status == ApplicationStatus.ACCEPTED,
+        projects = (
+            db.scalar(
+                select(func.count())
+                .select_from(Project)
+                .where(Project.owner_id == user_id)
             )
-        ) or 0
+            or 0
+        )
+
+        followers = (
+            db.scalar(
+                select(func.count())
+                .select_from(Follower)
+                .where(Follower.following_id == user_id)
+            )
+            or 0
+        )
+
+        following = (
+            db.scalar(
+                select(func.count())
+                .select_from(Follower)
+                .where(Follower.follower_id == user_id)
+            )
+            or 0
+        )
+
+        applications = (
+            db.scalar(
+                select(func.count())
+                .select_from(Application)
+                .where(Application.applicant_id == user_id)
+            )
+            or 0
+        )
+
+        accepted = (
+            db.scalar(
+                select(func.count())
+                .select_from(Application)
+                .where(
+                    Application.applicant_id == user_id,
+                    Application.status == ApplicationStatus.ACCEPTED,
+                )
+            )
+            or 0
+        )
 
         return UserStats(
             projects=projects,
@@ -147,7 +172,7 @@ class UserService:
             following=following,
             applications=applications,
             accepted=accepted,
-        )   
+        )
 
     @staticmethod
     def verify_email(

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 import uuid
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
+from app.models.application import Application, ApplicationStatus
+from app.models.follower import Follower
+from app.models.project import Project
 from app.models.user import User
-from app.schemas.user import UserCreate, UserUpdate
+from app.schemas.user import UserCreate, UserStats, UserUpdate
 
 
 class UserService:
@@ -109,6 +112,42 @@ class UserService:
         db.refresh(db_user)
 
         return db_user
+
+    @staticmethod
+    def get_user_stats(
+        db: Session,
+        user_id: uuid.UUID,
+    ) -> UserStats:
+        projects = db.scalar(
+            select(func.count()).select_from(Project).where(Project.owner_id == user_id)
+        ) or 0
+
+        followers = db.scalar(
+            select(func.count()).select_from(Follower).where(Follower.following_id == user_id)
+        ) or 0
+
+        following = db.scalar(
+            select(func.count()).select_from(Follower).where(Follower.follower_id == user_id)
+        ) or 0
+
+        applications = db.scalar(
+            select(func.count()).select_from(Application).where(Application.applicant_id == user_id)
+        ) or 0
+
+        accepted = db.scalar(
+            select(func.count()).select_from(Application).where(
+                Application.applicant_id == user_id,
+                Application.status == ApplicationStatus.ACCEPTED,
+            )
+        ) or 0
+
+        return UserStats(
+            projects=projects,
+            followers=followers,
+            following=following,
+            applications=applications,
+            accepted=accepted,
+        )   
 
     @staticmethod
     def verify_email(


### PR DESCRIPTION
## Summary

Adds a user statistics endpoint that exposes profile statistics for a user.

### Changes

- Added `UserStats` response schema
- Added `GET /users/{user_id}/stats` endpoint
- Implemented `UserService.get_user_stats()` using efficient SQL aggregate queries
- Returns:
  - Projects
  - Followers
  - Following
  - Applications
  - Accepted applications
- Returns `404` when the requested user does not exist

Closes #264