### PR TITLE
docs: add CHANGELOG.md following Keep a Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Added initial `CHANGELOG.md` following the Keep a Changelog specification.
+
+### Changed
+- None.
+
+### Deprecated
+- None.
+
+### Removed
+- None.
+
+### Fixed
+- None.
+
+### Security
+- None.


### PR DESCRIPTION
## Summary
This PR adds a `CHANGELOG.md` file following the Keep a Changelog specification.

## Changes Made
- Added a new `CHANGELOG.md` file
- Included an `Unreleased` section for upcoming changes
- Organized entries using the standard categories:
  - Added
  - Changed
  - Deprecated
  - Removed
  - Fixed
  - Security

closes #475 