### PR TITLE
feat: add backup and disaster recovery utility scripts

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -8,3 +8,27 @@ The following response headers can be enabled or disabled through environment se
 - ENABLE_CSP
 - ENABLE_DNS_PREFETCH_CONTROL
 - ENABLE_CROSS_DOMAIN_POLICIES
+
+## Backup & Restore
+
+### Create a database backup
+
+```bash
+python scripts/backup_database.py
+```
+
+### Restore a database backup
+
+```bash
+python scripts/restore_database.py backups/<backup_file>.sql
+```
+
+### Backup uploaded files
+
+```bash
+python scripts/backup_storage.py
+```
+
+Database backups are stored in the `backups/` directory.
+
+> Before restoring a backup, ensure the application is stopped and the target database is accessible.

--- a/backend/scripts/backup_database.py
+++ b/backend/scripts/backup_database.py
@@ -1,0 +1,49 @@
+import os
+import subprocess
+from datetime import datetime
+from pathlib import Path
+from urllib.parse import urlparse
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DATABASE_URL = os.getenv("DATABASE_URL")
+
+if not DATABASE_URL:
+    raise RuntimeError("DATABASE_URL is not configured.")
+
+ROOT = Path(__file__).resolve().parents[1]
+
+backup_dir = ROOT / "backups"
+backup_dir.mkdir(exist_ok=True)
+
+timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+backup_file = backup_dir / f"devlink_backup_{timestamp}.sql"
+
+parsed = urlparse(DATABASE_URL)
+
+db_name = parsed.path.lstrip("/")
+db_user = parsed.username
+db_password = parsed.password
+db_host = parsed.hostname
+db_port = parsed.port or 5432
+
+env = os.environ.copy()
+env["PGPASSWORD"] = db_password or ""
+
+command = [
+    "pg_dump",
+    "-h", db_host,
+    "-p", str(db_port),
+    "-U", db_user,
+    "-F", "p",
+    "-f", str(backup_file),
+    db_name,
+]
+
+print("Creating database backup...")
+
+subprocess.run(command, env=env, check=True)
+
+print(f"Backup created: {backup_file}")

--- a/backend/scripts/backup_storage.py
+++ b/backend/scripts/backup_storage.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+from zipfile import ZipFile, ZIP_DEFLATED
+from datetime import datetime
+
+ROOT = Path(__file__).resolve().parents[1]
+
+backup_dir = ROOT / "backups"
+backup_dir.mkdir(exist_ok=True)
+
+timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+archive = backup_dir / f"storage_backup_{timestamp}.zip"
+
+storage_dirs = [
+    ROOT / "uploads",
+]
+
+found = False
+
+with ZipFile(archive, "w", ZIP_DEFLATED) as zipf:
+    for directory in storage_dirs:
+        if directory.exists():
+            found = True
+
+            for file in directory.rglob("*"):
+                if file.is_file():
+                    zipf.write(file, file.relative_to(ROOT))
+
+if found:
+    print(f"Storage backup created: {archive}")
+else:
+    print("No storage directories found to back up.")

--- a/backend/scripts/restore_database.py
+++ b/backend/scripts/restore_database.py
@@ -1,0 +1,50 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DATABASE_URL = os.getenv("DATABASE_URL")
+
+if not DATABASE_URL:
+    raise RuntimeError("DATABASE_URL is not configured.")
+
+if len(sys.argv) != 2:
+    print("Usage:")
+    print("python scripts/restore_database.py backups/backup.sql")
+    sys.exit(1)
+
+backup_file = Path(sys.argv[1])
+
+if not backup_file.exists():
+    raise FileNotFoundError(f"{backup_file} does not exist.")
+
+parsed = urlparse(DATABASE_URL)
+
+db_name = parsed.path.lstrip("/")
+db_user = parsed.username
+db_password = parsed.password
+db_host = parsed.hostname
+db_port = parsed.port or 5432
+
+env = os.environ.copy()
+env["PGPASSWORD"] = db_password or ""
+
+command = [
+    "psql",
+    "-h", db_host,
+    "-p", str(db_port),
+    "-U", db_user,
+    "-d", db_name,
+    "-f", str(backup_file),
+]
+
+print(f"Restoring database from {backup_file}...")
+
+subprocess.run(command, env=env, check=True)
+
+print("Database restored successfully.")


### PR DESCRIPTION
# Pull Request

## Summary

This PR introduces utility scripts to support backup and disaster recovery for the DevLink backend. It provides simple tools for creating PostgreSQL database backups, restoring database dumps, backing up uploaded storage, and documents the workflow in the backend README.

---

## Related Issue

Closes #549 

---

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [ ] UI/UX enhancement
- [ ] Tests
- [x] Other (DevOps / Backup utilities)

---

## Changes Made

- Added `backup_database.py` for PostgreSQL database backups.
- Added `restore_database.py` for restoring database backups.
- Added `backup_storage.py` to archive uploaded files.
- Added `backend/backups/.gitkeep` to track the backup directory.
- Updated `backend/README.md` with backup and restore instructions.

---

## Screenshots

N/A (backend utility scripts)

---

## Testing

- [x] Tested locally
- [ ] Existing tests pass
- [ ] Added new tests
- [ ] UI verified
- [ ] Cross-browser tested

Additional testing notes:

- Verified the backup scripts are created successfully.
- Verified the restore command format.
- Confirmed backup files are generated inside the `backups/` directory.

---

## Checklist

- [x] My code follows the project's coding standards.
- [x] I have tested my changes locally.
- [x] I have updated the documentation where necessary.
- [x] My changes do not introduce new warnings or errors.
- [x] I have reviewed my own code.
- [x] This pull request focuses on a single feature.
- [x] I have linked the related issue.

---

## Additional Notes

These scripts are intended as lightweight utilities for local development and deployment environments. They use PostgreSQL command-line tools (`pg_dump` and `psql`) and are designed to complement the existing Docker-based backend setup.