### PR TITLE
feat: prevent invalid application status transitions

### DIFF
--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -33,6 +33,36 @@ class ApplicationService:
     Business logic for project applications.
     """
 
+    VALID_STATUS_TRANSITIONS = {
+        ApplicationStatus.PENDING: {
+            ApplicationStatus.ACCEPTED,
+            ApplicationStatus.REJECTED,
+            ApplicationStatus.WITHDRAWN,
+        },
+        ApplicationStatus.REVIEWING: {
+            ApplicationStatus.ACCEPTED,
+            ApplicationStatus.REJECTED,
+            ApplicationStatus.WITHDRAWN,
+        },
+        ApplicationStatus.ACCEPTED: set(),
+        ApplicationStatus.REJECTED: set(),
+        ApplicationStatus.WITHDRAWN: set(),
+    }
+
+    @staticmethod
+    def _validate_status_transition(
+        current: ApplicationStatus,
+        new: ApplicationStatus,
+    ) -> None:
+        if new not in ApplicationService.VALID_STATUS_TRANSITIONS[current]:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"Cannot change application status "
+                    f"from '{current.value}' to '{new.value}'."
+                ),
+            )
+
     @staticmethod
     def create_application(
         db: Session,
@@ -139,8 +169,12 @@ class ApplicationService:
         db_application: Application,
     ) -> Application:
 
-        db_application.status = ApplicationStatus.ACCEPTED
+        ApplicationService._validate_status_transition(
+            db_application.status,
+            ApplicationStatus.ACCEPTED,
+        )
 
+        db_application.status = ApplicationStatus.ACCEPTED
         db.flush()
         db.refresh(db_application)
 
@@ -173,6 +207,11 @@ class ApplicationService:
         db: Session,
         db_application: Application,
     ) -> Application:
+
+        ApplicationService._validate_status_transition(
+            db_application.status,
+            ApplicationStatus.REJECTED,
+        )
 
         db_application.status = ApplicationStatus.REJECTED
 
@@ -209,8 +248,12 @@ class ApplicationService:
         db_application: Application,
     ) -> Application:
 
-        db_application.status = ApplicationStatus.WITHDRAWN
+        ApplicationService._validate_status_transition(
+            db_application.status,
+            ApplicationStatus.WITHDRAWN,
+        )
 
+        db_application.status = ApplicationStatus.WITHDRAWN
         db.flush()
         db.refresh(db_application)
 


### PR DESCRIPTION
# Pull Request

## Summary

Prevent invalid application status transitions by centralizing transition validation in `ApplicationService`.

---

## Related Issue

Fixes #259

---

## Type of Change

- [x] Bug fix

---

## Changes Made

- Added centralized validation for application status transitions.
- Prevented invalid transitions from terminal states (Accepted, Rejected, Withdrawn).
- Kept transition rules in a single location for easier maintenance.

---

## Testing

- [x] Tested locally

Additional testing notes:

- Formatted the updated file using Black.
- Verified valid transitions continue to work.
- Verified invalid transitions now return an HTTP 400 error.

---

## Checklist

- [x] My code follows the project's coding standards.
- [x] I have tested my changes locally.
- [x] My changes do not introduce new warnings or errors.
- [x] I have reviewed my own code.
- [x] This pull request focuses on a single feature or fix.
- [x] I have linked the related issue.

---

## Additional Notes

Status transition validation is centralized inside `ApplicationService` to make future transition rules easier to maintain and extend.