### PR TITLE
fix(frontend): properly map profile_image to avatar from API response

### DIFF
--- a/frontend/src/api/modules/auth.ts
+++ b/frontend/src/api/modules/auth.ts
@@ -12,6 +12,7 @@ export interface AuthUser {
   username: string;
   full_name?: string;
   avatar?: string;
+  profile_image?: string;
 }
 export interface AuthResponse extends AuthTokens {
   user: AuthUser;

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -177,7 +177,7 @@ export const userService = {
         id: u.id,
         name: u.full_name ?? u.username,
         handle: u.username,
-        avatar: u.avatar ?? seed.currentUser.avatar,
+        avatar: u.profile_image ?? u.avatar ?? seed.currentUser.avatar,
         premium: (u as unknown as { premium?: boolean }).premium ?? false,
       };
     }, seed.currentUser),


### PR DESCRIPTION
# Pull Request

## Description

This pull request resolves an issue where the user avatar is displayed as a broken image on the navbar after login. The root cause of this issue was a mismatch in the expected property names. The backend API (`/api/auth/me`) was correctly returning the avatar URL in the `profile_image` field, but the frontend `AuthUser` interface and service logic expected it in the `avatar` field. This led to `undefined` resolving to the mock data fallback or breaking the image rendering.

By updating the frontend schemas and logic to parse `profile_image` alongside `avatar`, the user avatar now correctly displays on the navbar.

### Changes
- **Frontend/API**: Updated the `AuthUser` interface in `frontend/src/api/modules/auth.ts` to include the `profile_image?: string` field.
- **Frontend/Service**: Modified `userService.me()` in `frontend/src/services/index.ts` to properly map `avatar: u.profile_image ?? u.avatar ?? seed.currentUser.avatar`.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #380

## Testing

Verified that the user avatar logic now prioritizes the API's `profile_image` response, ensuring the real URL is parsed and displayed correctly in the navbar.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A - Data parsing fix only

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
