### PR TITLE
style: add .editorconfig file for consistent formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,28 @@
+# EditorConfig helps maintain consistent coding styles for multiple developers working on the same project across various editors and IDEs.
+# https://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.{js,jsx,ts,tsx,json,css,scss,html,yaml,yml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
## Description
This PR adds a root `.editorconfig` file to enforce consistent indentation, character encoding, newline formatting, and whitespace handling across all code editors and IDEs (VS Code, WebStorm, PyCharm, Vim, etc.).

## Changes Made
- Created root [`.editorconfig`](file:///c:/Users/babin/Desktop/ECSoC_2026/devlink/.editorconfig) configured with:
  - Global defaults: UTF-8 encoding, LF line endings, space indentation, trim trailing whitespace, insert final newline.
  - Python (`*.py`): 4 space indent per PEP 8.
  - JavaScript / TypeScript / React / JSON / CSS / SCSS / HTML / YAML (`*.js, *.ts, *.tsx, *.json, *.css, *.yaml`): 2 space indent.
  - Markdown (`*.md`): 2 space indent, trailing whitespace trimming disabled for standard Markdown hard breaks.
  - Makefile: Tab indent style.

## Issue Addressed
Closes #471

## Verification & Acceptance Criteria
- [x] `.editorconfig` created in root directory.
- [x] Correct formatting rules assigned for Python, TypeScript/React, Markdown, and configuration files.