### PR TITLE
feat(auth): implement refresh token rotation, revocation, and blacklisting

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -35,8 +35,8 @@ from app.schemas.auth import (
     RegisterRequest,
     GitHubLoginRequest,
     RefreshTokenRequest,
-    LogoutResponse,
-    CurrentUserResponse,
+    LogoutRequest,
+    LogoutResponse,    CurrentUserResponse,
     ChangePasswordRequest,
     ForgotPasswordResponse,
     ResetPasswordRequest,
@@ -277,10 +277,9 @@ def refresh(
             detail="Invalid refresh token.",
         )
 
-    auth_service = AuthService(db)
+auth_service = AuthService(db)
 
-    return auth_service.refresh_token(token_payload["sub"])
-
+    return auth_service.refresh_token(payload.refresh_token)
 
 # ==========================================================
 # Logout
@@ -295,14 +294,36 @@ def refresh(
 @limiter.limit("10/minute")
 def logout(
     request: Request,
+    payload: LogoutRequest,
     user_id: str = Depends(get_current_user_id),
     db: Session = Depends(get_database),
 ):
 
     auth_service = AuthService(db)
 
-    return auth_service.logout(user_id)
+    return auth_service.logout(user_id, payload.refresh_token)
 
+
+# ==========================================================
+# Logout From All Devices (bonus)
+# ==========================================================
+
+
+@router.post(
+    "/logout-all",
+    response_model=LogoutResponse,
+    summary="Logout from all devices",
+)
+@limiter.limit("10/minute")
+def logout_all(
+    request: Request,
+    user_id: str = Depends(get_current_user_id),
+    db: Session = Depends(get_database),
+):
+
+    auth_service = AuthService(db)
+
+    return auth_service.logout_all_devices(user_id)
 
 from app.schemas.auth import (  # noqa: E402
     ChangePasswordRequest,

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -109,8 +109,11 @@ class RefreshTokenRequest(BaseModel):
 # ==========================================================
 
 
-class LogoutResponse(BaseModel):
-    success: bool = True
+class LogoutRequest(BaseModel):
+    refresh_token: str | None = None
+
+
+class LogoutResponse(BaseModel):    success: bool = True
     message: str = "Successfully logged out."
 
 

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -27,7 +27,8 @@ from app.core.security import (
 )
 from app.models.user import User
 from app.models.password_history import PasswordHistory
-from app.schemas.auth import (
+from app.models.refresh_token import RefreshToken
+from app.services.refresh_token_service import RefreshTokenServicefrom app.schemas.auth import (
     LoginRequest,
     RegisterRequest,
 )
@@ -207,7 +208,17 @@ class AuthService:
             },
         )
 
-        refresh_token = create_refresh_token(str(user.id))
+refresh_token = create_refresh_token(str(user.id))
+
+        RefreshTokenService.create_token(
+            self.db,
+            RefreshToken(
+                user_id=user.id,
+                token=refresh_token,
+                expires_at=datetime.now(timezone.utc)
+                + timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS),
+            ),
+        )
 
         event_bus.publish(
             "USER_LOGIN",
@@ -216,8 +227,7 @@ class AuthService:
         )
         return {
             "success": True,
-            "message": "Login successful.",
-            "access_token": access_token,
+            "message": "Login successful.",            "access_token": access_token,
             "refresh_token": refresh_token,
             "token_type": "bearer",
             "user": user,
@@ -397,7 +407,17 @@ class AuthService:
                 "email": user.email,
             },
         )
-        refresh_token = create_refresh_token(str(user.id))
+refresh_token = create_refresh_token(str(user.id))
+
+        RefreshTokenService.create_token(
+            self.db,
+            RefreshToken(
+                user_id=user.id,
+                token=refresh_token,
+                expires_at=datetime.now(timezone.utc)
+                + timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS),
+            ),
+        )
 
         event_bus.publish(
             "USER_LOGIN",
@@ -407,8 +427,7 @@ class AuthService:
 
         return {
             "success": True,
-            "message": "GitHub login successful.",
-            "access_token": access_token,
+            "message": "GitHub login successful.",            "access_token": access_token,
             "refresh_token": refresh_token,
             "token_type": "bearer",
             "user": user,
@@ -462,10 +481,30 @@ class AuthService:
     # Refresh Token
     # =====================================================
 
-    def refresh_token(self, user_id: str):
+def refresh_token(self, old_refresh_token: str):
 
-        user = self.get_current_user(user_id)
+        # 1. Look up the token in the database (this is our "blacklist" check —
+        #    if it's not there, or it's revoked, it's not usable anymore).
+        db_token = RefreshTokenService.get_token(self.db, old_refresh_token)
 
+        if not db_token or db_token.is_revoked:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Refresh token has been revoked or is invalid.",
+            )
+
+        if db_token.expires_at < datetime.now(timezone.utc):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Refresh token has expired.",
+            )
+
+        user = self.get_current_user(str(db_token.user_id))
+
+        # 2. Rotation: kill the old refresh token so it can never be used again.
+        RefreshTokenService.revoke_token(self.db, db_token)
+
+        # 3. Issue a brand new pair of tokens.
         access_token = create_access_token(
             str(user.id),
             {
@@ -474,7 +513,17 @@ class AuthService:
             },
         )
 
-        refresh_token = create_refresh_token(str(user.id))
+        new_refresh_token = create_refresh_token(str(user.id))
+
+        RefreshTokenService.create_token(
+            self.db,
+            RefreshToken(
+                user_id=user.id,
+                token=new_refresh_token,
+                expires_at=datetime.now(timezone.utc)
+                + timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS),
+            ),
+        )
 
         event_bus.publish(
             "ACCESS_TOKEN_REFRESHED",
@@ -485,11 +534,10 @@ class AuthService:
             "success": True,
             "message": "Token refreshed successfully.",
             "access_token": access_token,
-            "refresh_token": refresh_token,
+            "refresh_token": new_refresh_token,
             "token_type": "bearer",
             "user": user,
         }
-
     # =====================================================
     # Change Password
     # =====================================================
@@ -568,9 +616,15 @@ class AuthService:
     # Logout
     # =====================================================
 
-    def logout(self, user_id: str):
+def logout(self, user_id: str, refresh_token: str | None = None):
 
         user = self.get_current_user(user_id)
+
+        if refresh_token:
+            db_token = RefreshTokenService.get_token(self.db, refresh_token)
+            if db_token and db_token.user_id == user.id:
+                RefreshTokenService.revoke_token(self.db, db_token)
+
         event_bus.publish(
             "USER_LOGOUT",
             email=user.email,
@@ -581,6 +635,26 @@ class AuthService:
             "message": "Logged out successfully.",
         }
 
+    def logout_all_devices(self, user_id: str):
+        """
+        Revoke every refresh token belonging to this user
+        (logs the user out everywhere).
+        """
+
+        user = self.get_current_user(user_id)
+
+        RefreshTokenService.revoke_all_tokens(self.db, user.id)
+
+        event_bus.publish(
+            "USER_LOGOUT",
+            email=user.email,
+            user_id=str(user.id),
+        )
+
+        return {
+            "success": True,
+            "message": "Logged out from all devices.",
+        }
     # =====================================================
     # Forgot Password
     # =====================================================

--- a/frontend/src/api/modules/auth.ts
+++ b/frontend/src/api/modules/auth.ts
@@ -29,14 +29,13 @@ export const authApi = {
     tokenStore.set(res.access_token, res.refresh_token);
     return res;
   },
-  async logout() {
+async logout() {
     try {
-      await api.post<void>("/api/auth/logout");
+      await api.post<void>("/api/auth/logout", { refresh_token: tokenStore.getRefresh() });
     } finally {
       tokenStore.clear();
     }
-  },
-  me: () => api.get<AuthUser>("/api/auth/me"),
+  },  me: () => api.get<AuthUser>("/api/auth/me"),
   forgotPassword: (email: string) =>
     api.post<{ ok: true }>("/api/auth/forgot-password", { email }, { auth: false }),
   resetPassword: (token: string, password: string) =>


### PR DESCRIPTION
## What this PR does

Closes #526.

The app already had a `RefreshToken` database model and a `RefreshTokenService`,
but they were never actually connected to the auth flow — `/refresh` just
trusted any signed JWT forever, with no way to invalidate a token. This PR
wires everything together:

- **Rotation**: every successful call to `POST /api/auth/refresh` revokes the
  refresh token that was used and issues a brand new access + refresh token
  pair. The old refresh token can never be reused after that.
- **Revocation**:
  - `POST /api/auth/logout` now accepts the current refresh token in the
    request body and marks it revoked in the database.
  - `POST /api/auth/logout-all` (new endpoint) revokes *every* refresh token
    for the current user, logging them out of all devices.
- **Blacklisting**: `/refresh` now looks the incoming token up in the
  `refresh_tokens` table before trusting it. If it isn't found, or it's
  already been revoked, or it has expired, the request is rejected with a
  401. This is effectively our blacklist — once a token is revoked/rotated,
  it's dead.
- Refresh tokens issued on login and GitHub OAuth login are now persisted to
  the database (previously they were only ever encoded as JWTs and never
  stored anywhere).
- Updated the frontend `logout()` call to send the refresh token so the
  backend knows exactly which session to revoke.

No new database migration was needed since the `refresh_tokens` table
migration already existed in the codebase.

## How to test
1. Log in → confirm a row appears in the `refresh_tokens` table.
2. Call `/api/auth/refresh` with the refresh token → confirm you get a new
   refresh token back, and the old row is now `is_revoked = true`.
3. Try reusing the old (already-rotated) refresh token → should get a 401.
4. Log out → confirm that token's row becomes `is_revoked = true` and it can
   no longer be used to refresh.
5. (If added) Call `/api/auth/logout-all` after logging in from two
   "sessions" → confirm both tokens are revoked.


Closes #526 

@nensii21 
I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.