### PR TITLE
feat(api): add CRUD endpoints for saved project searches

### DIFF
--- a/backend/alembic/versions/b1c2d3e4f5a6_create_saved_searches_table.py
+++ b/backend/alembic/versions/b1c2d3e4f5a6_create_saved_searches_table.py
@@ -1,0 +1,52 @@
+"""create saved_searches table
+
+Revision ID: b1c2d3e4f5a6
+Revises: a3b4c5d6e7f8
+Create Date: 2026-07-26 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "b1c2d3e4f5a6"
+down_revision: Union[str, None] = "a3b4c5d6e7f8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "saved_searches",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("filters", sa.JSON(), nullable=False, server_default="{}"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("user_id", "name", name="uq_user_saved_search_name"),
+    )
+    op.create_index("ix_saved_searches_user_id", "saved_searches", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_saved_searches_user_id", table_name="saved_searches")
+    op.drop_table("saved_searches")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -56,6 +56,7 @@ from app.routers import (
     skills,
     users,
     search,
+    saved_searches,
 )
 
 
@@ -261,3 +262,4 @@ app.include_router(
 )
 app.include_router(health.router)
 app.include_router(search.router, prefix="/api/search", tags=["Search"])
+app.include_router(saved_searches.router)

--- a/backend/app/models/saved_search.py
+++ b/backend/app/models/saved_search.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, JSON, String, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database.base import Base
+
+
+class SavedSearch(Base):
+    """
+    A named set of project search filters saved per user.
+    """
+
+    __tablename__ = "saved_searches"
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "name", name="uq_user_saved_search_name"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    name: Mapped[str] = mapped_column(
+        String(100),
+        nullable=False,
+    )
+
+    filters: Mapped[dict] = mapped_column(
+        JSON,
+        nullable=False,
+        default=dict,
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    user = relationship("User", backref="saved_searches")
+
+    def __repr__(self) -> str:
+        return f"<SavedSearch(name={self.name!r}, user={self.user_id})>"

--- a/backend/app/routers/recommendations.py
+++ b/backend/app/routers/recommendations.py
@@ -195,6 +195,8 @@ def get_recommended_projects(
         limit=limit,
         results=results,
     )
+
+
 @router.post(
     "/tech-stack",
     response_model=TechStackResponse,

--- a/backend/app/routers/saved_searches.py
+++ b/backend/app/routers/saved_searches.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.dependencies import get_database, get_current_user
+from app.models.user import User
+from app.schemas.saved_search import (
+    SavedSearchCreate,
+    SavedSearchResponse,
+    SavedSearchUpdate,
+)
+from app.services.saved_search_service import (
+    SavedSearchService,
+    DuplicateSavedSearchName,
+)
+
+router = APIRouter(
+    prefix="/api/saved-searches",
+    tags=["Saved Searches"],
+)
+
+
+def _get_or_404(db: Session, search_id: uuid.UUID, user_id: uuid.UUID):
+    saved = SavedSearchService.get(db, search_id, user_id)
+    if saved is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Saved search not found."
+        )
+    return saved
+
+
+@router.get("/", response_model=list[SavedSearchResponse])
+def list_saved_searches(
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
+):
+    return SavedSearchService.list(db, current_user.id)
+
+
+@router.post(
+    "/", response_model=SavedSearchResponse, status_code=status.HTTP_201_CREATED
+)
+def create_saved_search(
+    payload: SavedSearchCreate,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
+):
+    if SavedSearchService.name_exists(db, current_user.id, payload.name):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"A saved search named '{payload.name.strip()}' already exists.",
+        )
+    try:
+        return SavedSearchService.create(db, current_user.id, payload)
+    except DuplicateSavedSearchName:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"A saved search named '{payload.name.strip()}' already exists.",
+        )
+
+
+@router.get("/{search_id}", response_model=SavedSearchResponse)
+def get_saved_search(
+    search_id: uuid.UUID,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
+):
+    return _get_or_404(db, search_id, current_user.id)
+
+
+@router.patch("/{search_id}", response_model=SavedSearchResponse)
+def update_saved_search(
+    search_id: uuid.UUID,
+    payload: SavedSearchUpdate,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
+):
+    saved = _get_or_404(db, search_id, current_user.id)
+
+    if payload.name and payload.name.strip() != saved.name:
+        if SavedSearchService.name_exists(db, current_user.id, payload.name):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"A saved search named '{payload.name.strip()}' already exists.",
+            )
+    try:
+        return SavedSearchService.update(db, saved, payload)
+    except DuplicateSavedSearchName:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"A saved search named '{payload.name.strip()}' already exists.",
+        )
+
+
+@router.delete("/{search_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_saved_search(
+    search_id: uuid.UUID,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
+):
+    saved = _get_or_404(db, search_id, current_user.id)
+    SavedSearchService.delete(db, saved)

--- a/backend/app/schemas/saved_search.py
+++ b/backend/app/schemas/saved_search.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ProjectSearchFilters(BaseModel):
+    """Represents the filterable fields on a project search."""
+
+    q: Optional[str] = None
+    stage: Optional[str] = None
+    language: Optional[str] = None
+    experience: Optional[str] = None
+    is_remote: Optional[bool] = None
+    is_paid: Optional[bool] = None
+    is_open_source: Optional[bool] = None
+    tags: Optional[List[str]] = None
+    hiring: Optional[bool] = None
+
+
+class SavedSearchCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=100)
+    filters: ProjectSearchFilters
+
+
+class SavedSearchUpdate(BaseModel):
+    name: Optional[str] = Field(None, min_length=1, max_length=100)
+    filters: Optional[ProjectSearchFilters] = None
+
+
+class SavedSearchResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    user_id: uuid.UUID
+    name: str
+    filters: dict
+    created_at: datetime
+    updated_at: datetime

--- a/backend/app/services/saved_search_service.py
+++ b/backend/app/services/saved_search_service.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.models.saved_search import SavedSearch
+from app.schemas.saved_search import SavedSearchCreate, SavedSearchUpdate
+
+
+class DuplicateSavedSearchName(Exception):
+    pass
+
+
+class SavedSearchService:
+
+    @staticmethod
+    def list(db: Session, user_id: uuid.UUID) -> list[SavedSearch]:
+        return list(
+            db.scalars(
+                select(SavedSearch)
+                .where(SavedSearch.user_id == user_id)
+                .order_by(SavedSearch.created_at.desc())
+            )
+        )
+
+    @staticmethod
+    def get(
+        db: Session, search_id: uuid.UUID, user_id: uuid.UUID
+    ) -> SavedSearch | None:
+        return db.scalar(
+            select(SavedSearch).where(
+                SavedSearch.id == search_id,
+                SavedSearch.user_id == user_id,
+            )
+        )
+
+    @staticmethod
+    def name_exists(db: Session, user_id: uuid.UUID, name: str) -> bool:
+        return (
+            db.scalar(
+                select(SavedSearch).where(
+                    SavedSearch.user_id == user_id,
+                    SavedSearch.name == name.strip(),
+                )
+            )
+            is not None
+        )
+
+    @staticmethod
+    def create(
+        db: Session, user_id: uuid.UUID, payload: SavedSearchCreate
+    ) -> SavedSearch:
+        saved = SavedSearch(
+            user_id=user_id,
+            name=payload.name.strip(),
+            filters=payload.filters.model_dump(exclude_none=True),
+        )
+        db.add(saved)
+        try:
+            db.commit()
+        except IntegrityError:
+            db.rollback()
+            raise DuplicateSavedSearchName(payload.name.strip())
+        db.refresh(saved)
+        return saved
+
+    @staticmethod
+    def update(
+        db: Session,
+        saved: SavedSearch,
+        payload: SavedSearchUpdate,
+    ) -> SavedSearch:
+        if payload.name is not None:
+            saved.name = payload.name.strip()
+        if payload.filters is not None:
+            saved.filters = payload.filters.model_dump(exclude_none=True)
+        try:
+            db.commit()
+        except IntegrityError:
+            db.rollback()
+            raise DuplicateSavedSearchName(
+                payload.name.strip() if payload.name else saved.name
+            )
+        db.refresh(saved)
+        return saved
+
+    @staticmethod
+    def delete(db: Session, saved: SavedSearch) -> None:
+        db.delete(saved)
+        db.commit()

--- a/backend/app/tests/test_saved_searches.py
+++ b/backend/app/tests/test_saved_searches.py
@@ -1,0 +1,287 @@
+"""
+Tests for SavedSearch CRUD — service layer only (SQLite in-memory).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from app.database.base import Base
+from app.models.saved_search import SavedSearch
+from app.models.user import User
+from app.schemas.saved_search import (
+    ProjectSearchFilters,
+    SavedSearchCreate,
+    SavedSearchUpdate,
+)
+from app.services.saved_search_service import (
+    DuplicateSavedSearchName,
+    SavedSearchService,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def engine():
+    eng = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(eng)
+    yield eng
+    Base.metadata.drop_all(eng)
+
+
+@pytest.fixture
+def db(engine):
+    with Session(engine) as session:
+        yield session
+        session.rollback()
+
+
+def _make_user(db: Session) -> User:
+    user = User(
+        first_name="Test",
+        last_name="User",
+        username=f"user_{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        password_hash="hashed",
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+def _create_payload(name: str = "My Search", **filters) -> SavedSearchCreate:
+    return SavedSearchCreate(
+        name=name,
+        filters=ProjectSearchFilters(**filters),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Create
+# ---------------------------------------------------------------------------
+
+
+def test_create_saved_search(db):
+    user = _make_user(db)
+    payload = _create_payload("Backend Python", stage="idea", language="Python")
+
+    saved = SavedSearchService.create(db, user.id, payload)
+
+    assert saved.id is not None
+    assert saved.user_id == user.id
+    assert saved.name == "Backend Python"
+    assert saved.filters["stage"] == "idea"
+    assert saved.filters["language"] == "Python"
+
+
+def test_create_strips_whitespace_from_name(db):
+    user = _make_user(db)
+    payload = _create_payload("  Padded Name  ")
+
+    saved = SavedSearchService.create(db, user.id, payload)
+
+    assert saved.name == "Padded Name"
+
+
+def test_create_stores_only_set_filters(db):
+    user = _make_user(db)
+    payload = _create_payload("Sparse", is_remote=True)
+
+    saved = SavedSearchService.create(db, user.id, payload)
+
+    assert saved.filters == {"is_remote": True}
+    assert "stage" not in saved.filters
+
+
+def test_create_duplicate_name_raises(db):
+    user = _make_user(db)
+    SavedSearchService.create(db, user.id, _create_payload("Dup"))
+
+    with pytest.raises(DuplicateSavedSearchName):
+        SavedSearchService.create(db, user.id, _create_payload("Dup"))
+
+
+def test_create_same_name_different_users_allowed(db):
+    user_a = _make_user(db)
+    user_b = _make_user(db)
+
+    a = SavedSearchService.create(db, user_a.id, _create_payload("Shared Name"))
+    b = SavedSearchService.create(db, user_b.id, _create_payload("Shared Name"))
+
+    assert a.id != b.id
+
+
+# ---------------------------------------------------------------------------
+# List
+# ---------------------------------------------------------------------------
+
+
+def test_list_returns_only_current_users_searches(db):
+    owner = _make_user(db)
+    other = _make_user(db)
+
+    SavedSearchService.create(db, owner.id, _create_payload("Owner Search 1"))
+    SavedSearchService.create(db, owner.id, _create_payload("Owner Search 2"))
+    SavedSearchService.create(db, other.id, _create_payload("Other Search"))
+
+    results = SavedSearchService.list(db, owner.id)
+
+    assert len(results) == 2
+    names = {r.name for r in results}
+    assert "Owner Search 1" in names
+    assert "Owner Search 2" in names
+    assert "Other Search" not in names
+
+
+def test_list_returns_empty_for_new_user(db):
+    user = _make_user(db)
+    assert SavedSearchService.list(db, user.id) == []
+
+
+# ---------------------------------------------------------------------------
+# Get
+# ---------------------------------------------------------------------------
+
+
+def test_get_returns_own_search(db):
+    user = _make_user(db)
+    created = SavedSearchService.create(db, user.id, _create_payload("Get Me"))
+
+    fetched = SavedSearchService.get(db, created.id, user.id)
+
+    assert fetched is not None
+    assert fetched.id == created.id
+
+
+def test_get_returns_none_for_another_users_search(db):
+    owner = _make_user(db)
+    attacker = _make_user(db)
+    created = SavedSearchService.create(db, owner.id, _create_payload("Private"))
+
+    result = SavedSearchService.get(db, created.id, attacker.id)
+
+    assert result is None
+
+
+def test_get_returns_none_for_nonexistent_id(db):
+    user = _make_user(db)
+    result = SavedSearchService.get(db, uuid.uuid4(), user.id)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Update
+# ---------------------------------------------------------------------------
+
+
+def test_update_name(db):
+    user = _make_user(db)
+    saved = SavedSearchService.create(db, user.id, _create_payload("Old Name"))
+
+    updated = SavedSearchService.update(db, saved, SavedSearchUpdate(name="New Name"))
+
+    assert updated.name == "New Name"
+
+
+def test_update_filters(db):
+    user = _make_user(db)
+    saved = SavedSearchService.create(
+        db, user.id, _create_payload("Filter Update", stage="idea")
+    )
+
+    updated = SavedSearchService.update(
+        db,
+        saved,
+        SavedSearchUpdate(filters=ProjectSearchFilters(stage="beta", is_remote=True)),
+    )
+
+    assert updated.filters["stage"] == "beta"
+    assert updated.filters["is_remote"] is True
+
+
+def test_update_name_strips_whitespace(db):
+    user = _make_user(db)
+    saved = SavedSearchService.create(db, user.id, _create_payload("Trim Me"))
+
+    updated = SavedSearchService.update(
+        db, saved, SavedSearchUpdate(name="  Trimmed  ")
+    )
+
+    assert updated.name == "Trimmed"
+
+
+def test_update_to_duplicate_name_raises(db):
+    user = _make_user(db)
+    SavedSearchService.create(db, user.id, _create_payload("Existing"))
+    target = SavedSearchService.create(db, user.id, _create_payload("Target"))
+
+    with pytest.raises(DuplicateSavedSearchName):
+        SavedSearchService.update(db, target, SavedSearchUpdate(name="Existing"))
+
+
+def test_update_to_same_name_is_idempotent(db):
+    user = _make_user(db)
+    saved = SavedSearchService.create(db, user.id, _create_payload("Same"))
+
+    updated = SavedSearchService.update(db, saved, SavedSearchUpdate(name="Same"))
+
+    assert updated.name == "Same"
+
+
+# ---------------------------------------------------------------------------
+# Delete
+# ---------------------------------------------------------------------------
+
+
+def test_delete_removes_search(db):
+    user = _make_user(db)
+    saved = SavedSearchService.create(db, user.id, _create_payload("Delete Me"))
+
+    SavedSearchService.delete(db, saved)
+
+    assert SavedSearchService.get(db, saved.id, user.id) is None
+
+
+def test_delete_does_not_affect_other_searches(db):
+    user = _make_user(db)
+    keep = SavedSearchService.create(db, user.id, _create_payload("Keep"))
+    remove = SavedSearchService.create(db, user.id, _create_payload("Remove"))
+
+    SavedSearchService.delete(db, remove)
+
+    assert SavedSearchService.get(db, keep.id, user.id) is not None
+    assert SavedSearchService.get(db, remove.id, user.id) is None
+
+
+# ---------------------------------------------------------------------------
+# name_exists
+# ---------------------------------------------------------------------------
+
+
+def test_name_exists_true(db):
+    user = _make_user(db)
+    SavedSearchService.create(db, user.id, _create_payload("Exists"))
+    assert SavedSearchService.name_exists(db, user.id, "Exists") is True
+
+
+def test_name_exists_false(db):
+    user = _make_user(db)
+    assert SavedSearchService.name_exists(db, user.id, "Ghost") is False
+
+
+def test_name_exists_strips_whitespace(db):
+    user = _make_user(db)
+    SavedSearchService.create(db, user.id, _create_payload("Spaced"))
+    assert SavedSearchService.name_exists(db, user.id, "  Spaced  ") is True


### PR DESCRIPTION
## Summary

This PR adds support for saving project search filters, allowing users to create and manage reusable named searches.

## Changes

- Add `SavedSearch` model with per-user ownership
- Add CRUD API endpoints for saved searches
- Add request and response schemas
- Implement service layer for create, read, update, and delete operations
- Store project search filters as JSON
- Enforce unique saved search names per user
- Add database migration for the `saved_searches` table
- Register the saved searches router
- Add tests for CRUD operations, ownership checks, and duplicate name validation

## Acceptance Criteria

- ✅ CRUD endpoints
- ✅ Per-user storage
- ✅ Named searches

Closes #261