### PR TITLE
feat: add Share Project functionality

### DIFF
--- a/frontend/src/components/shared/ShareProjectButton.tsx
+++ b/frontend/src/components/shared/ShareProjectButton.tsx
@@ -1,0 +1,144 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Check, Copy, Link as LinkIcon, Share2 } from "lucide-react";
+import { toast } from "sonner";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
+import { copyText } from "@/lib/clipboard";
+
+export type ShareProjectButtonProps = {
+  projectTitle: string;
+  projectUrl?: string;
+  projectDescription?: string;
+};
+
+type CopyKind = "link" | "text" | null;
+
+export function ShareProjectButton({
+  projectTitle,
+  projectUrl,
+  projectDescription,
+}: ShareProjectButtonProps) {
+  const [hasNativeShare, setHasNativeShare] = useState(false);
+  const [copiedKind, setCopiedKind] = useState<CopyKind>(null);
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    setHasNativeShare(typeof navigator !== "undefined" && typeof navigator.share === "function");
+  }, []);
+
+  const canonicalUrl = useMemo(() => {
+    if (projectUrl || typeof window === "undefined") return projectUrl ?? "";
+
+    const url = new URL(window.location.href);
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  }, [projectUrl]);
+  const shareText = useMemo(() => {
+    const description = projectDescription?.trim();
+    return [
+      `Check out this project: ${projectTitle}`,
+      description && description.length <= 240 ? description : null,
+      canonicalUrl,
+    ]
+      .filter(Boolean)
+      .join("\n");
+  }, [canonicalUrl, projectDescription, projectTitle]);
+
+  const showCopied = useCallback((kind: Exclude<CopyKind, null>) => {
+    setCopiedKind(kind);
+    window.setTimeout(() => setCopiedKind(null), 2000);
+  }, []);
+
+  const handleCopy = useCallback(
+    async (kind: Exclude<CopyKind, null>) => {
+      try {
+        await copyText(kind === "link" ? canonicalUrl : shareText);
+        showCopied(kind);
+        toast.success(kind === "link" ? "Project link copied" : "Project text copied");
+      } catch {
+        toast.error("Could not copy to the clipboard");
+      }
+    },
+    [canonicalUrl, shareText, showCopied],
+  );
+
+  const handleNativeShare = useCallback(async () => {
+    if (!navigator.share) return;
+
+    try {
+      await navigator.share({
+        title: projectTitle,
+        text: shareText,
+        url: canonicalUrl,
+      });
+      toast.success("Project shared");
+    } catch (error) {
+      if (
+        (error instanceof DOMException && error.name === "AbortError") ||
+        (typeof error === "object" &&
+          error !== null &&
+          "name" in error &&
+          error.name === "AbortError")
+      ) {
+        return;
+      }
+      toast.error("Could not share this project");
+    }
+  }, [canonicalUrl, projectTitle, shareText]);
+
+  const button = (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      aria-label="Share project"
+      onClick={hasNativeShare ? handleNativeShare : undefined}
+    >
+      {copiedKind ? (
+        <Check size={14} aria-hidden="true" />
+      ) : (
+        <Share2 size={14} aria-hidden="true" />
+      )}
+      <span>{copiedKind ? "Copied" : "Share"}</span>
+    </Button>
+  );
+
+  if (hasNativeShare) return button;
+
+  return (
+    <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+      <DropdownMenuTrigger asChild>{button}</DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        className="w-[min(16rem,calc(100vw-2rem))]"
+        aria-label="Share project options"
+      >
+        <DropdownMenuItem onSelect={() => void handleCopy("link")}>
+          {copiedKind === "link" ? (
+            <Check size={14} className="text-success" aria-hidden="true" />
+          ) : (
+            <LinkIcon size={14} aria-hidden="true" />
+          )}
+          <span>{copiedKind === "link" ? "Copied" : "Copy project link"}</span>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={() => void handleCopy("text")}>
+          {copiedKind === "text" ? (
+            <Check size={14} className="text-success" aria-hidden="true" />
+          ) : (
+            <Copy size={14} aria-hidden="true" />
+          )}
+          <span>{copiedKind === "text" ? "Copied" : "Copy as text"}</span>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -1,7 +1,11 @@
 import { useEffect, useState } from "react";
 
 export function useTheme() {
-  const [isDark, setIsDark] = useState(() => localStorage.getItem("theme") === "dark");
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    setIsDark(localStorage.getItem("theme") === "dark");
+  }, []);
 
   useEffect(() => {
     document.documentElement.classList.toggle("dark", isDark);

--- a/frontend/src/lib/clipboard.ts
+++ b/frontend/src/lib/clipboard.ts
@@ -1,0 +1,37 @@
+/**
+ * Copy text using the modern Clipboard API when available, with a small
+ * fallback for browsers that do not expose it or reject the write.
+ */
+export async function copyText(text: string): Promise<void> {
+  try {
+    if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return;
+    }
+  } catch {
+    // Try the legacy path below when permissions or browser support prevent
+    // the modern API from completing the copy.
+  }
+
+  if (typeof document === "undefined" || typeof document.execCommand !== "function") {
+    throw new Error("Clipboard is unavailable");
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  textarea.style.top = "0";
+  document.body.appendChild(textarea);
+
+  try {
+    textarea.select();
+    textarea.setSelectionRange(0, textarea.value.length);
+    if (!document.execCommand("copy")) {
+      throw new Error("Clipboard copy failed");
+    }
+  } finally {
+    textarea.remove();
+  }
+}

--- a/frontend/src/routes/_app.projects.$projectId.tsx
+++ b/frontend/src/routes/_app.projects.$projectId.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import { builders, activity, currentUser } from "@/mocks/seed";
 import { Markdown } from "@/components/shared/Markdown";
 import { BackButton } from "@/components/shared/BackButton";
+import { ShareProjectButton } from "@/components/shared/ShareProjectButton";
 
 export const Route = createFileRoute("/_app/projects/$projectId")({
   head: ({ params }) => ({
@@ -72,6 +73,8 @@ function ProjectDetail() {
                 {copied ? "Copied!" : "Copy invite link"}
               </button>
             )}
+
+            <ShareProjectButton projectTitle={p.name} projectDescription={p.description} />
 
             <div className="hidden gap-4 text-[12px] text-muted-foreground sm:flex">
               <span className="inline-flex items-center gap-1">

--- a/frontend/src/routes/_app.projects.tsx
+++ b/frontend/src/routes/_app.projects.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, Outlet, useRouterState } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { projectsService } from "@/services";
 import { Card, TagChip, SectionHeader } from "@/components/shared/primitives";
@@ -70,6 +70,7 @@ function toggle<T>(set: T[], val: T): T[] {
 }
 
 function ProjectsPage() {
+  const pathname = useRouterState({ select: (state) => state.location.pathname });
   const [q, setQ] = useState("");
   const [statusFilter, setStatusFilter] = useState<
     "all" | "recruiting" | "in-progress" | "completed" | "archived"
@@ -85,6 +86,10 @@ function ProjectsPage() {
   });
 
   const hasActiveFilters = langs.length > 0 || difficulties.length > 0 || boolFilters.length > 0;
+
+  if (pathname !== "/projects" && pathname !== "/projects/") {
+    return <Outlet />;
+  }
 
   function resetFilters() {
     setLangs([]);
@@ -266,12 +271,7 @@ function ProjectsPage() {
       ) : (
         <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
           {filtered.map((p) => (
-            <Link
-              key={p.id}
-              to="/projects/$projectId"
-              params={{ projectId: p.id }}
-              className="block"
-            >
+            <a key={p.id} href={`/projects/${p.id}`} className="block">
               <Card interactive className="p-4">
                 <div className="flex items-start gap-3">
                   <span className="grid h-10 w-10 shrink-0 place-items-center rounded-md bg-muted text-xl">
@@ -339,7 +339,7 @@ function ProjectsPage() {
                   </span>
                 </div>
               </Card>
-            </Link>
+            </a>
           ))}
         </div>
       )}


### PR DESCRIPTION
Closes #162

## Summary

This PR implements Share Project functionality on the project details page. Users can share a project through the native Web Share API or use an accessible fallback menu to copy the project link.

The existing owner-only invite-link functionality remains unchanged.

## Changes

* Added a reusable `ShareProjectButton` component
* Added native Web Share API support on compatible devices
* Added an accessible fallback menu with:

  * Copy project link
  * Copy project details as text
* Added Clipboard API support with an `execCommand` fallback for older browsers
* Added success and failure toast notifications
* Added temporary checkmark and “Copied” feedback
* Handled native-share cancellation without showing an unnecessary error
* Added responsive menu sizing
* Preserved accessible button labels and focus behavior
* Supported Escape-key and outside-click menu closing through Radix
* Made the Share button available to owners and non-owners
* Preserved the existing owner-only Copy invite link behavior

## Supporting Fixes

While implementing and testing the feature, the project details page could not render reliably because of existing routing and server-side theme-storage issues.

The following focused fixes were added:

* Updated nested project routing so `/projects/:projectId` renders the project details page correctly
* Guarded theme storage access during server-side rendering to prevent `localStorage is not defined` errors
* Preserved the existing `/projects` listing route

These changes do not modify backend, authentication, authorization, or permission logic.

## Files Changed

* `frontend/src/components/shared/ShareProjectButton.tsx`
* `frontend/src/lib/clipboard.ts`
* `frontend/src/hooks/useTheme.ts`
* `frontend/src/routes/_app.projects.tsx`
* `frontend/src/routes/_app.projects.$projectId.tsx`

## Verification

* `npm ci` passed
* `npm run typecheck` passed
* `npm run build` passed
* ESLint passed for the changed files
* Verified `/projects/p4` renders the project details page
* Verified `/projects` continues to render the project listing
* Verified the Share button is available to owners and non-owners
* Verified the owner-only invite-link behavior remains unchanged
* Verified native sharing and clipboard fallback behavior
* Confirmed no backend, authentication, authorization, or permission logic was changed

Full repository lint remains blocked by pre-existing CRLF/Prettier issues outside the scope of this PR.

## ECSoC26

This contribution is part of ECSoC26.


**After work:**
<img width="1918" height="952" alt="image" src="https://github.com/user-attachments/assets/b27d9dd3-cb24-46e0-b14c-0291985a720e" />
