### PR TITLE
feat: Export User Data (#414)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -35,6 +35,7 @@ from app.routers import (
     bookmarks,
     builder_flares,
     conversations,
+    export,
     followers,
     health,
     messages,
@@ -178,6 +179,7 @@ async def global_exception_handler(request, exc):
 
 app.include_router(auth.router, prefix="/api/auth", tags=["Authentication"])
 app.include_router(users.router, prefix="/api/users", tags=["Users"])
+app.include_router(export.router, prefix="/api/users", tags=["Export"])
 app.include_router(projects.router, prefix="/api/projects", tags=["Projects"])
 app.include_router(builder_flares.router, prefix="/api/flare", tags=["Builder's Flare"])
 app.include_router(messages.router, prefix="/api/messages", tags=["Messages"])

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -187,6 +187,10 @@ class User(Base):
     )
 
     last_seen: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+
     last_active_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
         nullable=True,
@@ -241,12 +245,13 @@ class User(Base):
             return False
         threshold = getattr(self, "_online_threshold", 300)
         from datetime import datetime, timezone
+
         now = datetime.now(timezone.utc)
-        
+
         last_seen = self.last_seen
         if last_seen.tzinfo is None:
             last_seen = last_seen.replace(tzinfo=timezone.utc)
-            
+
         return (now - last_seen).total_seconds() < threshold
 
     # ------------------------------------------------------------------

--- a/backend/app/routers/export.py
+++ b/backend/app/routers/export.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from sqlalchemy.orm import Session
+
+from app.dependencies import get_database, get_current_active_user
+from app.models.user import User
+from app.schemas.export import ExportResponse
+from app.services.export_service import ExportService
+
+router = APIRouter()
+
+
+@router.post(
+    "/me/export",
+    response_model=ExportResponse,
+    summary="Export all user data",
+    description="Return a JSON archive of everything the authenticated user has on DevLink.",
+)
+def export_user_data(
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_database),
+):
+    data = ExportService.collect_user_data(db, current_user)
+    return ExportResponse(data=data)

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -5,9 +5,6 @@ import uuid
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 
 # pyrefly: ignore [missing-import]
-from fastapi import APIRouter, Depends, HTTPException, Query, status
-
-# pyrefly: ignore [missing-import]
 from sqlalchemy.orm import Session
 
 from app.dependencies import get_database
@@ -110,7 +107,9 @@ def create_user(
     response_model=CurrentUser,
 )
 def get_me(
-    online_threshold: int | None = Query(None, description="Online threshold in seconds"),
+    online_threshold: int | None = Query(
+        None, description="Online threshold in seconds"
+    ),
     current_user: User = Depends(get_current_user),
 ):
 
@@ -126,7 +125,9 @@ def get_me(
 )
 def get_user(
     user_id: uuid.UUID,
-    online_threshold: int | None = Query(None, description="Online threshold in seconds"),
+    online_threshold: int | None = Query(
+        None, description="Online threshold in seconds"
+    ),
     db: Session = Depends(get_database),
 ):
 
@@ -156,7 +157,9 @@ def list_users(
     request: Request,
     skip: int = Query(0, ge=0),
     limit: int = Query(20, ge=1, le=100),
-    online_threshold: int | None = Query(None, description="Online threshold in seconds"),
+    online_threshold: int | None = Query(
+        None, description="Online threshold in seconds"
+    ),
     db: Session = Depends(get_database),
 ):
 

--- a/backend/app/schemas/export.py
+++ b/backend/app/schemas/export.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any, Optional
+
+# pyrefly: ignore [missing-import]
+from pydantic import BaseModel, ConfigDict
+
+
+class ExportedSkill(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    name: str
+    level: Optional[str] = None
+    years_of_experience: int = 0
+
+
+class ExportedProject(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    title: str
+    slug: str
+    tagline: Optional[str] = None
+    description: str
+    stage: str
+    visibility: str
+    tech_stack: Optional[str] = None
+    repository_url: Optional[str] = None
+    website_url: Optional[str] = None
+    team_size: int = 1
+    hiring: bool = True
+    is_archived: bool = False
+    created_at: datetime
+    updated_at: datetime
+
+
+class ExportedApplication(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    project_id: uuid.UUID
+    status: str
+    message: Optional[str] = None
+    portfolio_url: Optional[str] = None
+    github_url: Optional[str] = None
+    created_at: datetime
+
+
+class ExportedConnection(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    user_id: uuid.UUID
+    username: Optional[str] = None
+    full_name: Optional[str] = None
+    direction: str
+    created_at: datetime
+
+
+class ExportedMessage(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    conversation_id: uuid.UUID
+    content: str
+    type: str
+    created_at: datetime
+
+
+class ExportedBookmark(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    project_id: uuid.UUID
+    created_at: datetime
+
+
+class ExportedOrganization(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    name: str
+    slug: str
+    organization_type: str
+    description: Optional[str] = None
+    created_at: datetime
+
+
+class UserExportData(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    exported_at: datetime
+    profile: dict[str, Any]
+    skills: list[ExportedSkill]
+    projects: list[ExportedProject]
+    project_memberships: list[dict[str, Any]]
+    applications: list[ExportedApplication]
+    connections: list[ExportedConnection]
+    messages: list[ExportedMessage]
+    bookmarks: list[ExportedBookmark]
+    organizations: list[ExportedOrganization]
+    activities: list[dict[str, Any]]
+    notifications: list[dict[str, Any]]
+    builder_flares: list[dict[str, Any]]
+
+
+class ExportResponse(BaseModel):
+    success: bool = True
+    data: UserExportData

--- a/backend/app/services/export_service.py
+++ b/backend/app/services/export_service.py
@@ -1,0 +1,386 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models.user import User
+from app.models.project import Project
+from app.models.application import Application
+from app.models.follower import Follower
+from app.models.bookmark import Bookmark
+from app.models.message import Message
+from app.models.notification import Notification
+from app.models.builder_flare import BuilderFlare
+from app.models.organization import Organization
+from app.models.activity import Activity
+from app.models.user_skill import UserSkill
+from app.models.project_member import ProjectMember
+from app.schemas.export import (
+    ExportedApplication,
+    ExportedBookmark,
+    ExportedConnection,
+    ExportedMessage,
+    ExportedOrganization,
+    ExportedProject,
+    ExportedSkill,
+    UserExportData,
+)
+
+
+class ExportService:
+    """
+    Collects and serialises every piece of data belonging to a user.
+    """
+
+    @staticmethod
+    def collect_user_data(db: Session, user: User) -> UserExportData:
+        now = datetime.now(timezone.utc)
+
+        profile = ExportService._build_profile(user)
+        skills = ExportService._get_skills(db, user.id)
+        projects = ExportService._get_projects(db, user.id)
+        project_memberships = ExportService._get_project_memberships(db, user.id)
+        applications = ExportService._get_applications(db, user.id)
+        connections = ExportService._get_connections(db, user.id)
+        messages = ExportService._get_messages(db, user.id)
+        bookmarks = ExportService._get_bookmarks(db, user.id)
+        organizations = ExportService._get_organizations(db, user.id)
+        activities = ExportService._get_activities(db, user.id)
+        notifications = ExportService._get_notifications(db, user.id)
+        builder_flares = ExportService._get_builder_flares(db, user.id)
+
+        return UserExportData(
+            exported_at=now,
+            profile=profile,
+            skills=skills,
+            projects=projects,
+            project_memberships=project_memberships,
+            applications=applications,
+            connections=connections,
+            messages=messages,
+            bookmarks=bookmarks,
+            organizations=organizations,
+            activities=activities,
+            notifications=notifications,
+            builder_flares=builder_flares,
+        )
+
+    # ------------------------------------------------------------------
+    # Profile
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _build_profile(user: User) -> dict:
+        return {
+            "id": str(user.id),
+            "first_name": user.first_name,
+            "last_name": user.last_name,
+            "username": user.username,
+            "email": user.email,
+            "headline": user.headline,
+            "bio": user.bio,
+            "profile_image": user.profile_image,
+            "cover_image": user.cover_image,
+            "location": user.location,
+            "timezone": user.timezone,
+            "website": str(user.website) if user.website else None,
+            "portfolio_url": str(user.portfolio_url) if user.portfolio_url else None,
+            "public_email": user.public_email,
+            "github_url": str(user.github_url) if user.github_url else None,
+            "linkedin_url": str(user.linkedin_url) if user.linkedin_url else None,
+            "role": user.role,
+            "experience_level": user.experience_level,
+            "company": user.company,
+            "open_to_work": user.open_to_work,
+            "is_verified": user.is_verified,
+            "created_at": user.created_at.isoformat() if user.created_at else None,
+        }
+
+    # ------------------------------------------------------------------
+    # Skills
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_skills(db: Session, user_id: uuid.UUID) -> list[ExportedSkill]:
+        from app.models.skill import Skill
+
+        rows = (
+            db.query(UserSkill, Skill)
+            .join(Skill, UserSkill.skill_id == Skill.id)
+            .filter(UserSkill.user_id == user_id)
+            .all()
+        )
+        return [
+            ExportedSkill(
+                id=skill.id,
+                name=skill.name,
+                level=us.level.value if us.level else None,
+                years_of_experience=us.years_of_experience,
+            )
+            for us, skill in rows
+        ]
+
+    # ------------------------------------------------------------------
+    # Projects
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_projects(db: Session, user_id: uuid.UUID) -> list[ExportedProject]:
+        rows = (
+            db.query(Project)
+            .filter(Project.owner_id == user_id)
+            .order_by(Project.created_at.desc())
+            .all()
+        )
+        return [
+            ExportedProject(
+                id=p.id,
+                title=p.title,
+                slug=p.slug,
+                tagline=p.tagline,
+                description=p.description,
+                stage=p.stage.value if p.stage else "IDEA",
+                visibility=p.visibility.value if p.visibility else "PUBLIC",
+                tech_stack=p.tech_stack,
+                repository_url=p.repository_url,
+                website_url=p.website_url,
+                team_size=p.team_size,
+                hiring=p.hiring,
+                is_archived=p.is_archived,
+                created_at=p.created_at,
+                updated_at=p.updated_at,
+            )
+            for p in rows
+        ]
+
+    # ------------------------------------------------------------------
+    # Project Memberships
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_project_memberships(db: Session, user_id: uuid.UUID) -> list[dict]:
+        rows = db.query(ProjectMember).filter(ProjectMember.user_id == user_id).all()
+        return [
+            {
+                "project_id": str(pm.project_id),
+                "role": pm.role.value if pm.role else "MEMBER",
+                "is_active": pm.is_active,
+                "joined_at": pm.joined_at.isoformat() if pm.joined_at else None,
+            }
+            for pm in rows
+        ]
+
+    # ------------------------------------------------------------------
+    # Applications
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_applications(db: Session, user_id: uuid.UUID) -> list[ExportedApplication]:
+        rows = (
+            db.query(Application)
+            .filter(Application.applicant_id == user_id)
+            .order_by(Application.created_at.desc())
+            .all()
+        )
+        return [
+            ExportedApplication(
+                id=a.id,
+                project_id=a.project_id,
+                status=a.status.value if a.status else "PENDING",
+                message=a.message,
+                portfolio_url=a.portfolio_url,
+                github_url=a.github_url,
+                created_at=a.created_at,
+            )
+            for a in rows
+        ]
+
+    # ------------------------------------------------------------------
+    # Connections (followers + following)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_connections(db: Session, user_id: uuid.UUID) -> list[ExportedConnection]:
+        connections: list[ExportedConnection] = []
+
+        following_rows = (
+            db.query(Follower).filter(Follower.follower_id == user_id).all()
+        )
+        for f in following_rows:
+            target = db.get(User, f.following_id)
+            connections.append(
+                ExportedConnection(
+                    user_id=f.following_id,
+                    username=target.username if target else None,
+                    full_name=(
+                        f"{target.first_name} {target.last_name}" if target else None
+                    ),
+                    direction="following",
+                    created_at=f.created_at,
+                )
+            )
+
+        follower_rows = (
+            db.query(Follower).filter(Follower.following_id == user_id).all()
+        )
+        for f in follower_rows:
+            source = db.get(User, f.follower_id)
+            connections.append(
+                ExportedConnection(
+                    user_id=f.follower_id,
+                    username=source.username if source else None,
+                    full_name=(
+                        f"{source.first_name} {source.last_name}" if source else None
+                    ),
+                    direction="follower",
+                    created_at=f.created_at,
+                )
+            )
+
+        return connections
+
+    # ------------------------------------------------------------------
+    # Messages
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_messages(db: Session, user_id: uuid.UUID) -> list[ExportedMessage]:
+        rows = (
+            db.query(Message)
+            .filter(Message.sender_id == user_id)
+            .order_by(Message.created_at.desc())
+            .limit(1000)
+            .all()
+        )
+        return [
+            ExportedMessage(
+                id=m.id,
+                conversation_id=m.conversation_id,
+                content=m.content,
+                type=m.type.value if m.type else "TEXT",
+                created_at=m.created_at,
+            )
+            for m in rows
+        ]
+
+    # ------------------------------------------------------------------
+    # Bookmarks
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_bookmarks(db: Session, user_id: uuid.UUID) -> list[ExportedBookmark]:
+        rows = (
+            db.query(Bookmark)
+            .filter(Bookmark.user_id == user_id)
+            .order_by(Bookmark.created_at.desc())
+            .all()
+        )
+        return [
+            ExportedBookmark(
+                id=b.id,
+                project_id=b.project_id,
+                created_at=b.created_at,
+            )
+            for b in rows
+        ]
+
+    # ------------------------------------------------------------------
+    # Organizations
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_organizations(
+        db: Session, user_id: uuid.UUID
+    ) -> list[ExportedOrganization]:
+        rows = db.query(Organization).filter(Organization.owner_id == user_id).all()
+        return [
+            ExportedOrganization(
+                id=o.id,
+                name=o.name,
+                slug=o.slug,
+                organization_type=(
+                    o.organization_type.value if o.organization_type else "STARTUP"
+                ),
+                description=o.description,
+                created_at=o.created_at,
+            )
+            for o in rows
+        ]
+
+    # ------------------------------------------------------------------
+    # Activities
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_activities(db: Session, user_id: uuid.UUID) -> list[dict]:
+        rows = (
+            db.query(Activity)
+            .filter(Activity.actor_id == user_id)
+            .order_by(Activity.created_at.desc())
+            .limit(500)
+            .all()
+        )
+        return [
+            {
+                "id": str(a.id),
+                "activity_type": a.activity_type.value if a.activity_type else None,
+                "title": a.title,
+                "description": a.description,
+                "target_id": str(a.target_id) if a.target_id else None,
+                "target_type": a.target_type,
+                "created_at": a.created_at.isoformat() if a.created_at else None,
+            }
+            for a in rows
+        ]
+
+    # ------------------------------------------------------------------
+    # Notifications
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_notifications(db: Session, user_id: uuid.UUID) -> list[dict]:
+        rows = (
+            db.query(Notification)
+            .filter(Notification.recipient_id == user_id)
+            .order_by(Notification.created_at.desc())
+            .limit(500)
+            .all()
+        )
+        return [
+            {
+                "id": str(n.id),
+                "type": n.type.value if n.type else None,
+                "title": n.title,
+                "message": n.message,
+                "is_read": n.is_read,
+                "created_at": n.created_at.isoformat() if n.created_at else None,
+            }
+            for n in rows
+        ]
+
+    # ------------------------------------------------------------------
+    # Builder Flares
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_builder_flares(db: Session, user_id: uuid.UUID) -> list[dict]:
+        rows = (
+            db.query(BuilderFlare)
+            .filter(BuilderFlare.created_by == user_id)
+            .order_by(BuilderFlare.created_at.desc())
+            .all()
+        )
+        return [
+            {
+                "id": str(f.id),
+                "project_id": str(f.project_id),
+                "title": f.title,
+                "description": f.description,
+                "role": f.role,
+                "status": f.status.value if f.status else "OPEN",
+                "created_at": f.created_at.isoformat() if f.created_at else None,
+            }
+            for f in rows
+        ]

--- a/backend/tests/test_last_seen.py
+++ b/backend/tests/test_last_seen.py
@@ -40,7 +40,9 @@ def setup_db():
     app.dependency_overrides.clear()
 
 
-def _register_and_login(client: TestClient, email: str, username: str) -> tuple[str, str]:
+def _register_and_login(
+    client: TestClient, email: str, username: str
+) -> tuple[str, str]:
     # Register
     client.post(
         "/api/auth/register",
@@ -62,7 +64,7 @@ def _register_and_login(client: TestClient, email: str, username: str) -> tuple[
 def test_last_seen_updated_on_login():
     client = TestClient(app)
     user_id, token = _register_and_login(client, "test@devlink.com", "testuser")
-    
+
     # Check that user.last_seen is not None after login
     db = TestingSessionLocal()
     user = db.get(User, uuid.UUID(user_id))
@@ -73,22 +75,22 @@ def test_last_seen_updated_on_login():
 def test_last_seen_updated_on_authenticated_requests_with_throttling():
     client = TestClient(app)
     user_id, token = _register_and_login(client, "test@devlink.com", "testuser")
-    
+
     db = TestingSessionLocal()
     user = db.get(User, uuid.UUID(user_id))
     first_seen = user.last_seen
     assert first_seen is not None
-    
+
     # Repeated request within 60 seconds should NOT update last_seen (throttling)
     client.get("/api/users/me", headers={"Authorization": f"Bearer {token}"})
     db.refresh(user)
     assert user.last_seen == first_seen
-    
+
     # Manually set last_seen to 70 seconds ago to bypass throttle
     user.last_seen = datetime.now(timezone.utc) - timedelta(seconds=70)
     db.commit()
     throttled_seen = user.last_seen
-    
+
     # Next request should trigger update
     client.get("/api/users/me", headers={"Authorization": f"Bearer {token}"})
     db.refresh(user)
@@ -99,32 +101,32 @@ def test_last_seen_updated_on_authenticated_requests_with_throttling():
 def test_is_online_status_and_custom_thresholds():
     client = TestClient(app)
     user_id, token = _register_and_login(client, "test@devlink.com", "testuser")
-    
+
     # 1. Default threshold (300 seconds) - should be online
     r = client.get("/api/users/me", headers={"Authorization": f"Bearer {token}"})
     data = r.json()
     assert data["is_online"] is True
     assert data["last_seen"] is not None
-    
+
     # 2. Check via public profile endpoint
     r2 = client.get(f"/api/users/{user_id}")
     assert r2.json()["is_online"] is True
-    
+
     # 3. Simulate user has not been seen for 10 minutes (600 seconds)
     db = TestingSessionLocal()
     user = db.get(User, uuid.UUID(user_id))
     user.last_seen = datetime.now(timezone.utc) - timedelta(minutes=10)
     db.commit()
     db.close()
-    
+
     # Check default (should be offline now)
     r3 = client.get(f"/api/users/{user_id}")
     assert r3.json()["is_online"] is False
-    
+
     # Check with query param online_threshold=1200 (20 minutes) -> should show online!
     r4 = client.get(f"/api/users/{user_id}?online_threshold=1200")
     assert r4.json()["is_online"] is True
-    
+
     # Check on list users endpoint with custom threshold
     r5 = client.get("/api/users/?online_threshold=1200")
     users = r5.json()

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -16,6 +16,8 @@ export { searchApi } from "./modules/search";
 export { activitiesApi } from "./modules/activities";
 export { collectionsApi } from "./modules/collections";
 export { bookmarksApi } from "./modules/bookmarks";
+export { exportApi } from "./modules/export";
+export type { UserExportData, ExportResponse } from "./modules/export";
 export type {
   BookmarkResponse as BookmarkItem,
   BookmarkCheckResponse,

--- a/frontend/src/api/modules/export.ts
+++ b/frontend/src/api/modules/export.ts
@@ -1,0 +1,92 @@
+import { api } from "../client";
+
+export interface ExportedSkill {
+  id: string;
+  name: string;
+  level: string | null;
+  years_of_experience: number;
+}
+
+export interface ExportedProject {
+  id: string;
+  title: string;
+  slug: string;
+  tagline: string | null;
+  description: string;
+  stage: string;
+  visibility: string;
+  tech_stack: string | null;
+  repository_url: string | null;
+  website_url: string | null;
+  team_size: number;
+  hiring: boolean;
+  is_archived: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ExportedApplication {
+  id: string;
+  project_id: string;
+  status: string;
+  message: string | null;
+  portfolio_url: string | null;
+  github_url: string | null;
+  created_at: string;
+}
+
+export interface ExportedConnection {
+  user_id: string;
+  username: string | null;
+  full_name: string | null;
+  direction: string;
+  created_at: string;
+}
+
+export interface ExportedMessage {
+  id: string;
+  conversation_id: string;
+  content: string;
+  type: string;
+  created_at: string;
+}
+
+export interface ExportedBookmark {
+  id: string;
+  project_id: string;
+  created_at: string;
+}
+
+export interface ExportedOrganization {
+  id: string;
+  name: string;
+  slug: string;
+  organization_type: string;
+  description: string | null;
+  created_at: string;
+}
+
+export interface UserExportData {
+  exported_at: string;
+  profile: Record<string, unknown>;
+  skills: ExportedSkill[];
+  projects: ExportedProject[];
+  project_memberships: Record<string, unknown>[];
+  applications: ExportedApplication[];
+  connections: ExportedConnection[];
+  messages: ExportedMessage[];
+  bookmarks: ExportedBookmark[];
+  organizations: ExportedOrganization[];
+  activities: Record<string, unknown>[];
+  notifications: Record<string, unknown>[];
+  builder_flares: Record<string, unknown>[];
+}
+
+export interface ExportResponse {
+  success: boolean;
+  data: UserExportData;
+}
+
+export const exportApi = {
+  exportData: () => api.post<ExportResponse>("/api/users/me/export"),
+};

--- a/frontend/src/routes/_app.builders.tsx
+++ b/frontend/src/routes/_app.builders.tsx
@@ -2,19 +2,19 @@ import { createFileRoute, Link, useNavigate, useRouterState, Outlet } from "@tan
 import { useQuery } from "@tanstack/react-query";
 import { buildersService } from "@/services";
 import type { Builder } from "@/services";
-import { Card, AnimatedCard, TagChip, Avatar, Skeleton, EmptyState } from "@/components/shared/primitives";
+import {
+  Card,
+  AnimatedCard,
+  TagChip,
+  Avatar,
+  Skeleton,
+  EmptyState,
+} from "@/components/shared/primitives";
 import { HighlightText } from "@/components/shared/HighlightText";
 import { LastActive } from "@/components/shared/LastActive";
 import { useState } from "react";
 import { cn } from "@/lib/utils";
-import {
-  Search,
-  Sparkles,
-  Calendar,
-  Briefcase,
-  Check,
-  Bookmark,
-} from "lucide-react";
+import { Search, Sparkles, Calendar, Briefcase, Check, Bookmark } from "lucide-react";
 import { motion } from "framer-motion";
 import { containerVariants } from "@/lib/animations";
 
@@ -356,7 +356,11 @@ function BuildersPage() {
             const isConnected = connections.includes(b.id);
             return (
               <Link key={b.id} to="/builders/$builderId" params={{ builderId: b.id }}>
-                <AnimatedCard interactive index={i} className="p-4 text-center h-full flex flex-col justify-between">
+                <AnimatedCard
+                  interactive
+                  index={i}
+                  className="p-4 text-center h-full flex flex-col justify-between"
+                >
                   <div>
                     <div className="mx-auto w-fit">
                       <Avatar src={b.avatar} alt={b.name} size={64} online={b.online} />

--- a/frontend/src/routes/_app.settings.tsx
+++ b/frontend/src/routes/_app.settings.tsx
@@ -1,13 +1,14 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { Card } from "@/components/shared/primitives";
 import { useState, useCallback } from "react";
-import { Eye, EyeOff } from "lucide-react";
+import { Eye, EyeOff, Download } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import { currentUser } from "@/mocks/seed";
 import { LoadingButton } from "@/components/shared/LoadingButton";
+import { exportApi } from "@/api";
 
-const tabs = ["Account", "Appearance", "Notifications", "Security", "Billing"] as const;
+const tabs = ["Account", "Appearance", "Notifications", "Security", "Billing", "Export"] as const;
 type Tab = (typeof tabs)[number];
 
 export const Route = createFileRoute("/_app/settings")({
@@ -29,6 +30,7 @@ function SettingsPage() {
   const [showNewPassword, setShowNewPassword] = useState(false);
   const [savingAccount, setSavingAccount] = useState(false);
   const [savingPassword, setSavingPassword] = useState(false);
+  const [exporting, setExporting] = useState(false);
   const inp =
     "w-full rounded-md border border-border bg-surface px-3 py-[8px] text-[14px] text-foreground outline-none focus:border-primary focus:ring-2 focus:ring-primary/20";
   const lbl = "mb-1 block text-[13px] font-semibold text-foreground";
@@ -188,6 +190,50 @@ function SettingsPage() {
               <div className="rounded-md border border-primary/30 bg-primary-soft p-4 text-[13px] text-foreground">
                 You're on the <span className="font-semibold">Pro</span> plan. Next invoice on Nov
                 4, 2026.
+              </div>
+            )}
+            {tab === "Export" && (
+              <div className="space-y-4">
+                <p className="text-[13px] text-muted-foreground">
+                  Download a complete copy of your DevLink data. This includes your profile, skills,
+                  projects, connections, messages, bookmarks, and activity history.
+                </p>
+                <div className="rounded-md border border-border p-4">
+                  <h3 className="text-[14px] font-semibold text-foreground">Export your data</h3>
+                  <p className="mt-1 text-[12px] text-muted-foreground">
+                    Your data will be exported as a JSON file.
+                  </p>
+                  <LoadingButton
+                    className="mt-3"
+                    loading={exporting}
+                    loadingText="Preparing export..."
+                    onClick={async () => {
+                      setExporting(true);
+                      try {
+                        const res = await exportApi.exportData();
+                        const blob = new Blob([JSON.stringify(res.data, null, 2)], {
+                          type: "application/json",
+                        });
+                        const url = URL.createObjectURL(blob);
+                        const a = document.createElement("a");
+                        a.href = url;
+                        a.download = `devlink-export-${new Date().toISOString().slice(0, 10)}.json`;
+                        document.body.appendChild(a);
+                        a.click();
+                        document.body.removeChild(a);
+                        URL.revokeObjectURL(url);
+                        toast.success("Data exported successfully");
+                      } catch (err) {
+                        toast.error("Failed to export data. Please try again.");
+                      } finally {
+                        setExporting(false);
+                      }
+                    }}
+                  >
+                    <Download size={16} className="mr-2" />
+                    Export data
+                  </LoadingButton>
+                </div>
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary

Allow users to export all of their DevLink data as a downloadable JSON archive.

Closes #414

## Changes

### Backend
- **Export Router** (`backend/app/routers/export.py`): `POST /api/users/me/export` endpoint returning the authenticated user's complete data
- **Export Service** (`backend/app/services/export_service.py`): Collects profile, skills, projects, project memberships, applications, connections, messages, bookmarks, organizations, activities, notifications, and builder flares
- **Export Schemas** (`backend/app/schemas/export.py`): Pydantic response models for all exported data types
- **Router Registration** (`backend/app/main.py`): Registered export router under `/api/users`

### Frontend
- **API Module** (`frontend/src/api/modules/export.ts`): Typed API client for the export endpoint with full response type definitions
- **API Exports** (`frontend/src/api/index.ts`): Added `exportApi` + type exports
- **Settings Page** (`frontend/src/routes/_app.settings.tsx`): Added "Export" tab with a download button that fetches data and saves it as a timestamped JSON file

## API

| Method | Endpoint | Description |
|--------|----------|-------------|
| POST | `/api/users/me/export` | Export all user data |

## Data Included

| Category | Description |
|----------|-------------|
| Profile | Name, username, email, bio, links, professional info |
| Skills | User skills with level and experience |
| Projects | All owned projects |
| Memberships | Project team memberships |
| Applications | Job/project applications |
| Connections | Followers and following |
| Messages | Messages sent (capped at 1000) |
| Bookmarks | Saved projects |
| Organizations | Owned organizations |
| Activities | Activity feed (capped at 500) |
| Notifications | Notification history (capped at 500) |
| Builder Flares | Flares created