### PR TITLE
feat(frontend): implement Organization Profiles layout and routing (fixes #114)

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -7,6 +7,7 @@ import {
   Compass,
   Bookmark,
   Users2,
+  Building2,
   Sparkles,
   Share2,
   Flame,
@@ -41,6 +42,7 @@ const groups: Group[] = [
     label: "Community",
     items: [
       { label: "Builders", to: "/builders", icon: <Users2 size={16} /> },
+      { label: "Organizations", to: "/organizations", icon: <Building2 size={16} /> },
       { label: "AI Matches", to: "/builders?tab=matches", icon: <Sparkles size={16} /> },
       { label: "Connections", to: "/builders?tab=connections", icon: <Share2 size={16} /> },
     ],

--- a/frontend/src/features/organizations/components/OrganizationHeader.tsx
+++ b/frontend/src/features/organizations/components/OrganizationHeader.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+interface OrganizationHeaderProps {
+  name: string;
+  logoUrl?: string;
+  bannerUrl?: string;
+  location?: string;
+  website?: string;
+  isHiring: boolean;
+}
+
+export const OrganizationHeader: React.FC<OrganizationHeaderProps> = ({
+  name,
+  logoUrl,
+  bannerUrl,
+  location,
+  website,
+  isHiring,
+}) => {
+  return (
+    <div className="relative rounded-xl border border-gray-800 bg-gray-900/50 overflow-hidden mb-6">
+      {/* Banner */}
+      <div className="h-32 sm:h-48 w-full bg-gradient-to-r from-blue-900 to-indigo-900 relative">
+        {bannerUrl && (
+          <img src={bannerUrl} alt={`${name} banner`} className="w-full h-full object-cover" />
+        )}
+      </div>
+
+      {/* Profile Details Bar */}
+      <div className="p-6 pt-0 relative flex flex-col sm:flex-row items-start sm:items-end justify-between gap-4">
+        <div className="flex items-end gap-4 -mt-12 sm:-mt-16">
+          {/* Logo */}
+          <div className="w-24 h-24 sm:w-32 sm:h-32 rounded-xl border-4 border-gray-900 bg-gray-800 overflow-hidden flex items-center justify-center font-bold text-2xl text-white shadow-lg">
+            {logoUrl ? (
+              <img src={logoUrl} alt={`${name} logo`} className="w-full h-full object-cover" />
+            ) : (
+              name.slice(0, 2).toUpperCase()
+            )}
+          </div>
+
+          <div className="mb-2">
+            <h1 className="text-2xl sm:text-3xl font-bold text-white flex items-center gap-2">
+              {name}
+              {isHiring && (
+                <span className="text-xs px-2.5 py-1 rounded-full bg-emerald-500/10 text-emerald-400 border border-emerald-500/20 font-medium">
+                  Hiring
+                </span>
+              )}
+            </h1>
+            {location && <p className="text-sm text-gray-400">{location}</p>}
+          </div>
+        </div>
+
+        {website && (
+          <a
+            href={website}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white font-medium text-sm transition-colors"
+          >
+            Visit Website
+          </a>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/features/organizations/components/OrganizationProfile.tsx
+++ b/frontend/src/features/organizations/components/OrganizationProfile.tsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react';
+import { OrganizationHeader } from './OrganizationHeader';
+
+interface OrganizationProfileProps {
+  organizationData: {
+    name: string;
+    logo_url?: string;
+    banner_url?: string;
+    location?: string;
+    website?: string;
+    description?: string;
+    hiring: boolean;
+  };
+}
+
+export const OrganizationProfile: React.FC<OrganizationProfileProps> = ({ organizationData }) => {
+  const [activeTab, setActiveTab] = useState<'about' | 'team' | 'projects' | 'hiring'>('about');
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 py-8">
+      {/* Header */}
+      <OrganizationHeader
+        name={organizationData.name}
+        logoUrl={organizationData.logo_url}
+        bannerUrl={organizationData.banner_url}
+        location={organizationData.location}
+        website={organizationData.website}
+        isHiring={organizationData.hiring}
+      />
+
+      {/* Tabs */}
+      <div className="flex border-b border-gray-800 mb-6 gap-6">
+        {(['about', 'team', 'projects', 'hiring'] as const).map((tab) => (
+          <button
+            key={tab}
+            onClick={() => setActiveTab(tab)}
+            className={`pb-3 text-sm font-medium capitalize border-b-2 transition-colors ${
+              activeTab === tab
+                ? 'border-indigo-500 text-indigo-400'
+                : 'border-transparent text-gray-400 hover:text-gray-200'
+            }`}
+          >
+            {tab}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab Content */}
+      <div className="bg-gray-900/30 border border-gray-800 rounded-xl p-6">
+        {activeTab === 'about' && (
+          <div>
+            <h2 className="text-xl font-semibold text-white mb-3">About Us</h2>
+            <p className="text-gray-300 leading-relaxed">
+              {organizationData.description || 'No description provided.'}
+            </p>
+          </div>
+        )}
+
+        {activeTab === 'team' && (
+          <div>
+            <h2 className="text-xl font-semibold text-white mb-4">Team Members</h2>
+            <p className="text-gray-400 text-sm">Showing team members connected to {organizationData.name}.</p>
+          </div>
+        )}
+
+        {activeTab === 'projects' && (
+          <div>
+            <h2 className="text-xl font-semibold text-white mb-4">Projects</h2>
+            <p className="text-gray-400 text-sm">Projects built or maintained by {organizationData.name}.</p>
+          </div>
+        )}
+
+        {activeTab === 'hiring' && (
+          <div>
+            <h2 className="text-xl font-semibold text-white mb-4">Open Roles</h2>
+            {organizationData.hiring ? (
+              <p className="text-gray-300 text-sm">We are actively recruiting talent! Apply below.</p>
+            ) : (
+              <p className="text-gray-400 text-sm">We are not actively hiring right now.</p>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as PortfolioUsernameRouteImport } from './routes/portfolio.$usern
 import { Route as AppSettingsRouteImport } from './routes/_app.settings'
 import { Route as AppSearchRouteImport } from './routes/_app.search'
 import { Route as AppProjectsRouteImport } from './routes/_app.projects'
+import { Route as AppOrganizationsRouteImport } from './routes/_app.organizations'
 import { Route as AppNotificationsRouteImport } from './routes/_app.notifications'
 import { Route as AppMessagesRouteImport } from './routes/_app.messages'
 import { Route as AppHackathonsRouteImport } from './routes/_app.hackathons'
@@ -25,8 +26,10 @@ import { Route as AppDashboardRouteImport } from './routes/_app.dashboard'
 import { Route as AppBuildersRouteImport } from './routes/_app.builders'
 import { Route as AppBookmarksRouteImport } from './routes/_app.bookmarks'
 import { Route as AppAnalyticsRouteImport } from './routes/_app.analytics'
+import { Route as AppOrganizationsIndexRouteImport } from './routes/_app.organizations.index'
 import { Route as AppProjectsProjectIdRouteImport } from './routes/_app.projects.$projectId'
 import { Route as AppProfileUsernameRouteImport } from './routes/_app.profile.$username'
+import { Route as AppOrganizationsOrgIdRouteImport } from './routes/_app.organizations.$orgId'
 import { Route as AppMessagesConversationIdRouteImport } from './routes/_app.messages.$conversationId'
 import { Route as AppBuildersBuilderIdRouteImport } from './routes/_app.builders.$builderId'
 
@@ -69,6 +72,11 @@ const AppProjectsRoute = AppProjectsRouteImport.update({
   path: '/projects',
   getParentRoute: () => AppRoute,
 } as any)
+const AppOrganizationsRoute = AppOrganizationsRouteImport.update({
+  id: '/organizations',
+  path: '/organizations',
+  getParentRoute: () => AppRoute,
+} as any)
 const AppNotificationsRoute = AppNotificationsRouteImport.update({
   id: '/notifications',
   path: '/notifications',
@@ -109,6 +117,11 @@ const AppAnalyticsRoute = AppAnalyticsRouteImport.update({
   path: '/analytics',
   getParentRoute: () => AppRoute,
 } as any)
+const AppOrganizationsIndexRoute = AppOrganizationsIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => AppOrganizationsRoute,
+} as any)
 const AppProjectsProjectIdRoute = AppProjectsProjectIdRouteImport.update({
   id: '/$projectId',
   path: '/$projectId',
@@ -118,6 +131,11 @@ const AppProfileUsernameRoute = AppProfileUsernameRouteImport.update({
   id: '/profile/$username',
   path: '/profile/$username',
   getParentRoute: () => AppRoute,
+} as any)
+const AppOrganizationsOrgIdRoute = AppOrganizationsOrgIdRouteImport.update({
+  id: '/$orgId',
+  path: '/$orgId',
+  getParentRoute: () => AppOrganizationsRoute,
 } as any)
 const AppMessagesConversationIdRoute =
   AppMessagesConversationIdRouteImport.update({
@@ -143,14 +161,17 @@ export interface FileRoutesByFullPath {
   '/hackathons': typeof AppHackathonsRoute
   '/messages': typeof AppMessagesRouteWithChildren
   '/notifications': typeof AppNotificationsRoute
+  '/organizations': typeof AppOrganizationsRouteWithChildren
   '/projects': typeof AppProjectsRouteWithChildren
   '/search': typeof AppSearchRoute
   '/settings': typeof AppSettingsRoute
   '/portfolio/$username': typeof PortfolioUsernameRoute
   '/builders/$builderId': typeof AppBuildersBuilderIdRoute
   '/messages/$conversationId': typeof AppMessagesConversationIdRoute
+  '/organizations/$orgId': typeof AppOrganizationsOrgIdRoute
   '/profile/$username': typeof AppProfileUsernameRoute
   '/projects/$projectId': typeof AppProjectsProjectIdRoute
+  '/organizations/': typeof AppOrganizationsIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -170,8 +191,10 @@ export interface FileRoutesByTo {
   '/portfolio/$username': typeof PortfolioUsernameRoute
   '/builders/$builderId': typeof AppBuildersBuilderIdRoute
   '/messages/$conversationId': typeof AppMessagesConversationIdRoute
+  '/organizations/$orgId': typeof AppOrganizationsOrgIdRoute
   '/profile/$username': typeof AppProfileUsernameRoute
   '/projects/$projectId': typeof AppProjectsProjectIdRoute
+  '/organizations': typeof AppOrganizationsIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -187,14 +210,17 @@ export interface FileRoutesById {
   '/_app/hackathons': typeof AppHackathonsRoute
   '/_app/messages': typeof AppMessagesRouteWithChildren
   '/_app/notifications': typeof AppNotificationsRoute
+  '/_app/organizations': typeof AppOrganizationsRouteWithChildren
   '/_app/projects': typeof AppProjectsRouteWithChildren
   '/_app/search': typeof AppSearchRoute
   '/_app/settings': typeof AppSettingsRoute
   '/portfolio/$username': typeof PortfolioUsernameRoute
   '/_app/builders/$builderId': typeof AppBuildersBuilderIdRoute
   '/_app/messages/$conversationId': typeof AppMessagesConversationIdRoute
+  '/_app/organizations/$orgId': typeof AppOrganizationsOrgIdRoute
   '/_app/profile/$username': typeof AppProfileUsernameRoute
   '/_app/projects/$projectId': typeof AppProjectsProjectIdRoute
+  '/_app/organizations/': typeof AppOrganizationsIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -210,14 +236,17 @@ export interface FileRouteTypes {
     | '/hackathons'
     | '/messages'
     | '/notifications'
+    | '/organizations'
     | '/projects'
     | '/search'
     | '/settings'
     | '/portfolio/$username'
     | '/builders/$builderId'
     | '/messages/$conversationId'
+    | '/organizations/$orgId'
     | '/profile/$username'
     | '/projects/$projectId'
+    | '/organizations/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -237,8 +266,10 @@ export interface FileRouteTypes {
     | '/portfolio/$username'
     | '/builders/$builderId'
     | '/messages/$conversationId'
+    | '/organizations/$orgId'
     | '/profile/$username'
     | '/projects/$projectId'
+    | '/organizations'
   id:
     | '__root__'
     | '/'
@@ -253,14 +284,17 @@ export interface FileRouteTypes {
     | '/_app/hackathons'
     | '/_app/messages'
     | '/_app/notifications'
+    | '/_app/organizations'
     | '/_app/projects'
     | '/_app/search'
     | '/_app/settings'
     | '/portfolio/$username'
     | '/_app/builders/$builderId'
     | '/_app/messages/$conversationId'
+    | '/_app/organizations/$orgId'
     | '/_app/profile/$username'
     | '/_app/projects/$projectId'
+    | '/_app/organizations/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -329,6 +363,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppProjectsRouteImport
       parentRoute: typeof AppRoute
     }
+    '/_app/organizations': {
+      id: '/_app/organizations'
+      path: '/organizations'
+      fullPath: '/organizations'
+      preLoaderRoute: typeof AppOrganizationsRouteImport
+      parentRoute: typeof AppRoute
+    }
     '/_app/notifications': {
       id: '/_app/notifications'
       path: '/notifications'
@@ -385,6 +426,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppAnalyticsRouteImport
       parentRoute: typeof AppRoute
     }
+    '/_app/organizations/': {
+      id: '/_app/organizations/'
+      path: '/'
+      fullPath: '/organizations/'
+      preLoaderRoute: typeof AppOrganizationsIndexRouteImport
+      parentRoute: typeof AppOrganizationsRoute
+    }
     '/_app/projects/$projectId': {
       id: '/_app/projects/$projectId'
       path: '/$projectId'
@@ -398,6 +446,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/profile/$username'
       preLoaderRoute: typeof AppProfileUsernameRouteImport
       parentRoute: typeof AppRoute
+    }
+    '/_app/organizations/$orgId': {
+      id: '/_app/organizations/$orgId'
+      path: '/$orgId'
+      fullPath: '/organizations/$orgId'
+      preLoaderRoute: typeof AppOrganizationsOrgIdRouteImport
+      parentRoute: typeof AppOrganizationsRoute
     }
     '/_app/messages/$conversationId': {
       id: '/_app/messages/$conversationId'
@@ -440,6 +495,19 @@ const AppMessagesRouteWithChildren = AppMessagesRoute._addFileChildren(
   AppMessagesRouteChildren,
 )
 
+interface AppOrganizationsRouteChildren {
+  AppOrganizationsOrgIdRoute: typeof AppOrganizationsOrgIdRoute
+  AppOrganizationsIndexRoute: typeof AppOrganizationsIndexRoute
+}
+
+const AppOrganizationsRouteChildren: AppOrganizationsRouteChildren = {
+  AppOrganizationsOrgIdRoute: AppOrganizationsOrgIdRoute,
+  AppOrganizationsIndexRoute: AppOrganizationsIndexRoute,
+}
+
+const AppOrganizationsRouteWithChildren =
+  AppOrganizationsRoute._addFileChildren(AppOrganizationsRouteChildren)
+
 interface AppProjectsRouteChildren {
   AppProjectsProjectIdRoute: typeof AppProjectsProjectIdRoute
 }
@@ -461,6 +529,7 @@ interface AppRouteChildren {
   AppHackathonsRoute: typeof AppHackathonsRoute
   AppMessagesRoute: typeof AppMessagesRouteWithChildren
   AppNotificationsRoute: typeof AppNotificationsRoute
+  AppOrganizationsRoute: typeof AppOrganizationsRouteWithChildren
   AppProjectsRoute: typeof AppProjectsRouteWithChildren
   AppSearchRoute: typeof AppSearchRoute
   AppSettingsRoute: typeof AppSettingsRoute
@@ -476,6 +545,7 @@ const AppRouteChildren: AppRouteChildren = {
   AppHackathonsRoute: AppHackathonsRoute,
   AppMessagesRoute: AppMessagesRouteWithChildren,
   AppNotificationsRoute: AppNotificationsRoute,
+  AppOrganizationsRoute: AppOrganizationsRouteWithChildren,
   AppProjectsRoute: AppProjectsRouteWithChildren,
   AppSearchRoute: AppSearchRoute,
   AppSettingsRoute: AppSettingsRoute,

--- a/frontend/src/routes/_app.organizations.$orgId.tsx
+++ b/frontend/src/routes/_app.organizations.$orgId.tsx
@@ -1,0 +1,22 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { OrganizationProfile } from '../features/organizations/components/OrganizationProfile';
+
+export const Route = createFileRoute('/_app/organizations/$orgId')({
+  component: OrganizationProfilePage,
+});
+
+function OrganizationProfilePage() {
+  const { orgId } = Route.useParams();
+
+  const mockOrgData = {
+    name: 'DevLink',
+    logo_url: '',
+    banner_url: '',
+    location: 'Remote',
+    website: 'https://github.com/nensii21/devlink',
+    description: 'The developer portfolio & project collaboration network.',
+    hiring: true,
+  };
+
+  return <OrganizationProfile organizationData={mockOrgData} />;
+}

--- a/frontend/src/routes/_app.organizations.index.tsx
+++ b/frontend/src/routes/_app.organizations.index.tsx
@@ -1,0 +1,59 @@
+import { createFileRoute, Link } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/_app/organizations/')({
+  component: OrganizationsListPage,
+});
+
+function OrganizationsListPage() {
+  const mockOrgs = [
+    {
+      id: 'devlink-org',
+      name: 'DevLink',
+      description: 'The developer portfolio & project collaboration network.',
+      hiring: true,
+      members_count: 12,
+      projects_count: 5,
+    },
+  ];
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 py-8">
+      <div className="flex justify-between items-center mb-8">
+        <div>
+          <h1 className="text-3xl font-bold text-white">Organizations</h1>
+          <p className="text-gray-400 mt-1">
+            Discover startups, open-source orgs, and teams building awesome products.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {mockOrgs.map((org) => (
+          <Link
+            key={org.id}
+            to="/organizations/$orgId"
+            params={{ orgId: org.id }}
+            className="block p-6 rounded-xl border border-gray-800 bg-gray-900/40 hover:border-indigo-500/50 hover:bg-gray-800/40 transition-all cursor-pointer"
+          >
+            <div className="flex justify-between items-start mb-3">
+              <h2 className="text-xl font-semibold text-white hover:text-indigo-400 transition-colors">
+                {org.name}
+              </h2>
+              {org.hiring && (
+                <span className="text-xs px-2.5 py-1 rounded-full bg-emerald-500/10 text-emerald-400 border border-emerald-500/20 font-medium">
+                  Hiring
+                </span>
+              )}
+            </div>
+            <p className="text-gray-300 text-sm mb-4">{org.description}</p>
+            <div className="flex gap-4 text-xs text-gray-400">
+              <span>{org.members_count} Members</span>
+              <span>•</span>
+              <span>{org.projects_count} Projects</span>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/routes/_app.organizations.tsx
+++ b/frontend/src/routes/_app.organizations.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute, Outlet } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/_app/organizations')({
+  component: OrganizationsLayout,
+});
+
+function OrganizationsLayout() {
+  return <Outlet />;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -19,7 +19,7 @@
     "paths": {
       "@/*": ["src/*"]
     },
-    "ignoreDeprecations": "5.0",
+    "ignoreDeprecations": "6.0",
 
     "types": ["vite/client"],
 


### PR DESCRIPTION

## Summary
Implemented the frontend layout, interactive UI components, and TanStack Router dynamic routes for Organization Profiles as specified in Issue #114.

---

## Related Issue
Fixes #114

---

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [x] UI/UX enhancement
- [ ] Tests
- [ ] Other

---

## Changes Made
- Created `OrganizationProfile` and `OrganizationHeader` UI components supporting logo, banner, organization details, hiring status badge, and interactive tab navigation (About, Team, Projects, Hiring).
- Configured routes using TanStack Router for `/organizations` (list view) and `/organizations/$orgId` (dynamic profile view).
- Integrated the **Organizations** view under the *Community* section in `Sidebar.tsx`.

---

## Screenshots (if applicable)
<img width="1599" height="713" alt="image" src="https://github.com/user-attachments/assets/2dec282f-6b5d-4671-b6b5-ca6301f0d1f4" />

---

## Testing
- [x] Tested locally
- [ ] Existing tests pass
- [ ] Added new tests
- [x] UI verified
- [ ] Cross-browser tested (if applicable)

Additional testing notes:
- Verified navigation from sidebar to `/organizations` list.
- Verified route dynamic transition to `/organizations/$orgId` upon card interaction.
- Checked tab switching state across About, Team, Projects, and Hiring tabs with zero console errors.

---

## Checklist
- [x] My code follows the project's coding standards.
- [x] I have tested my changes locally.
- [ ] I have updated the documentation where necessary.
- [x] My changes do not introduce new warnings or errors.
- [x] I have reviewed my own code.
- [x] This pull request focuses on a single feature or fix.
- [x] I have linked the related issue.

---

## Additional Notes
UI currently utilizes structured mock data pending integration with backend organization endpoints.