### PR TITLE
perf: optimize unread notification count query

### DIFF
--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -162,9 +162,13 @@ class NotificationService:
         recipient_id: uuid.UUID,
     ) -> int:
 
-        stmt = select(func.count()).select_from(Notification).where(
-            Notification.recipient_id == recipient_id,
-            Notification.is_read.is_(False),
+        stmt = (
+            select(func.count())
+            .select_from(Notification)
+            .where(
+                Notification.recipient_id == recipient_id,
+                Notification.is_read.is_(False),
+            )
         )
 
         return db.scalar(stmt) or 0

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 
 # pyrefly: ignore [missing-import]
-from sqlalchemy import select
+from sqlalchemy import func, select
 
 # pyrefly: ignore [missing-import]
 from sqlalchemy.orm import Session
@@ -162,12 +162,12 @@ class NotificationService:
         recipient_id: uuid.UUID,
     ) -> int:
 
-        stmt = select(Notification).where(
+        stmt = select(func.count()).select_from(Notification).where(
             Notification.recipient_id == recipient_id,
             Notification.is_read.is_(False),
         )
 
-        return len(list(db.scalars(stmt)))
+        return db.scalar(stmt) or 0
 
     @staticmethod
     def mark_as_read(


### PR DESCRIPTION
# Pull Request

## Summary

Optimized the unread notification count by replacing the existing approach of loading unread notifications into memory with a SQL `COUNT(*)` query. This keeps the behavior the same while making the query more efficient.

---

## Related Issue

Closes #199

---

## Type of Change

- [x] Performance improvement

---

## Changes Made

- Used `func.count()` to count unread notifications directly in the database.
- Removed the need to fetch unread notification records just to calculate the count.
- Kept the existing functionality unchanged while improving efficiency.

---

## Screenshots (if applicable)

N/A

---

## Testing

- [x] Tested locally

**Additional testing notes:**

Verified that the unread notification count returns the expected value after the optimization.

---

## Checklist

- [x] My code follows the project's coding standards.
- [x] I have tested my changes locally.
- [ ] I have updated the documentation where necessary.
- [x] My changes do not introduce new warnings or errors.
- [x] I have reviewed my own code.
- [x] This pull request focuses on a single feature or fix.
- [x] I have linked the related issue.

---

## Additional Notes

This PR only includes the unread notification count optimization. No other functionality was changed.