### PR TITLE
refactor(backend): move user report and resume-url logic from router to UserService

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -33,9 +33,7 @@ from app.schemas.user_report import (
     UserReportCreate,
     UserReportResponse,
 )
-from app.models.user_report import UserReport
-from app.core.security import hash_password
-from app.services.user_service import UserService
+from app.core.security import hash_passwordfrom app.services.user_service import UserService
 from app.core.cache import cached
 from app.utils.validators import validate_username
 
@@ -228,13 +226,10 @@ async def upload_resume(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    resume_url = save_resume_upload(contents, file.filename, current_user.id)
-    current_user.resume_url = str(request.base_url).rstrip("/") + resume_url
-    db.commit()
-    db.refresh(current_user)
+resume_url = save_resume_upload(contents, file.filename, current_user.id)
+    full_resume_url = str(request.base_url).rstrip("/") + resume_url
 
-    return current_user
-
+    return UserService.update_resume_url(db, current_user, full_resume_url)
 
 @router.delete(
     "/me",
@@ -401,18 +396,7 @@ def report_user(
     target_user = UserService.get_user(db, user_id)
     if target_user is None:
         raise HTTPException(status_code=404, detail="User not found")
-    if current_user.id == target_user.id:
+if current_user.id == target_user.id:
         raise HTTPException(status_code=400, detail="You cannot report yourself")
-    db_report = UserReport(
-        reporter_id=current_user.id,
-        reported_id=target_user.id,
-        reason=report.reason,
-        description=report.description,
-        status="pending",
-    )
 
-    db.add(db_report)
-    db.commit()
-    db.refresh(db_report)
-
-    return db_report
+    return UserService.create_user_report(db, current_user.id, target_user.id, report)

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -14,7 +14,8 @@ from app.models.follower import Follower
 from app.models.project import Project
 from app.core.cache import cached
 from app.schemas.user import UserStats
-
+from app.models.user_report import UserReport
+from app.schemas.user_report import UserReportCreate
 
 class UserService:
     """
@@ -284,9 +285,43 @@ class UserService:
         db_user: User,
     ) -> User:
 
-        db_user.is_verified = True
+db_user.is_verified = True
 
         db.flush()
         db.refresh(db_user)
 
         return db_user
+
+    @staticmethod
+    def update_resume_url(
+        db: Session,
+        user: User,
+        resume_url: str,
+    ) -> User:
+        user.resume_url = resume_url
+
+        db.commit()
+        db.refresh(user)
+
+        return user
+
+    @staticmethod
+    def create_user_report(
+        db: Session,
+        reporter_id: uuid.UUID,
+        reported_id: uuid.UUID,
+        report: UserReportCreate,
+    ) -> UserReport:
+        db_report = UserReport(
+            reporter_id=reporter_id,
+            reported_id=reported_id,
+            reason=report.reason,
+            description=report.description,
+            status="pending",
+        )
+
+        db.add(db_report)
+        db.commit()
+        db.refresh(db_report)
+
+        return db_report


### PR DESCRIPTION
## What this PR does
Part of the Repository-Service Pattern refactor (#525).

Two endpoints in `app/routers/users.py` were writing directly to the
database instead of going through the service layer:

1. `POST /me/resume` — updated `current_user.resume_url` and called
   `db.commit()` / `db.refresh()` straight from the router.
2. `POST /{user_id}/report` — built a `UserReport` model instance and
   called `db.add()` / `db.commit()` / `db.refresh()` straight from the router.

Both are now handled by two new methods on `UserService`
(`update_resume_url` and `create_user_report`), so the router's only
job is to validate the request and call the service. This follows the
Router → Service → Database flow described in the issue.

## Files changed
- `backend/app/services/user_service.py` — added `update_resume_url` and `create_user_report`
- `backend/app/routers/users.py` — replaced inline DB logic with calls to the new service methods, removed the now-unused `UserReport` model import

## Notes
This PR only covers `users.py`, which had two clean, self-contained
cases. I noticed a few unrelated pre-existing issues in other files
(a broken function in `projects.py`, a duplicate router definition in
`issues.py`, and a `get_db` vs `get_database` typo elsewhere in
`users.py`) — I've left those alone since they're separate bugs, not
part of this refactor, and would be safer to fix in their own PRs.

Closes #525 

@nensii21 
I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.