### PR TITLE
feat: add copy email button

### DIFF
--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -112,6 +112,11 @@ class User(Base):
         nullable=True,
     )
 
+    public_email: Mapped[str | None] = mapped_column(
+        String(255),
+        nullable=True,
+    )
+
     github_url: Mapped[str | None] = mapped_column(
         String(255),
         nullable=True,

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -21,11 +21,13 @@ from app.middleware.rate_limit import (
 )
 from app.dependencies import get_database
 from app.schemas.auth import (
+
     AuthResponse,
+    ForgotPasswordRequest,
     LoginRequest,
     RegisterRequest,
 )
-from app.schemas.user import UserResponse
+from app.schemas.user import UserResponse, CurrentUser
 from app.services.auth_service import AuthService
 
 router = APIRouter(
@@ -39,7 +41,7 @@ router = APIRouter(
 
 @router.post(
     "/register",
-    response_model=UserResponse,
+    response_model=CurrentUser,
     status_code=status.HTTP_201_CREATED,
     summary="Register a new user",
 )

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -21,7 +21,6 @@ from app.middleware.rate_limit import (
 )
 from app.dependencies import get_database
 from app.schemas.auth import (
-
     AuthResponse,
     ForgotPasswordRequest,
     LoginRequest,

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -17,6 +17,7 @@ from app.models.user import User
 from app.schemas.user import (
     UserCreate,
     UserResponse,
+    CurrentUser,
     UserStats,
     UserUpdate,
     UsernameAvailabilityResponse,
@@ -101,7 +102,7 @@ def create_user(
 
 @router.get(
     "/me",
-    response_model=UserResponse,
+    response_model=CurrentUser,
 )
 def get_me(
     current_user: User = Depends(get_current_user),
@@ -168,7 +169,7 @@ def get_user_stats(
 
 @router.put(
     "/me",
-    response_model=UserResponse,
+    response_model=CurrentUser,
 )
 def update_me(
     user: UserUpdate,

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -22,7 +22,7 @@ class UserBase(BaseModel):
         max_length=50,
     )
 
-    email: EmailStr
+    public_email: Optional[EmailStr] = None
 
     headline: Optional[str] = Field(
         default=None,
@@ -55,6 +55,7 @@ class UserBase(BaseModel):
 
 
 class UserCreate(UserBase):
+    email: EmailStr
     password: str = Field(
         ...,
         min_length=8,
@@ -76,6 +77,7 @@ class UserUpdate(BaseModel):
 
     location: Optional[str] = None
     timezone: Optional[str] = None
+    public_email: Optional[EmailStr] = None
 
     website: Optional[HttpUrl] = None
     portfolio_url: Optional[HttpUrl] = None
@@ -118,6 +120,7 @@ class UserResponse(UserBase):
 
 
 class CurrentUser(UserResponse):
+    email: EmailStr
     email_verified_at: Optional[datetime] = None
     last_login: Optional[datetime] = None
 

--- a/frontend/src/mocks/seed.ts
+++ b/frontend/src/mocks/seed.ts
@@ -19,6 +19,7 @@ export interface Builder {
   online: boolean;
   bio: string;
   lastActiveAt: string | null;
+  publicEmail?: string;
 }
 export interface Project {
   id: ID;
@@ -129,6 +130,7 @@ export const builders: Builder[] = [
     online: true,
     bio: "Loves accessible UIs and design systems.",
     lastActiveAt: ago(1),
+    publicEmail: "priya@example.com",
   },
   {
     id: "b2",

--- a/frontend/src/routes/_app.profile.$username.tsx
+++ b/frontend/src/routes/_app.profile.$username.tsx
@@ -2,8 +2,9 @@ import { createFileRoute, notFound, Link, useNavigate } from "@tanstack/react-ro
 import { Card, TagChip, Avatar } from "@/components/shared/primitives";
 import { LastActive } from "@/components/shared/LastActive";
 import { builders, currentUser, projects } from "@/mocks/seed";
-import { MapPin, Calendar, Link as LinkIcon, MessageCircle } from "lucide-react";
+import { MapPin, Calendar, Link as LinkIcon, MessageCircle, Mail } from "lucide-react";
 import { toast } from "sonner";
+import { copyText } from "@/lib/clipboard";
 
 export const Route = createFileRoute("/_app/profile/$username")({
   head: ({ params }) => ({
@@ -108,21 +109,40 @@ function ProfilePage() {
               <LastActive lastActiveAt={b.lastActiveAt} />
             </div>
           </div>
-          {!me && (
-            <button
-              type="button"
-              onClick={() =>
-                navigate({
-                  to: "/messages/$conversationId",
-                  params: { conversationId: b.id },
-                })
-              }
-              className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-2 text-[13px] font-semibold text-primary-foreground transition-opacity hover:opacity-90"
-            >
-              <MessageCircle size={16} />
-              Contact Developer
-            </button>
-          )}
+          <div className="flex items-center gap-2">
+            {b.publicEmail && (
+              <button
+                type="button"
+                onClick={async () => {
+                  try {
+                    await copyText(b.publicEmail!);
+                    toast.success("Email copied to clipboard!");
+                  } catch {
+                    toast.error("Failed to copy email");
+                  }
+                }}
+                className="inline-flex items-center gap-2 rounded-md border border-border bg-surface px-3 py-2 text-[13px] font-semibold text-foreground transition-colors hover:bg-muted"
+              >
+                <Mail size={16} />
+                Copy Email
+              </button>
+            )}
+            {!me && (
+              <button
+                type="button"
+                onClick={() =>
+                  navigate({
+                    to: "/messages/$conversationId",
+                    params: { conversationId: b.id },
+                  })
+                }
+                className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-2 text-[13px] font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+              >
+                <MessageCircle size={16} />
+                Contact Developer
+              </button>
+            )}
+          </div>
         </div>
       </Card>
 


### PR DESCRIPTION
# Pull Request

## Summary

Adds a **Copy Email** button to user profiles, allowing visitors to quickly copy a user's public email address while keeping private email addresses hidden from public responses.

---

## Related Issue

- Closes #343

---

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [x] UI/UX enhancement
- [ ] Tests
- [ ] Other

---

## Changes Made

- Added a `public_email` field to the user model and updated user schemas to separate public and private email exposure.
- Updated authentication and user endpoints to return the appropriate response models for authenticated users and public profiles.
- Added support for a public email in the frontend mock data.
- Added a **Copy Email** button to the profile page that:
  - is displayed only when a public email is available,
  - uses the existing clipboard utility,
  - provides toast feedback on success or failure.

---

## Screenshots (if applicable)

_Add screenshots or a short screen recording demonstrating the Copy Email button._

---

## Testing

- [x] Tested locally
- [ ] Existing tests pass
- [ ] Added new tests
- [x] UI verified
- [ ] Cross-browser tested (if applicable)

Additional testing notes:

- Verified that the Copy Email button is displayed only when a public email is available.
- Verified that clicking the button copies the public email to the clipboard and displays user feedback.

---

## Checklist

- [x] My code follows the project's coding standards.
- [x] I have tested my changes locally.
- [ ] I have updated the documentation where necessary.
- [x] My changes do not introduce new warnings or errors.
- [x] I have reviewed my own code.
- [x] This pull request focuses on a single feature or fix.
- [x] I have linked the related issue.

---

## Additional Notes

This implementation introduces a dedicated `public_email` field to ensure only explicitly shared email addresses are exposed on public profiles, while authenticated users continue to access their private email through the appropriate API responses.