### PR TITLE
feat: implement GET /users/check-username endpoint

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -15,13 +15,50 @@ from app.schemas.user import (
     UserCreate,
     UserResponse,
     UserUpdate,
+    UsernameAvailabilityResponse,
 )
 from app.services.auth_service import AuthService
 from app.services.user_service import UserService
+from app.utils.validators import validate_username
 
 router = APIRouter(
     tags=["Users"],
 )
+
+
+@router.get(
+    "/check-username",
+    response_model=UsernameAvailabilityResponse,
+    summary="Check Username Availability",
+)
+def check_username(
+    username: str = Query(..., description="The username to check availability for"),
+    db: Session = Depends(get_database),
+):
+    """
+    Check if a username is available for registration.
+    """
+    try:
+        username = validate_username(username)
+    except HTTPException as exc:
+        raise exc
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        )
+
+    existing_user = UserService.get_by_username(db, username)
+    if existing_user:
+        return UsernameAvailabilityResponse(
+            available=False,
+            message="Username is already taken.",
+        )
+
+    return UsernameAvailabilityResponse(
+        available=True,
+        message="Username is available.",
+    )
 
 
 @router.post(

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -150,3 +150,13 @@ class DeveloperProfile(BaseModel):
 
 class UserMessage(BaseModel):
     message: str
+
+
+# ==========================================================
+# Username Availability
+# ==========================================================
+
+
+class UsernameAvailabilityResponse(BaseModel):
+    available: bool
+    message: str

--- a/backend/app/tests/test_check_username.py
+++ b/backend/app/tests/test_check_username.py
@@ -1,0 +1,93 @@
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.database.base import Base
+from app.dependencies import get_database
+from app.main import app
+from app.models.user import User
+
+# Setup in-memory SQLite database
+engine = create_engine(
+    "sqlite:///:memory:",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture(scope="function")
+def db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture(scope="function")
+def client(db):
+    def override_get_db():
+        try:
+            yield db
+        finally:
+            pass
+
+    app.dependency_overrides[get_database] = override_get_db
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def create_test_user(db, username):
+    user = User(
+        first_name="Test",
+        last_name="User",
+        username=username,
+        email=f"{username}@example.com",
+        password_hash="hashed_password",
+        is_active=True,
+        is_verified=True,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def test_check_username_available(client):
+    response = client.get(
+        "/api/users/check-username", params={"username": "free_username"}
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["available"] is True
+    assert response.json()["message"] == "Username is available."
+
+
+def test_check_username_taken(client, db):
+    create_test_user(db, "taken_username")
+
+    response = client.get(
+        "/api/users/check-username", params={"username": "taken_username"}
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["available"] is False
+    assert response.json()["message"] == "Username is already taken."
+
+
+def test_check_username_invalid_format(client):
+    # Too short
+    response = client.get("/api/users/check-username", params={"username": "ab"})
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Username may contain only letters" in response.json()["detail"]
+
+    # Invalid characters
+    response = client.get("/api/users/check-username", params={"username": "user*name"})
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Username may contain only letters" in response.json()["detail"]

--- a/frontend/src/routes/_app.settings.tsx
+++ b/frontend/src/routes/_app.settings.tsx
@@ -26,7 +26,8 @@ function SettingsPage() {
   const [tab, setTab] = useState<Tab>("Account");
   const [showCurrentPassword, setShowCurrentPassword] = useState(false);
   const [showNewPassword, setShowNewPassword] = useState(false);
-  const inp = "w-full rounded-md border border-border bg-surface px-3 py-[8px] text-[14px] text-foreground outline-none focus:border-primary focus:ring-2 focus:ring-primary/20";
+  const inp =
+    "w-full rounded-md border border-border bg-surface px-3 py-[8px] text-[14px] text-foreground outline-none focus:border-primary focus:ring-2 focus:ring-primary/20";
   const lbl = "mb-1 block text-[13px] font-semibold text-foreground";
 
   return (
@@ -118,48 +119,48 @@ function SettingsPage() {
               </div>
             )}
             {tab === "Security" && (
-  <div className="space-y-4">
-    <div>
-      <label className={lbl}>Current password</label>
-      <div className="relative">
-        <input
-          type={showCurrentPassword ? "text" : "password"}
-          className={`${inp} pr-10`}
-        />
-        <button
-          type="button"
-          onClick={() => setShowCurrentPassword(!showCurrentPassword)}
-          className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-          aria-label={showCurrentPassword ? "Hide password" : "Show password"}
-        >
-          {showCurrentPassword ? <EyeOff size={18} /> : <Eye size={18} />}
-        </button>
-      </div>
-    </div>
+              <div className="space-y-4">
+                <div>
+                  <label className={lbl}>Current password</label>
+                  <div className="relative">
+                    <input
+                      type={showCurrentPassword ? "text" : "password"}
+                      className={`${inp} pr-10`}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowCurrentPassword(!showCurrentPassword)}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                      aria-label={showCurrentPassword ? "Hide password" : "Show password"}
+                    >
+                      {showCurrentPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+                    </button>
+                  </div>
+                </div>
 
-    <div>
-      <label className={lbl}>New password</label>
-      <div className="relative">
-        <input
-          type={showNewPassword ? "text" : "password"}
-          className={`${inp} pr-10`}
-        />
-        <button
-          type="button"
-          onClick={() => setShowNewPassword(!showNewPassword)}
-          className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-          aria-label={showNewPassword ? "Hide password" : "Show password"}
-        >
-          {showNewPassword ? <EyeOff size={18} /> : <Eye size={18} />}
-        </button>
-      </div>
-    </div>
+                <div>
+                  <label className={lbl}>New password</label>
+                  <div className="relative">
+                    <input
+                      type={showNewPassword ? "text" : "password"}
+                      className={`${inp} pr-10`}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowNewPassword(!showNewPassword)}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                      aria-label={showNewPassword ? "Hide password" : "Show password"}
+                    >
+                      {showNewPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+                    </button>
+                  </div>
+                </div>
 
-    <button className="rounded-md bg-primary px-4 py-2 text-[13px] font-semibold text-primary-foreground hover:opacity-90">
-      Update password
-    </button>
-  </div>
-)}
+                <button className="rounded-md bg-primary px-4 py-2 text-[13px] font-semibold text-primary-foreground hover:opacity-90">
+                  Update password
+                </button>
+              </div>
+            )}
             {tab === "Billing" && (
               <div className="rounded-md border border-primary/30 bg-primary-soft p-4 text-[13px] text-foreground">
                 You're on the <span className="font-semibold">Pro</span> plan. Next invoice on Nov


### PR DESCRIPTION
## Summary

This PR adds a new endpoint to check username availability before user registration, allowing clients to validate usernames in real time.

## Changes Made

- Added `GET /api/users/check-username` endpoint.
- Added `UsernameAvailabilityResponse` schema for a consistent API response.
- Validates username format before checking availability.
- Returns `400 Bad Request` for invalid usernames.
- Returns availability status and a descriptive message for valid requests.
- Placed the endpoint before the dynamic `/{user_id}` route to avoid routing conflicts.
- Added unit tests covering:
  - Available usernames
  - Already taken usernames
  - Invalid username formats

## Testing

- ✅ Verified available usernames return `200 OK` with `available: true`.
- ✅ Verified existing usernames return `200 OK` with `available: false`.
- ✅ Verified invalid usernames return `400 Bad Request`.
- ✅ All related tests pass successfully.

Closes #256 