### PR TITLE
test: add form validation tests for Login, Signup, Profile, Create Pr…

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -27,7 +27,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - run: npm ci
       - run: npm run build
       - run: npm audit --audit-level=high
       - name: Lint check

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -72,8 +72,8 @@ class UserUpdate(BaseModel):
     first_name: Optional[str] = None
     last_name: Optional[str] = None
 
-    headline: Optional[str] = None
-    bio: Optional[str] = None
+    headline: Optional[str] = Field(default=None, max_length=150)
+    bio: Optional[str] = Field(default=None, max_length=1000)
 
     location: Optional[str] = None
     timezone: Optional[str] = None

--- a/backend/tests/test_forms_validation.py
+++ b/backend/tests/test_forms_validation.py
@@ -37,7 +37,9 @@ class TestLoginFormValidation:
 
     def test_login_api_endpoint_validation(self, client: TestClient):
         # Invalid email payload to endpoint returns HTTP 422
-        resp = client.post("/api/auth/login", json={"email": "bad-email", "password": "123"})
+        resp = client.post(
+            "/api/auth/login", json={"email": "bad-email", "password": "123"}
+        )
         assert resp.status_code == 422
 
 
@@ -199,7 +201,9 @@ class TestSettingsFormValidation:
     def test_change_password_invalid_inputs(self):
         # New password too short (< 8 chars)
         with pytest.raises(ValidationError) as exc_info:
-            ChangePasswordRequest(current_password="OldPassword123!", new_password="short")
+            ChangePasswordRequest(
+                current_password="OldPassword123!", new_password="short"
+            )
         field_names = [err["loc"][0] for err in exc_info.value.errors()]
         assert "new_password" in field_names
 

--- a/backend/tests/test_forms_validation.py
+++ b/backend/tests/test_forms_validation.py
@@ -1,0 +1,213 @@
+import pytest
+from pydantic import ValidationError
+from app.schemas.auth import LoginRequest, RegisterRequest, ChangePasswordRequest
+from app.schemas.user import UserUpdate, UserBase
+from app.schemas.project import ProjectCreate, ProjectStage, ProjectVisibility
+from fastapi.testclient import TestClient
+
+
+# ==============================================================================
+# 1. LOGIN FORM VALIDATION TESTS
+# ==============================================================================
+class TestLoginFormValidation:
+    def test_login_required_fields_missing(self):
+        with pytest.raises(ValidationError) as exc_info:
+            LoginRequest.model_validate({})
+        errors = exc_info.value.errors()
+        field_names = [err["loc"][0] for err in errors]
+        assert "email" in field_names
+        assert "password" in field_names
+
+    def test_login_invalid_inputs(self):
+        # Invalid email format
+        with pytest.raises(ValidationError) as exc_info:
+            LoginRequest(email="invalid-email-format", password="password123")
+        assert any(err["loc"][0] == "email" for err in exc_info.value.errors())
+
+        # Password too short (< 8 chars)
+        with pytest.raises(ValidationError) as exc_info:
+            LoginRequest(email="user@example.com", password="short")
+        assert any(err["loc"][0] == "password" for err in exc_info.value.errors())
+
+    def test_login_successful_submission(self):
+        payload = {"email": "user@example.com", "password": "Password123!"}
+        req = LoginRequest.model_validate(payload)
+        assert req.email == "user@example.com"
+        assert req.password == "Password123!"
+
+    def test_login_api_endpoint_validation(self, client: TestClient):
+        # Invalid email payload to endpoint returns HTTP 422
+        resp = client.post("/api/auth/login", json={"email": "bad-email", "password": "123"})
+        assert resp.status_code == 422
+
+
+# ==============================================================================
+# 2. SIGNUP FORM VALIDATION TESTS
+# ==============================================================================
+class TestSignupFormValidation:
+    def test_signup_required_fields_missing(self):
+        with pytest.raises(ValidationError) as exc_info:
+            RegisterRequest.model_validate({})
+        field_names = [err["loc"][0] for err in exc_info.value.errors()]
+        for field in ["first_name", "last_name", "username", "email", "password"]:
+            assert field in field_names
+
+    def test_signup_invalid_inputs(self):
+        # First name too short, username too short, invalid email, password too short
+        with pytest.raises(ValidationError) as exc_info:
+            RegisterRequest(
+                first_name="A",
+                last_name="B",
+                username="ab",
+                email="not-an-email",
+                password="123",
+            )
+        field_names = [err["loc"][0] for err in exc_info.value.errors()]
+        assert "first_name" in field_names
+        assert "last_name" in field_names
+        assert "username" in field_names
+        assert "email" in field_names
+        assert "password" in field_names
+
+    def test_signup_successful_submission(self):
+        payload = {
+            "first_name": "John",
+            "last_name": "Doe",
+            "username": "johndoe",
+            "email": "johndoe@example.com",
+            "password": "Password123!",
+        }
+        req = RegisterRequest.model_validate(payload)
+        assert req.first_name == "John"
+        assert req.username == "johndoe"
+        assert req.email == "johndoe@example.com"
+
+    def test_signup_api_endpoint_validation(self, client: TestClient):
+        # Invalid payload to registration endpoint returns 422
+        resp = client.post(
+            "/api/auth/register",
+            json={
+                "first_name": "J",
+                "last_name": "D",
+                "username": "u",
+                "email": "invalid-email",
+                "password": "short",
+            },
+        )
+        assert resp.status_code == 422
+
+
+# ==============================================================================
+# 3. PROFILE FORM VALIDATION TESTS
+# ==============================================================================
+class TestProfileFormValidation:
+    def test_profile_required_fields_base(self):
+        # UserBase requires first_name, last_name, username
+        with pytest.raises(ValidationError) as exc_info:
+            UserBase.model_validate({})
+        field_names = [err["loc"][0] for err in exc_info.value.errors()]
+        assert "first_name" in field_names
+        assert "last_name" in field_names
+        assert "username" in field_names
+
+    def test_profile_invalid_inputs(self):
+        # Bio exceeding 1000 characters or invalid URLs
+        with pytest.raises(ValidationError) as exc_info:
+            UserUpdate(
+                bio="x" * 1001,
+                website="invalid-url-schema",
+                github_url="not-a-url",
+                public_email="bad-email",
+            )
+        field_names = [err["loc"][0] for err in exc_info.value.errors()]
+        assert "bio" in field_names
+        assert "website" in field_names
+        assert "github_url" in field_names
+        assert "public_email" in field_names
+
+    def test_profile_successful_submission(self):
+        payload = {
+            "first_name": "Jane",
+            "last_name": "Developer",
+            "headline": "Senior Full Stack Engineer",
+            "bio": "Building scalable modern web apps.",
+            "public_email": "jane.public@example.com",
+            "website": "https://janedev.io",
+            "github_url": "https://github.com/janedev",
+            "linkedin_url": "https://linkedin.com/in/janedev",
+        }
+        update = UserUpdate.model_validate(payload)
+        assert update.first_name == "Jane"
+        assert str(update.website) == "https://janedev.io/"
+        assert str(update.github_url) == "https://github.com/janedev"
+
+
+# ==============================================================================
+# 4. CREATE PROJECT FORM VALIDATION TESTS
+# ==============================================================================
+class TestCreateProjectFormValidation:
+    def test_create_project_required_fields_missing(self):
+        with pytest.raises(ValidationError) as exc_info:
+            ProjectCreate.model_validate({})
+        field_names = [err["loc"][0] for err in exc_info.value.errors()]
+        assert "title" in field_names
+        assert "slug" in field_names
+        assert "description" in field_names
+
+    def test_create_project_invalid_inputs(self):
+        # Invalid stage enum value
+        with pytest.raises(ValidationError) as exc_info:
+            ProjectCreate(
+                title="My Project",
+                slug="my-project",
+                description="Project description",
+                stage="INVALID_STAGE",
+            )
+        field_names = [err["loc"][0] for err in exc_info.value.errors()]
+        assert "stage" in field_names
+
+    def test_create_project_successful_submission(self):
+        payload = {
+            "title": "Awesome Dev Tool",
+            "slug": "awesome-dev-tool",
+            "tagline": "The best developer tool ever built",
+            "description": "An end-to-end framework for building high quality web applications.",
+            "stage": ProjectStage.BETA,
+            "visibility": ProjectVisibility.PUBLIC,
+            "tech_stack": "Python, TypeScript, FastAPI",
+            "team_size": 2,
+            "max_team_size": 10,
+        }
+        proj = ProjectCreate.model_validate(payload)
+        assert proj.title == "Awesome Dev Tool"
+        assert proj.slug == "awesome-dev-tool"
+        assert proj.stage == ProjectStage.BETA
+        assert proj.max_team_size == 10
+
+
+# ==============================================================================
+# 5. SETTINGS FORM VALIDATION TESTS
+# ==============================================================================
+class TestSettingsFormValidation:
+    def test_change_password_required_fields_missing(self):
+        with pytest.raises(ValidationError) as exc_info:
+            ChangePasswordRequest.model_validate({})
+        field_names = [err["loc"][0] for err in exc_info.value.errors()]
+        assert "current_password" in field_names
+        assert "new_password" in field_names
+
+    def test_change_password_invalid_inputs(self):
+        # New password too short (< 8 chars)
+        with pytest.raises(ValidationError) as exc_info:
+            ChangePasswordRequest(current_password="OldPassword123!", new_password="short")
+        field_names = [err["loc"][0] for err in exc_info.value.errors()]
+        assert "new_password" in field_names
+
+    def test_change_password_successful_submission(self):
+        payload = {
+            "current_password": "OldPassword123!",
+            "new_password": "NewSecurePassword456!",
+        }
+        req = ChangePasswordRequest.model_validate(payload)
+        assert req.current_password == "OldPassword123!"
+        assert req.new_password == "NewSecurePassword456!"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -67,6 +67,8 @@
         "zod": "^3.24.2"
       },
       "devDependencies": {
+        "@emnapi/core": "^1.11.2",
+        "@emnapi/runtime": "^1.11.2",
         "@eslint/js": "^9.32.0",
         "@lovable.dev/vite-tanstack-config": "^2.6.4",
         "@types/node": "^22.16.5",
@@ -544,10 +546,33 @@
       "version": "1.5.0",
       "license": "MIT"
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -486,6 +486,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -534,6 +535,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -541,27 +543,6 @@
     "node_modules/@date-fns/tz": {
       "version": "1.5.0",
       "license": "MIT"
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
-      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
@@ -4864,7 +4845,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -5706,6 +5688,7 @@
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -75,6 +75,8 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@emnapi/core": "^1.11.2",
+    "@emnapi/runtime": "^1.11.2",
     "@eslint/js": "^9.32.0",
     "@lovable.dev/vite-tanstack-config": "^2.6.4",
     "@types/node": "^22.16.5",

--- a/frontend/src/features/organizations/components/OrganizationHeader.tsx
+++ b/frontend/src/features/organizations/components/OrganizationHeader.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 
 interface OrganizationHeaderProps {
   name: string;

--- a/frontend/src/features/organizations/components/OrganizationProfile.tsx
+++ b/frontend/src/features/organizations/components/OrganizationProfile.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { OrganizationHeader } from './OrganizationHeader';
+import React, { useState } from "react";
+import { OrganizationHeader } from "./OrganizationHeader";
 
 interface OrganizationProfileProps {
   organizationData: {
@@ -14,7 +14,7 @@ interface OrganizationProfileProps {
 }
 
 export const OrganizationProfile: React.FC<OrganizationProfileProps> = ({ organizationData }) => {
-  const [activeTab, setActiveTab] = useState<'about' | 'team' | 'projects' | 'hiring'>('about');
+  const [activeTab, setActiveTab] = useState<"about" | "team" | "projects" | "hiring">("about");
 
   return (
     <div className="max-w-6xl mx-auto px-4 py-8">
@@ -30,14 +30,14 @@ export const OrganizationProfile: React.FC<OrganizationProfileProps> = ({ organi
 
       {/* Tabs */}
       <div className="flex border-b border-gray-800 mb-6 gap-6">
-        {(['about', 'team', 'projects', 'hiring'] as const).map((tab) => (
+        {(["about", "team", "projects", "hiring"] as const).map((tab) => (
           <button
             key={tab}
             onClick={() => setActiveTab(tab)}
             className={`pb-3 text-sm font-medium capitalize border-b-2 transition-colors ${
               activeTab === tab
-                ? 'border-indigo-500 text-indigo-400'
-                : 'border-transparent text-gray-400 hover:text-gray-200'
+                ? "border-indigo-500 text-indigo-400"
+                : "border-transparent text-gray-400 hover:text-gray-200"
             }`}
           >
             {tab}
@@ -47,34 +47,40 @@ export const OrganizationProfile: React.FC<OrganizationProfileProps> = ({ organi
 
       {/* Tab Content */}
       <div className="bg-gray-900/30 border border-gray-800 rounded-xl p-6">
-        {activeTab === 'about' && (
+        {activeTab === "about" && (
           <div>
             <h2 className="text-xl font-semibold text-white mb-3">About Us</h2>
             <p className="text-gray-300 leading-relaxed">
-              {organizationData.description || 'No description provided.'}
+              {organizationData.description || "No description provided."}
             </p>
           </div>
         )}
 
-        {activeTab === 'team' && (
+        {activeTab === "team" && (
           <div>
             <h2 className="text-xl font-semibold text-white mb-4">Team Members</h2>
-            <p className="text-gray-400 text-sm">Showing team members connected to {organizationData.name}.</p>
+            <p className="text-gray-400 text-sm">
+              Showing team members connected to {organizationData.name}.
+            </p>
           </div>
         )}
 
-        {activeTab === 'projects' && (
+        {activeTab === "projects" && (
           <div>
             <h2 className="text-xl font-semibold text-white mb-4">Projects</h2>
-            <p className="text-gray-400 text-sm">Projects built or maintained by {organizationData.name}.</p>
+            <p className="text-gray-400 text-sm">
+              Projects built or maintained by {organizationData.name}.
+            </p>
           </div>
         )}
 
-        {activeTab === 'hiring' && (
+        {activeTab === "hiring" && (
           <div>
             <h2 className="text-xl font-semibold text-white mb-4">Open Roles</h2>
             {organizationData.hiring ? (
-              <p className="text-gray-300 text-sm">We are actively recruiting talent! Apply below.</p>
+              <p className="text-gray-300 text-sm">
+                We are actively recruiting talent! Apply below.
+              </p>
             ) : (
               <p className="text-gray-400 text-sm">We are not actively hiring right now.</p>
             )}

--- a/frontend/src/lib/schemas/__tests__/forms.test.ts
+++ b/frontend/src/lib/schemas/__tests__/forms.test.ts
@@ -42,7 +42,7 @@ describe("Form Validation Schemas", () => {
       expect(shortPassword.success).toBe(false);
       if (!shortPassword.success) {
         expect(shortPassword.error.flatten().fieldErrors.password).toContain(
-          "At least 8 characters"
+          "At least 8 characters",
         );
       }
     });
@@ -216,9 +216,7 @@ describe("Form Validation Schemas", () => {
         const fieldErrors = result.error.flatten().fieldErrors;
         expect(fieldErrors.title).toContain("Title must be at least 3 characters");
         expect(fieldErrors.tagline).toContain("Tagline cannot exceed 150 characters");
-        expect(fieldErrors.description).toContain(
-          "Description must be at least 10 characters"
-        );
+        expect(fieldErrors.description).toContain("Description must be at least 10 characters");
         expect(fieldErrors.stage).toContain("Invalid project stage");
         expect(fieldErrors.repository_url).toContain("Must be a valid URL");
         expect(fieldErrors.demo_url).toContain("Must be a valid URL");
@@ -322,9 +320,7 @@ describe("Form Validation Schemas", () => {
         expect(result.success).toBe(false);
         if (!result.success) {
           const fieldErrors = result.error.flatten().fieldErrors;
-          expect(fieldErrors.new_password).toContain(
-            "New password must be at least 8 characters"
-          );
+          expect(fieldErrors.new_password).toContain("New password must be at least 8 characters");
           expect(fieldErrors.confirm_new_password).toContain("New passwords must match");
         }
       });

--- a/frontend/src/lib/schemas/__tests__/forms.test.ts
+++ b/frontend/src/lib/schemas/__tests__/forms.test.ts
@@ -1,0 +1,346 @@
+import { describe, it, expect } from "vitest";
+import {
+  loginSchema,
+  signupSchema,
+  profileSchema,
+  createProjectSchema,
+  accountSettingsSchema,
+  changePasswordSchema,
+} from "../forms";
+
+describe("Form Validation Schemas", () => {
+  // ------------------------------------------------------------------
+  // 1. LOGIN FORM TESTS
+  // ------------------------------------------------------------------
+  describe("Login Form (loginSchema)", () => {
+    it("should fail validation when required fields are empty", () => {
+      const result = loginSchema.safeParse({ email: "", password: "" });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const fieldErrors = result.error.flatten().fieldErrors;
+        expect(fieldErrors.email).toBeDefined();
+        expect(fieldErrors.password).toBeDefined();
+      }
+    });
+
+    it("should fail validation when invalid inputs are provided", () => {
+      // Invalid email format
+      const invalidEmail = loginSchema.safeParse({
+        email: "not-an-email",
+        password: "Password123!",
+      });
+      expect(invalidEmail.success).toBe(false);
+      if (!invalidEmail.success) {
+        expect(invalidEmail.error.flatten().fieldErrors.email).toContain("Enter a valid email");
+      }
+
+      // Password too short (< 8 chars)
+      const shortPassword = loginSchema.safeParse({
+        email: "user@example.com",
+        password: "123",
+      });
+      expect(shortPassword.success).toBe(false);
+      if (!shortPassword.success) {
+        expect(shortPassword.error.flatten().fieldErrors.password).toContain(
+          "At least 8 characters"
+        );
+      }
+    });
+
+    it("should pass validation with valid inputs for successful submission", () => {
+      const validData = {
+        email: "user@example.com",
+        password: "Password123!",
+      };
+      const result = loginSchema.safeParse(validData);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual(validData);
+      }
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // 2. SIGNUP FORM TESTS
+  // ------------------------------------------------------------------
+  describe("Signup Form (signupSchema)", () => {
+    it("should fail validation when required fields are missing or empty", () => {
+      const result = signupSchema.safeParse({
+        first_name: "",
+        last_name: "",
+        username: "",
+        email: "",
+        password: "",
+        confirmPassword: "",
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const fieldErrors = result.error.flatten().fieldErrors;
+        expect(fieldErrors.first_name).toBeDefined();
+        expect(fieldErrors.last_name).toBeDefined();
+        expect(fieldErrors.username).toBeDefined();
+        expect(fieldErrors.email).toBeDefined();
+        expect(fieldErrors.password).toBeDefined();
+      }
+    });
+
+    it("should fail validation for invalid inputs", () => {
+      // Short first/last names & invalid username regex & short password
+      const result = signupSchema.safeParse({
+        first_name: "A",
+        last_name: "B",
+        username: "invalid-username!", // contains hyphens & exclamation
+        email: "invalid-email",
+        password: "short",
+        confirmPassword: "differentPassword",
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const fieldErrors = result.error.flatten().fieldErrors;
+        expect(fieldErrors.first_name).toContain("At least 2 characters");
+        expect(fieldErrors.last_name).toContain("At least 2 characters");
+        expect(fieldErrors.username).toContain("Letters, numbers, and underscores only");
+        expect(fieldErrors.email).toContain("Enter a valid email");
+        expect(fieldErrors.password).toContain("At least 8 characters");
+        expect(fieldErrors.confirmPassword).toContain("Passwords must match");
+      }
+    });
+
+    it("should pass validation with valid inputs for successful submission", () => {
+      const validData = {
+        first_name: "Jane",
+        last_name: "Doe",
+        username: "janedoe99",
+        email: "jane.doe@example.com",
+        password: "SecurePassword123!",
+        confirmPassword: "SecurePassword123!",
+      };
+      const result = signupSchema.safeParse(validData);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual(validData);
+      }
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // 3. PROFILE FORM TESTS
+  // ------------------------------------------------------------------
+  describe("Profile Form (profileSchema)", () => {
+    it("should fail validation when required fields are missing", () => {
+      const result = profileSchema.safeParse({
+        first_name: "",
+        last_name: "",
+        username: "",
+        email: "",
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const fieldErrors = result.error.flatten().fieldErrors;
+        expect(fieldErrors.first_name).toBeDefined();
+        expect(fieldErrors.last_name).toBeDefined();
+        expect(fieldErrors.username).toBeDefined();
+        expect(fieldErrors.email).toBeDefined();
+      }
+    });
+
+    it("should fail validation for invalid inputs (bad URLs, bio over length limit)", () => {
+      const result = profileSchema.safeParse({
+        first_name: "John",
+        last_name: "Smith",
+        username: "john_smith",
+        email: "john@example.com",
+        bio: "a".repeat(1001), // > 1000 characters
+        website: "not-a-url",
+        github_url: "invalid-github-url",
+        linkedin_url: "invalid-linkedin-url",
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const fieldErrors = result.error.flatten().fieldErrors;
+        expect(fieldErrors.bio).toContain("Bio cannot exceed 1000 characters");
+        expect(fieldErrors.website).toContain("Must be a valid URL");
+        expect(fieldErrors.github_url).toContain("Must be a valid URL");
+        expect(fieldErrors.linkedin_url).toContain("Must be a valid URL");
+      }
+    });
+
+    it("should pass validation with valid inputs for successful submission", () => {
+      const validData = {
+        first_name: "John",
+        last_name: "Smith",
+        username: "john_smith",
+        email: "john@example.com",
+        bio: "Full stack developer passionate about open source.",
+        website: "https://johnsmith.dev",
+        github_url: "https://github.com/johnsmith",
+        linkedin_url: "https://linkedin.com/in/johnsmith",
+      };
+      const result = profileSchema.safeParse(validData);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual(validData);
+      }
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // 4. CREATE PROJECT FORM TESTS
+  // ------------------------------------------------------------------
+  describe("Create Project Form (createProjectSchema)", () => {
+    it("should fail validation when required fields are missing", () => {
+      const result = createProjectSchema.safeParse({
+        title: "",
+        description: "",
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const fieldErrors = result.error.flatten().fieldErrors;
+        expect(fieldErrors.title).toBeDefined();
+        expect(fieldErrors.description).toBeDefined();
+      }
+    });
+
+    it("should fail validation for invalid inputs", () => {
+      const result = createProjectSchema.safeParse({
+        title: "AB", // < 3 chars
+        tagline: "a".repeat(151), // > 150 chars
+        description: "Short", // < 10 chars
+        stage: "unknown_stage", // invalid enum
+        repository_url: "bad-repo-url",
+        demo_url: "bad-demo-url",
+        max_team_size: 0, // < 1
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const fieldErrors = result.error.flatten().fieldErrors;
+        expect(fieldErrors.title).toContain("Title must be at least 3 characters");
+        expect(fieldErrors.tagline).toContain("Tagline cannot exceed 150 characters");
+        expect(fieldErrors.description).toContain(
+          "Description must be at least 10 characters"
+        );
+        expect(fieldErrors.stage).toContain("Invalid project stage");
+        expect(fieldErrors.repository_url).toContain("Must be a valid URL");
+        expect(fieldErrors.demo_url).toContain("Must be a valid URL");
+        expect(fieldErrors.max_team_size).toContain("Team size must be at least 1");
+      }
+    });
+
+    it("should pass validation with valid inputs for successful submission", () => {
+      const validData = {
+        title: "DevLink Platform",
+        tagline: "Developer showcase and collaboration platform",
+        description: "A comprehensive web application for developers to build and share.",
+        stage: "beta" as const,
+        tech_stack: "React, TypeScript, FastAPI, PostgreSQL",
+        repository_url: "https://github.com/example/devlink",
+        demo_url: "https://devlink.example.com",
+        max_team_size: 10,
+      };
+      const result = createProjectSchema.safeParse(validData);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual(validData);
+      }
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // 5. SETTINGS FORM TESTS
+  // ------------------------------------------------------------------
+  describe("Settings Forms", () => {
+    describe("Account Settings Form (accountSettingsSchema)", () => {
+      it("should fail validation when required fields are empty", () => {
+        const result = accountSettingsSchema.safeParse({
+          name: "",
+          username: "",
+          email: "",
+        });
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          const fieldErrors = result.error.flatten().fieldErrors;
+          expect(fieldErrors.name).toBeDefined();
+          expect(fieldErrors.username).toBeDefined();
+          expect(fieldErrors.email).toBeDefined();
+        }
+      });
+
+      it("should fail validation for invalid inputs", () => {
+        const result = accountSettingsSchema.safeParse({
+          name: "A",
+          username: "user@invalid",
+          email: "not-an-email",
+          bio: "x".repeat(1001),
+        });
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          const fieldErrors = result.error.flatten().fieldErrors;
+          expect(fieldErrors.name).toContain("At least 2 characters");
+          expect(fieldErrors.username).toContain("Letters, numbers, and underscores only");
+          expect(fieldErrors.email).toContain("Enter a valid email");
+          expect(fieldErrors.bio).toContain("Bio cannot exceed 1000 characters");
+        }
+      });
+
+      it("should pass validation with valid inputs for successful submission", () => {
+        const validData = {
+          name: "Nancy Wheeler",
+          username: "nancy_w",
+          email: "nancy@devlink.io",
+          bio: "Product engineer. React / Postgres / Rust.",
+        };
+        const result = accountSettingsSchema.safeParse(validData);
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.data).toEqual(validData);
+        }
+      });
+    });
+
+    describe("Change Password Form (changePasswordSchema)", () => {
+      it("should fail validation when required fields are empty", () => {
+        const result = changePasswordSchema.safeParse({
+          current_password: "",
+          new_password: "",
+          confirm_new_password: "",
+        });
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          const fieldErrors = result.error.flatten().fieldErrors;
+          expect(fieldErrors.current_password).toBeDefined();
+          expect(fieldErrors.new_password).toBeDefined();
+          expect(fieldErrors.confirm_new_password).toBeDefined();
+        }
+      });
+
+      it("should fail validation when new password is too short or confirmation mismatch", () => {
+        const result = changePasswordSchema.safeParse({
+          current_password: "OldPassword123!",
+          new_password: "short",
+          confirm_new_password: "different",
+        });
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          const fieldErrors = result.error.flatten().fieldErrors;
+          expect(fieldErrors.new_password).toContain(
+            "New password must be at least 8 characters"
+          );
+          expect(fieldErrors.confirm_new_password).toContain("New passwords must match");
+        }
+      });
+
+      it("should pass validation with valid inputs for successful submission", () => {
+        const validData = {
+          current_password: "OldPassword123!",
+          new_password: "NewSecurePassword456!",
+          confirm_new_password: "NewSecurePassword456!",
+        };
+        const result = changePasswordSchema.safeParse(validData);
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.data).toEqual(validData);
+        }
+      });
+    });
+  });
+});

--- a/frontend/src/lib/schemas/forms.ts
+++ b/frontend/src/lib/schemas/forms.ts
@@ -1,10 +1,12 @@
 import { z } from "zod";
 
 // Helper for optional URL fields that allow empty string
-const optionalUrl = z.string().optional().refine(
-  (val) => !val || val.trim() === "" || z.string().url().safeParse(val).success,
-  { message: "Must be a valid URL" }
-);
+const optionalUrl = z
+  .string()
+  .optional()
+  .refine((val) => !val || val.trim() === "" || z.string().url().safeParse(val).success, {
+    message: "Must be a valid URL",
+  });
 
 // 1. Login Form Schema
 export const loginSchema = z.object({

--- a/frontend/src/lib/schemas/forms.ts
+++ b/frontend/src/lib/schemas/forms.ts
@@ -1,0 +1,129 @@
+import { z } from "zod";
+
+// Helper for optional URL fields that allow empty string
+const optionalUrl = z.string().optional().refine(
+  (val) => !val || val.trim() === "" || z.string().url().safeParse(val).success,
+  { message: "Must be a valid URL" }
+);
+
+// 1. Login Form Schema
+export const loginSchema = z.object({
+  email: z.string().min(1, "Email is required").email("Enter a valid email"),
+  password: z.string().min(1, "Password is required").min(8, "At least 8 characters"),
+});
+
+export type LoginFormData = z.infer<typeof loginSchema>;
+
+// 2. Signup Form Schema
+export const signupSchema = z
+  .object({
+    first_name: z
+      .string()
+      .min(1, "First name is required")
+      .min(2, "At least 2 characters")
+      .max(100, "At most 100 characters"),
+    last_name: z
+      .string()
+      .min(1, "Last name is required")
+      .min(2, "At least 2 characters")
+      .max(100, "At most 100 characters"),
+    username: z
+      .string()
+      .min(1, "Username is required")
+      .min(3, "At least 3 characters")
+      .max(50, "At most 50 characters")
+      .regex(/^[a-zA-Z0-9_]+$/, "Letters, numbers, and underscores only"),
+    email: z.string().min(1, "Email is required").email("Enter a valid email"),
+    password: z.string().min(1, "Password is required").min(8, "At least 8 characters"),
+    confirmPassword: z.string().min(1, "Confirm password is required"),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords must match",
+    path: ["confirmPassword"],
+  });
+
+export type SignupFormData = z.infer<typeof signupSchema>;
+
+// 3. Profile Form Schema
+export const profileSchema = z.object({
+  first_name: z
+    .string()
+    .min(1, "First name is required")
+    .min(2, "At least 2 characters")
+    .max(100, "At most 100 characters"),
+  last_name: z
+    .string()
+    .min(1, "Last name is required")
+    .min(2, "At least 2 characters")
+    .max(100, "At most 100 characters"),
+  username: z
+    .string()
+    .min(1, "Username is required")
+    .min(3, "At least 3 characters")
+    .max(50, "At most 50 characters")
+    .regex(/^[a-zA-Z0-9_]+$/, "Letters, numbers, and underscores only"),
+  email: z.string().min(1, "Email is required").email("Enter a valid email"),
+  bio: z.string().max(1000, "Bio cannot exceed 1000 characters").optional(),
+  website: optionalUrl,
+  github_url: optionalUrl,
+  linkedin_url: optionalUrl,
+});
+
+export type ProfileFormData = z.infer<typeof profileSchema>;
+
+// 4. Create Project Form Schema
+export const createProjectSchema = z.object({
+  title: z
+    .string()
+    .min(1, "Title is required")
+    .min(3, "Title must be at least 3 characters")
+    .max(100, "Title cannot exceed 100 characters"),
+  tagline: z.string().max(150, "Tagline cannot exceed 150 characters").optional(),
+  description: z
+    .string()
+    .min(1, "Description is required")
+    .min(10, "Description must be at least 10 characters"),
+  stage: z.enum(["idea", "in_development", "beta", "launched"], {
+    errorMap: () => ({ message: "Invalid project stage" }),
+  }),
+  tech_stack: z.string().optional(),
+  repository_url: optionalUrl,
+  demo_url: optionalUrl,
+  max_team_size: z
+    .number({ invalid_type_error: "Team size must be a number" })
+    .min(1, "Team size must be at least 1")
+    .max(100, "Team size cannot exceed 100"),
+});
+
+export type CreateProjectFormData = z.infer<typeof createProjectSchema>;
+
+// 5. Settings Form Schemas (Account Settings & Change Password)
+export const accountSettingsSchema = z.object({
+  name: z.string().min(1, "Full name is required").min(2, "At least 2 characters"),
+  username: z
+    .string()
+    .min(1, "Username is required")
+    .min(3, "At least 3 characters")
+    .max(50, "At most 50 characters")
+    .regex(/^[a-zA-Z0-9_]+$/, "Letters, numbers, and underscores only"),
+  email: z.string().min(1, "Email is required").email("Enter a valid email"),
+  bio: z.string().max(1000, "Bio cannot exceed 1000 characters").optional(),
+});
+
+export type AccountSettingsFormData = z.infer<typeof accountSettingsSchema>;
+
+export const changePasswordSchema = z
+  .object({
+    current_password: z.string().min(1, "Current password is required"),
+    new_password: z
+      .string()
+      .min(1, "New password is required")
+      .min(8, "New password must be at least 8 characters"),
+    confirm_new_password: z.string().min(1, "Please confirm your new password"),
+  })
+  .refine((data) => data.new_password === data.confirm_new_password, {
+    message: "New passwords must match",
+    path: ["confirm_new_password"],
+  });
+
+export type ChangePasswordFormData = z.infer<typeof changePasswordSchema>;

--- a/frontend/src/routes/_app.organizations.$orgId.tsx
+++ b/frontend/src/routes/_app.organizations.$orgId.tsx
@@ -1,7 +1,7 @@
-import { createFileRoute } from '@tanstack/react-router';
-import { OrganizationProfile } from '../features/organizations/components/OrganizationProfile';
+import { createFileRoute } from "@tanstack/react-router";
+import { OrganizationProfile } from "../features/organizations/components/OrganizationProfile";
 
-export const Route = createFileRoute('/_app/organizations/$orgId')({
+export const Route = createFileRoute("/_app/organizations/$orgId")({
   component: OrganizationProfilePage,
 });
 
@@ -9,12 +9,12 @@ function OrganizationProfilePage() {
   const { orgId } = Route.useParams();
 
   const mockOrgData = {
-    name: 'DevLink',
-    logo_url: '',
-    banner_url: '',
-    location: 'Remote',
-    website: 'https://github.com/nensii21/devlink',
-    description: 'The developer portfolio & project collaboration network.',
+    name: "DevLink",
+    logo_url: "",
+    banner_url: "",
+    location: "Remote",
+    website: "https://github.com/nensii21/devlink",
+    description: "The developer portfolio & project collaboration network.",
     hiring: true,
   };
 

--- a/frontend/src/routes/_app.organizations.index.tsx
+++ b/frontend/src/routes/_app.organizations.index.tsx
@@ -1,15 +1,15 @@
-import { createFileRoute, Link } from '@tanstack/react-router';
+import { createFileRoute, Link } from "@tanstack/react-router";
 
-export const Route = createFileRoute('/_app/organizations/')({
+export const Route = createFileRoute("/_app/organizations/")({
   component: OrganizationsListPage,
 });
 
 function OrganizationsListPage() {
   const mockOrgs = [
     {
-      id: 'devlink-org',
-      name: 'DevLink',
-      description: 'The developer portfolio & project collaboration network.',
+      id: "devlink-org",
+      name: "DevLink",
+      description: "The developer portfolio & project collaboration network.",
       hiring: true,
       members_count: 12,
       projects_count: 5,

--- a/frontend/src/routes/_app.organizations.tsx
+++ b/frontend/src/routes/_app.organizations.tsx
@@ -1,6 +1,6 @@
-import { createFileRoute, Outlet } from '@tanstack/react-router';
+import { createFileRoute, Outlet } from "@tanstack/react-router";
 
-export const Route = createFileRoute('/_app/organizations')({
+export const Route = createFileRoute("/_app/organizations")({
   component: OrganizationsLayout,
 });
 

--- a/frontend/src/routes/auth.tsx
+++ b/frontend/src/routes/auth.tsx
@@ -18,25 +18,7 @@ export const Route = createFileRoute("/auth")({
   component: AuthScreen,
 });
 
-const signInSchema = z.object({
-  email: z.string().email("Enter a valid email"),
-  password: z.string().min(8, "At least 8 characters"),
-});
-const signUpSchema = signInSchema
-  .extend({
-    first_name: z.string().min(2, "At least 2 characters").max(100, "At most 100 characters"),
-    last_name: z.string().min(2, "At least 2 characters").max(100, "At most 100 characters"),
-    username: z
-      .string()
-      .min(3, "At least 3 characters")
-      .max(50, "At most 50 characters")
-      .regex(/^[a-zA-Z0-9_]+$/, "Letters, numbers, and underscores only"),
-    confirmPassword: z.string(),
-  })
-  .refine((d) => d.password === d.confirmPassword, {
-    message: "Passwords must match",
-    path: ["confirmPassword"],
-  });
+import { loginSchema as signInSchema, signupSchema as signUpSchema } from "@/lib/schemas/forms";
 
 type SignIn = z.infer<typeof signInSchema>;
 type SignUp = z.infer<typeof signUpSchema>;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -19,7 +19,6 @@
     "paths": {
       "@/*": ["src/*"]
     },
-    "ignoreDeprecations": "6.0",
 
     "types": ["vite/client"],
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive form validation test suites for all core application forms across both the frontend and backend to ensure validation behaves correctly for required fields, invalid inputs, and successful submissions.

### Forms Covered

* Login
* Signup
* Profile
* Create Project
* Settings (Account Settings & Change Password)

---

## Acceptance Criteria

* ✅ Required fields tested
* ✅ Invalid inputs tested
* ✅ Successful submissions tested

---

## Key Changes

### Frontend

* Added centralized Zod validation schemas for:

  * Login
  * Signup
  * Profile
  * Create Project
  * Account Settings
  * Change Password
* Refactored the authentication screen to use the shared validation schemas.
* Added a Vitest test suite covering:

  * Required field validation
  * Invalid input scenarios
  * Boundary conditions
  * Successful validation cases

### Backend

* Updated the `UserUpdate` schema with validation limits:

  * `headline` (maximum 150 characters)
  * `bio` (maximum 1000 characters)
* Added a Pytest suite to validate:

  * Pydantic request models
  * Form validation logic
  * HTTP 422 validation responses for invalid requests

---

## Test Results

### Frontend (Vitest)

```bash
npx vitest run src/lib/schemas/__tests__/forms.test.ts
```

**Result:** ✅ 18/18 tests passed

### Backend (Pytest)

```bash
python -m pytest tests/test_forms_validation.py
```

**Result:** ✅ 17/17 tests passed

##fixes  #390 