### PR TITLE
Improve mobile touch target sizes for invite request action buttons

### DIFF
--- a/frontend/src/features/dashboard/sections.tsx
+++ b/frontend/src/features/dashboard/sections.tsx
@@ -113,10 +113,10 @@ export function InviteRequests() {
               </p>
             </div>
             <div className="flex gap-1.5">
-              <button className="grid h-8 w-8 place-items-center rounded-xl border border-emerald-500/30 bg-emerald-500/10 text-emerald-500 transition-colors hover:bg-emerald-500/20 active:scale-95">
+              <button className="grid h-11 w-11 place-items-center rounded-xl border border-emerald-500/30 bg-emerald-500/10 text-emerald-500 transition-colors hover:bg-emerald-500/20 active:scale-95">
                 <Check size={15} />
               </button>
-              <button className="grid h-8 w-8 place-items-center rounded-xl border border-destructive/30 bg-destructive/10 text-destructive transition-colors hover:bg-destructive/20 active:scale-95">
+              <button className="grid h-11 w-11 place-items-center rounded-xl border border-destructive/30 bg-destructive/10 text-destructive transition-colors hover:bg-destructive/20 active:scale-95">
                 <X size={15} />
               </button>
             </div>


### PR DESCRIPTION
## Summary

This PR improves the touch target size of the action buttons in the **Invite Requests** section on mobile devices.

### Changes
- Increased the size of the accept and reject icon buttons from `h-8 w-8` to `h-11 w-11`.
- Improved touch accessibility while preserving the existing visual design and functionality.

### Testing
- Verified the Invite Requests section in mobile responsive view.
- Confirmed that the buttons are easier to tap.
- Confirmed there are no layout or visual regressions.

Closes #351 
<img width="659" height="730" alt="Screenshot 2026-07-24 171448" src="https://github.com/user-attachments/assets/c941f17c-8904-4805-b108-b3492e77d157" />
