### PR TITLE
feat: integrated hackathon platform — team formation, registration, submissions, judging & leaderboard

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -3,9 +3,11 @@ from logging.config import fileConfig
 from alembic import context
 from app.core.config import settings
 from app.database.base import Base
-from sqlalchemy import engine_from_config, pool
 
-# Import every model here
+# Import all models so Alembic can see them in Base.metadata
+import app.models  # noqa: F401
+
+from sqlalchemy import engine_from_config, pool
 
 config = context.config
 

--- a/backend/alembic/versions/b2e4f6a8c0d1_add_issues_tables.py
+++ b/backend/alembic/versions/b2e4f6a8c0d1_add_issues_tables.py
@@ -1,0 +1,104 @@
+"""Add issues and duplicate_suggestions tables
+
+Revision ID: b2e4f6a8c0d1
+Revises: 1a2b3c4d5e6f
+Create Date: 2026-07-22
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+# revision identifiers
+revision = "b2e4f6a8c0d1"
+down_revision = "1a2b3c4d5e6f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Create issues table
+    op.create_table(
+        "issues",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "project_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("projects.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "author_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("title", sa.String(500), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum("open", "in_progress", "closed", "duplicate", name="issuestatus"),
+            nullable=False,
+            server_default="open",
+            index=True,
+        ),
+        sa.Column(
+            "priority",
+            sa.Enum("low", "medium", "high", "critical", name="issuepriority"),
+            nullable=False,
+            server_default="medium",
+        ),
+        sa.Column("labels", sa.String(500), nullable=True),
+        sa.Column("embedding", sa.Text(), nullable=True),
+        sa.Column(
+            "is_duplicate_checked", sa.Boolean(), nullable=False, server_default="false"
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            index=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+        ),
+    )
+
+    # Create duplicate_suggestions table
+    op.create_table(
+        "duplicate_suggestions",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "source_issue_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("issues.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "duplicate_issue_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("issues.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("similarity_score", sa.Float(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("duplicate_suggestions")
+    op.drop_table("issues")
+    op.execute("DROP TYPE IF EXISTS issuestatus")
+    op.execute("DROP TYPE IF EXISTS issuepriority")

--- a/backend/alembic/versions/b7f6e5d4c3a2_create_hackathon_tables.py
+++ b/backend/alembic/versions/b7f6e5d4c3a2_create_hackathon_tables.py
@@ -40,7 +40,15 @@ def upgrade() -> None:
         sa.Column("website_url", sa.String(length=500), nullable=True),
         sa.Column(
             "status",
-            sa.Enum("draft", "registration_open", "in_progress", "judging", "completed", "cancelled", name="hackathonstatus"),
+            sa.Enum(
+                "draft",
+                "registration_open",
+                "in_progress",
+                "judging",
+                "completed",
+                "cancelled",
+                name="hackathonstatus",
+            ),
             server_default="draft",
             nullable=False,
         ),
@@ -60,9 +68,15 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(["created_by"], ["users.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
     )
-    op.create_index(op.f("ix_hackathons_created_by"), "hackathons", ["created_by"], unique=False)
-    op.create_index(op.f("ix_hackathons_status"), "hackathons", ["status"], unique=False)
-    op.create_index(op.f("ix_hackathons_created_at"), "hackathons", ["created_at"], unique=False)
+    op.create_index(
+        op.f("ix_hackathons_created_by"), "hackathons", ["created_by"], unique=False
+    )
+    op.create_index(
+        op.f("ix_hackathons_status"), "hackathons", ["status"], unique=False
+    )
+    op.create_index(
+        op.f("ix_hackathons_created_at"), "hackathons", ["created_at"], unique=False
+    )
 
     # hackathon_teams
     op.create_table(
@@ -85,12 +99,24 @@ def upgrade() -> None:
             server_default=sa.text("now()"),
             nullable=False,
         ),
-        sa.ForeignKeyConstraint(["hackathon_id"], ["hackathons.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["hackathon_id"], ["hackathons.id"], ondelete="CASCADE"
+        ),
         sa.ForeignKeyConstraint(["created_by"], ["users.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
     )
-    op.create_index(op.f("ix_hackathon_teams_hackathon_id"), "hackathon_teams", ["hackathon_id"], unique=False)
-    op.create_index(op.f("ix_hackathon_teams_created_by"), "hackathon_teams", ["created_by"], unique=False)
+    op.create_index(
+        op.f("ix_hackathon_teams_hackathon_id"),
+        "hackathon_teams",
+        ["hackathon_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_hackathon_teams_created_by"),
+        "hackathon_teams",
+        ["created_by"],
+        unique=False,
+    )
 
     # hackathon_team_members
     op.create_table(
@@ -117,13 +143,25 @@ def upgrade() -> None:
             server_default=sa.text("now()"),
             nullable=False,
         ),
-        sa.ForeignKeyConstraint(["team_id"], ["hackathon_teams.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["team_id"], ["hackathon_teams.id"], ondelete="CASCADE"
+        ),
         sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("team_id", "user_id", name="uq_hackathon_team_member"),
     )
-    op.create_index(op.f("ix_hackathon_team_members_team_id"), "hackathon_team_members", ["team_id"], unique=False)
-    op.create_index(op.f("ix_hackathon_team_members_user_id"), "hackathon_team_members", ["user_id"], unique=False)
+    op.create_index(
+        op.f("ix_hackathon_team_members_team_id"),
+        "hackathon_team_members",
+        ["team_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_hackathon_team_members_user_id"),
+        "hackathon_team_members",
+        ["user_id"],
+        unique=False,
+    )
 
     # hackathon_registrations
     op.create_table(
@@ -134,7 +172,13 @@ def upgrade() -> None:
         sa.Column("team_id", sa.UUID(), nullable=True),
         sa.Column(
             "status",
-            sa.Enum("pending", "confirmed", "cancelled", "waitlisted", name="registrationstatus"),
+            sa.Enum(
+                "pending",
+                "confirmed",
+                "cancelled",
+                "waitlisted",
+                name="registrationstatus",
+            ),
             server_default="pending",
             nullable=False,
         ),
@@ -152,16 +196,42 @@ def upgrade() -> None:
             server_default=sa.text("now()"),
             nullable=False,
         ),
-        sa.ForeignKeyConstraint(["hackathon_id"], ["hackathons.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["hackathon_id"], ["hackathons.id"], ondelete="CASCADE"
+        ),
         sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(["team_id"], ["hackathon_teams.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(
+            ["team_id"], ["hackathon_teams.id"], ondelete="SET NULL"
+        ),
         sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("hackathon_id", "user_id", name="uq_hackathon_registration"),
+        sa.UniqueConstraint(
+            "hackathon_id", "user_id", name="uq_hackathon_registration"
+        ),
     )
-    op.create_index(op.f("ix_hackathon_registrations_hackathon_id"), "hackathon_registrations", ["hackathon_id"], unique=False)
-    op.create_index(op.f("ix_hackathon_registrations_user_id"), "hackathon_registrations", ["user_id"], unique=False)
-    op.create_index(op.f("ix_hackathon_registrations_status"), "hackathon_registrations", ["status"], unique=False)
-    op.create_index(op.f("ix_hackathon_registrations_created_at"), "hackathon_registrations", ["created_at"], unique=False)
+    op.create_index(
+        op.f("ix_hackathon_registrations_hackathon_id"),
+        "hackathon_registrations",
+        ["hackathon_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_hackathon_registrations_user_id"),
+        "hackathon_registrations",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_hackathon_registrations_status"),
+        "hackathon_registrations",
+        ["status"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_hackathon_registrations_created_at"),
+        "hackathon_registrations",
+        ["created_at"],
+        unique=False,
+    )
 
     # hackathon_submissions
     op.create_table(
@@ -176,7 +246,14 @@ def upgrade() -> None:
         sa.Column("demo_url", sa.String(length=500), nullable=True),
         sa.Column(
             "status",
-            sa.Enum("draft", "submitted", "in_review", "accepted", "rejected", name="submissionstatus"),
+            sa.Enum(
+                "draft",
+                "submitted",
+                "in_review",
+                "accepted",
+                "rejected",
+                name="submissionstatus",
+            ),
             server_default="draft",
             nullable=False,
         ),
@@ -192,14 +269,33 @@ def upgrade() -> None:
             server_default=sa.text("now()"),
             nullable=False,
         ),
-        sa.ForeignKeyConstraint(["hackathon_id"], ["hackathons.id"], ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(["team_id"], ["hackathon_teams.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["hackathon_id"], ["hackathons.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["team_id"], ["hackathon_teams.id"], ondelete="CASCADE"
+        ),
         sa.ForeignKeyConstraint(["submitted_by"], ["users.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
     )
-    op.create_index(op.f("ix_hackathon_submissions_hackathon_id"), "hackathon_submissions", ["hackathon_id"], unique=False)
-    op.create_index(op.f("ix_hackathon_submissions_team_id"), "hackathon_submissions", ["team_id"], unique=False)
-    op.create_index(op.f("ix_hackathon_submissions_status"), "hackathon_submissions", ["status"], unique=False)
+    op.create_index(
+        op.f("ix_hackathon_submissions_hackathon_id"),
+        "hackathon_submissions",
+        ["hackathon_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_hackathon_submissions_team_id"),
+        "hackathon_submissions",
+        ["team_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_hackathon_submissions_status"),
+        "hackathon_submissions",
+        ["status"],
+        unique=False,
+    )
 
     # hackathon_judges
     op.create_table(
@@ -213,13 +309,25 @@ def upgrade() -> None:
             server_default=sa.text("now()"),
             nullable=False,
         ),
-        sa.ForeignKeyConstraint(["hackathon_id"], ["hackathons.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["hackathon_id"], ["hackathons.id"], ondelete="CASCADE"
+        ),
         sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("hackathon_id", "user_id", name="uq_hackathon_judge"),
     )
-    op.create_index(op.f("ix_hackathon_judges_hackathon_id"), "hackathon_judges", ["hackathon_id"], unique=False)
-    op.create_index(op.f("ix_hackathon_judges_user_id"), "hackathon_judges", ["user_id"], unique=False)
+    op.create_index(
+        op.f("ix_hackathon_judges_hackathon_id"),
+        "hackathon_judges",
+        ["hackathon_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_hackathon_judges_user_id"),
+        "hackathon_judges",
+        ["user_id"],
+        unique=False,
+    )
 
     # hackathon_scores
     op.create_table(
@@ -241,13 +349,27 @@ def upgrade() -> None:
             server_default=sa.text("now()"),
             nullable=False,
         ),
-        sa.ForeignKeyConstraint(["submission_id"], ["hackathon_submissions.id"], ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(["judge_id"], ["hackathon_judges.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["submission_id"], ["hackathon_submissions.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["judge_id"], ["hackathon_judges.id"], ondelete="CASCADE"
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("submission_id", "judge_id", name="uq_hackathon_score"),
     )
-    op.create_index(op.f("ix_hackathon_scores_submission_id"), "hackathon_scores", ["submission_id"], unique=False)
-    op.create_index(op.f("ix_hackathon_scores_judge_id"), "hackathon_scores", ["judge_id"], unique=False)
+    op.create_index(
+        op.f("ix_hackathon_scores_submission_id"),
+        "hackathon_scores",
+        ["submission_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_hackathon_scores_judge_id"),
+        "hackathon_scores",
+        ["judge_id"],
+        unique=False,
+    )
 
     # ### end Alembic commands ###
 
@@ -257,28 +379,53 @@ def downgrade() -> None:
     # ### commands auto generated by Alembic - please adjust! ###
 
     op.drop_index(op.f("ix_hackathon_scores_judge_id"), table_name="hackathon_scores")
-    op.drop_index(op.f("ix_hackathon_scores_submission_id"), table_name="hackathon_scores")
+    op.drop_index(
+        op.f("ix_hackathon_scores_submission_id"), table_name="hackathon_scores"
+    )
     op.drop_table("hackathon_scores")
     op.execute("DROP TYPE IF EXISTS submissionstatus")
 
     op.drop_index(op.f("ix_hackathon_judges_user_id"), table_name="hackathon_judges")
-    op.drop_index(op.f("ix_hackathon_judges_hackathon_id"), table_name="hackathon_judges")
+    op.drop_index(
+        op.f("ix_hackathon_judges_hackathon_id"), table_name="hackathon_judges"
+    )
     op.drop_table("hackathon_judges")
 
-    op.drop_index(op.f("ix_hackathon_submissions_status"), table_name="hackathon_submissions")
-    op.drop_index(op.f("ix_hackathon_submissions_team_id"), table_name="hackathon_submissions")
-    op.drop_index(op.f("ix_hackathon_submissions_hackathon_id"), table_name="hackathon_submissions")
+    op.drop_index(
+        op.f("ix_hackathon_submissions_status"), table_name="hackathon_submissions"
+    )
+    op.drop_index(
+        op.f("ix_hackathon_submissions_team_id"), table_name="hackathon_submissions"
+    )
+    op.drop_index(
+        op.f("ix_hackathon_submissions_hackathon_id"),
+        table_name="hackathon_submissions",
+    )
     op.drop_table("hackathon_submissions")
 
-    op.drop_index(op.f("ix_hackathon_registrations_created_at"), table_name="hackathon_registrations")
-    op.drop_index(op.f("ix_hackathon_registrations_status"), table_name="hackathon_registrations")
-    op.drop_index(op.f("ix_hackathon_registrations_user_id"), table_name="hackathon_registrations")
-    op.drop_index(op.f("ix_hackathon_registrations_hackathon_id"), table_name="hackathon_registrations")
+    op.drop_index(
+        op.f("ix_hackathon_registrations_created_at"),
+        table_name="hackathon_registrations",
+    )
+    op.drop_index(
+        op.f("ix_hackathon_registrations_status"), table_name="hackathon_registrations"
+    )
+    op.drop_index(
+        op.f("ix_hackathon_registrations_user_id"), table_name="hackathon_registrations"
+    )
+    op.drop_index(
+        op.f("ix_hackathon_registrations_hackathon_id"),
+        table_name="hackathon_registrations",
+    )
     op.drop_table("hackathon_registrations")
     op.execute("DROP TYPE IF EXISTS registrationstatus")
 
-    op.drop_index(op.f("ix_hackathon_team_members_user_id"), table_name="hackathon_team_members")
-    op.drop_index(op.f("ix_hackathon_team_members_team_id"), table_name="hackathon_team_members")
+    op.drop_index(
+        op.f("ix_hackathon_team_members_user_id"), table_name="hackathon_team_members"
+    )
+    op.drop_index(
+        op.f("ix_hackathon_team_members_team_id"), table_name="hackathon_team_members"
+    )
     op.drop_table("hackathon_team_members")
     op.execute("DROP TYPE IF EXISTS teammemberrole")
 

--- a/backend/alembic/versions/ffff00000001_merge_all_heads.py
+++ b/backend/alembic/versions/ffff00000001_merge_all_heads.py
@@ -1,0 +1,32 @@
+"""Merge all branch heads into a single head
+
+Revision ID: ffff00000001
+Revises: 4b4c96034900, 523764cd8096, a1b2c3d4e5f6, a2c5d3f7e1b4, b2e4f6a8c0d1, b7f6e5d4c3a2, c5d6e7f8a9b0, d87970cbb1e6, f1b4a3a6b5c7
+Create Date: 2026-07-28
+
+"""
+
+from typing import Sequence, Union
+
+revision: str = "ffff00000001"
+down_revision: Union[str, Sequence[str], None] = (
+    "4b4c96034900",
+    "523764cd8096",
+    "a1b2c3d4e5f6",
+    "a2c5d3f7e1b4",
+    "b2e4f6a8c0d1",
+    "b7f6e5d4c3a2",
+    "c5d6e7f8a9b0",
+    "d87970cbb1e6",
+    "f1b4a3a6b5c7",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/backend/app/database/base.py
+++ b/backend/app/database/base.py
@@ -8,6 +8,3 @@ class Base(DeclarativeBase):
     """
 
     pass
-
-
-# Import all models so SQLAlchemy registers them

--- a/backend/app/models/hackathon.py
+++ b/backend/app/models/hackathon.py
@@ -173,8 +173,5 @@ class Hackathon(Base):
 
     def __repr__(self) -> str:
         return (
-            f"<Hackathon("
-            f"name='{self.name}', "
-            f"status='{self.status.value}'"
-            f")>"
+            f"<Hackathon(" f"name='{self.name}', " f"status='{self.status.value}'" f")>"
         )

--- a/backend/app/routers/hackathons.py
+++ b/backend/app/routers/hackathons.py
@@ -282,7 +282,9 @@ def cancel_registration(
     db: Session = Depends(get_database),
     current_user: User = Depends(get_current_user),
 ):
-    db_registration = HackathonService.get_registration(db, hackathon_id, current_user.id)
+    db_registration = HackathonService.get_registration(
+        db, hackathon_id, current_user.id
+    )
 
     if db_registration is None:
         raise HTTPException(

--- a/backend/app/schemas/hackathon.py
+++ b/backend/app/schemas/hackathon.py
@@ -12,7 +12,6 @@ from app.models.hackathon_registration import RegistrationStatus
 from app.models.hackathon_submission import SubmissionStatus
 from app.models.hackathon_team import TeamMemberRole
 
-
 # ==============================================================
 # Hackathon
 # ==============================================================

--- a/backend/app/schemas/hackathon.py
+++ b/backend/app/schemas/hackathon.py
@@ -203,7 +203,9 @@ class HackathonScoreResponse(HackathonScoreBase):
 
 
 class HackathonLeaderboardEntry(BaseModel):
+    rank: int = 0
     team_id: str
     team_name: str
-    total_score: int | None = None
-    score_count: int = 0
+    submission_title: str = ""
+    avg_score: float = 0.0
+    judge_count: int = 0

--- a/backend/app/services/hackathon_service.py
+++ b/backend/app/services/hackathon_service.py
@@ -401,24 +401,27 @@ class HackathonService:
             select(
                 HackathonTeam.id,
                 HackathonTeam.name,
-                sqlfunc.sum(HackathonScore.score).label("total_score"),
-                sqlfunc.count(HackathonScore.id).label("score_count"),
+                HackathonSubmission.title.label("submission_title"),
+                sqlfunc.avg(HackathonScore.score).label("avg_score"),
+                sqlfunc.count(HackathonScore.id).label("judge_count"),
             )
             .join(HackathonSubmission, HackathonSubmission.team_id == HackathonTeam.id)
             .join(HackathonScore, HackathonScore.submission_id == HackathonSubmission.id)
             .where(HackathonTeam.hackathon_id == hackathon_id)
-            .group_by(HackathonTeam.id, HackathonTeam.name)
-            .order_by(sqlfunc.sum(HackathonScore.score).desc())
+            .group_by(HackathonTeam.id, HackathonTeam.name, HackathonSubmission.title)
+            .order_by(sqlfunc.avg(HackathonScore.score).desc())
         )
 
         results = db.execute(stmt).all()
 
         return [
             {
+                "rank": idx + 1,
                 "team_id": str(row.id),
                 "team_name": row.name,
-                "total_score": row.total_score,
-                "score_count": row.score_count,
+                "submission_title": row.submission_title or "",
+                "avg_score": round(float(row.avg_score), 1) if row.avg_score is not None else 0.0,
+                "judge_count": row.judge_count,
             }
-            for row in results
+            for idx, row in enumerate(results)
         ]

--- a/backend/app/services/hackathon_service.py
+++ b/backend/app/services/hackathon_service.py
@@ -406,7 +406,9 @@ class HackathonService:
                 sqlfunc.count(HackathonScore.id).label("judge_count"),
             )
             .join(HackathonSubmission, HackathonSubmission.team_id == HackathonTeam.id)
-            .join(HackathonScore, HackathonScore.submission_id == HackathonSubmission.id)
+            .join(
+                HackathonScore, HackathonScore.submission_id == HackathonSubmission.id
+            )
             .where(HackathonTeam.hackathon_id == hackathon_id)
             .group_by(HackathonTeam.id, HackathonTeam.name, HackathonSubmission.title)
             .order_by(sqlfunc.avg(HackathonScore.score).desc())
@@ -420,7 +422,9 @@ class HackathonService:
                 "team_id": str(row.id),
                 "team_name": row.name,
                 "submission_title": row.submission_title or "",
-                "avg_score": round(float(row.avg_score), 1) if row.avg_score is not None else 0.0,
+                "avg_score": (
+                    round(float(row.avg_score), 1) if row.avg_score is not None else 0.0
+                ),
                 "judge_count": row.judge_count,
             }
             for idx, row in enumerate(results)

--- a/frontend/src/api/modules/hackathons.ts
+++ b/frontend/src/api/modules/hackathons.ts
@@ -1,5 +1,7 @@
 import { api } from "../client";
-import type { Hackathon, HackathonTeam } from "@/mocks/seed";
+import type { Hackathon, HackathonTeam, HackathonSubmission, HackathonLeaderboardEntry } from "@/mocks/seed";
+
+export type { HackathonSubmission, HackathonLeaderboardEntry };
 
 export const hackathonsApi = {
   list: () => api.get<Hackathon[]>("/api/hackathons"),
@@ -16,7 +18,7 @@ export const hackathonsApi = {
     api.post<HackathonTeam>(`/api/hackathons/${id}/teams`, body),
   joinTeam: (teamId: string) => api.post<void>(`/api/hackathons/teams/${teamId}/join`),
   leaveTeam: (teamId: string) => api.delete<void>(`/api/hackathons/teams/${teamId}/leave`),
-  getSubmissions: (id: string) => api.get(`/api/hackathons/${id}/submissions`),
+  getSubmissions: (id: string) => api.get<HackathonSubmission[]>(`/api/hackathons/${id}/submissions`),
   createSubmission: (
     id: string,
     body: {
@@ -26,6 +28,6 @@ export const hackathonsApi = {
       repo_url?: string;
       demo_url?: string;
     },
-  ) => api.post(`/api/hackathons/${id}/submissions`, body),
-  getLeaderboard: (id: string) => api.get(`/api/hackathons/${id}/leaderboard`),
+  ) => api.post<HackathonSubmission>(`/api/hackathons/${id}/submissions`, body),
+  getLeaderboard: (id: string) => api.get<HackathonLeaderboardEntry[]>(`/api/hackathons/${id}/leaderboard`),
 };

--- a/frontend/src/components/hackathons/CreateHackathonDialog.tsx
+++ b/frontend/src/components/hackathons/CreateHackathonDialog.tsx
@@ -1,0 +1,215 @@
+import { useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { hackathonsService } from "@/services";
+import type { Hackathon } from "@/services";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+interface F {
+  name: string; description: string; theme: string; prize: string;
+  starts_at: string; ends_at: string; min_team_size: string; max_team_size: string;
+  website_url: string;
+}
+
+interface E { name?: string; description?: string; starts_at?: string; ends_at?: string; min_team_size?: string; max_team_size?: string; }
+
+const EMPTY: F = { name: "", description: "", theme: "", prize: "", starts_at: "", ends_at: "", min_team_size: "2", max_team_size: "4", website_url: "" };
+
+function fi(err?: string) {
+  return `w-full rounded-md border bg-surface px-3 py-2 text-[13px] outline-none focus:ring-2 focus:ring-primary/20 ${err ? "border-destructive" : "border-border focus:border-primary"}`;
+}
+
+export function CreateHackathonDialog({ open, onOpenChange }: Props) {
+  const navigate = useNavigate();
+  const [form, setForm] = useState<F>(EMPTY);
+  const [errors, setErrors] = useState<E>({});
+  const [loading, setLoading] = useState(false);
+
+  function set(k: keyof F, v: string) {
+    setForm((p) => ({ ...p, [k]: v }));
+    setErrors((p) => ({ ...p, [k]: undefined }));
+  }
+
+  function validate(): boolean {
+    const e: E = {};
+    if (!form.name.trim()) e.name = "Name is required.";
+    if (!form.description.trim()) e.description = "Description is required.";
+    if (!form.starts_at) e.starts_at = "Start date is required.";
+    if (!form.ends_at) e.ends_at = "End date is required.";
+    if (form.starts_at && form.ends_at && form.ends_at <= form.starts_at)
+      e.ends_at = "End must be after start.";
+    const min = parseInt(form.min_team_size);
+    const max = parseInt(form.max_team_size);
+    if (!min || min < 1) e.min_team_size = "Must be at least 1.";
+    if (!max || max < 1) e.max_team_size = "Must be at least 1.";
+    if (min && max && max < min) e.max_team_size = "Max must be ≥ min.";
+    setErrors(e);
+    return Object.keys(e).length === 0;
+  }
+
+  function handleClose() {
+    setForm(EMPTY);
+    setErrors({});
+    onOpenChange(false);
+  }
+
+  async function handleCreate() {
+    if (!validate()) return;
+    setLoading(true);
+    try {
+      const body: Partial<Hackathon> = {
+        name: form.name.trim(),
+        description: form.description.trim(),
+        theme: form.theme.trim() || undefined,
+        prize: form.prize.trim() || undefined,
+        starts_at: new Date(form.starts_at).toISOString(),
+        ends_at: new Date(form.ends_at).toISOString(),
+        min_team_size: parseInt(form.min_team_size),
+        max_team_size: parseInt(form.max_team_size),
+        website_url: form.website_url.trim() || undefined,
+        status: "registration_open",
+        is_published: true,
+      };
+      const created = await hackathonsService.create(body);
+      toast.success("Hackathon created!");
+      handleClose();
+      // Navigate to the new hackathon if we got an ID back
+      if (created && (created as Hackathon).id) {
+        navigate({
+          to: "/hackathons/$hackathonId",
+          params: { hackathonId: (created as Hackathon).id },
+        });
+      }
+    } catch {
+      toast.error("Failed to create hackathon. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="max-h-[90vh] max-w-lg overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Create a hackathon</DialogTitle>
+          <DialogDescription>Fill in the details to launch your event.</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* Name */}
+          <div>
+            <label className="mb-1.5 block text-[13px] font-medium text-foreground">
+              Name <span className="text-destructive">*</span>
+            </label>
+            <input value={form.name} onChange={(e) => set("name", e.target.value)}
+              placeholder="e.g. AI for Good 2025" maxLength={200} className={fi(errors.name)}
+              autoFocus />
+            {errors.name && <p className="mt-1 text-[12px] text-destructive">{errors.name}</p>}
+          </div>
+
+          {/* Description */}
+          <div>
+            <label className="mb-1.5 block text-[13px] font-medium text-foreground">
+              Description <span className="text-destructive">*</span>
+            </label>
+            <textarea value={form.description} onChange={(e) => set("description", e.target.value)}
+              rows={3} placeholder="What is this hackathon about?" className={`${fi(errors.description)} resize-none`} />
+            {errors.description && <p className="mt-1 text-[12px] text-destructive">{errors.description}</p>}
+          </div>
+
+          {/* Theme + Prize */}
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <label className="mb-1.5 block text-[13px] font-medium text-foreground">
+                Theme <span className="font-normal text-muted-foreground">(optional)</span>
+              </label>
+              <input value={form.theme} onChange={(e) => set("theme", e.target.value)}
+                placeholder="e.g. Social Impact" maxLength={200} className={fi()} />
+            </div>
+            <div>
+              <label className="mb-1.5 block text-[13px] font-medium text-foreground">
+                Prize <span className="font-normal text-muted-foreground">(optional)</span>
+              </label>
+              <input value={form.prize} onChange={(e) => set("prize", e.target.value)}
+                placeholder="e.g. $10k" maxLength={100} className={fi()} />
+            </div>
+          </div>
+
+          {/* Dates */}
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <label className="mb-1.5 block text-[13px] font-medium text-foreground">
+                Starts <span className="text-destructive">*</span>
+              </label>
+              <input type="datetime-local" value={form.starts_at}
+                onChange={(e) => set("starts_at", e.target.value)} className={fi(errors.starts_at)} />
+              {errors.starts_at && <p className="mt-1 text-[12px] text-destructive">{errors.starts_at}</p>}
+            </div>
+            <div>
+              <label className="mb-1.5 block text-[13px] font-medium text-foreground">
+                Ends <span className="text-destructive">*</span>
+              </label>
+              <input type="datetime-local" value={form.ends_at}
+                onChange={(e) => set("ends_at", e.target.value)} className={fi(errors.ends_at)} />
+              {errors.ends_at && <p className="mt-1 text-[12px] text-destructive">{errors.ends_at}</p>}
+            </div>
+          </div>
+
+          {/* Team sizes */}
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <label className="mb-1.5 block text-[13px] font-medium text-foreground">
+                Min team size <span className="text-destructive">*</span>
+              </label>
+              <input type="number" min={1} max={20} value={form.min_team_size}
+                onChange={(e) => set("min_team_size", e.target.value)} className={fi(errors.min_team_size)} />
+              {errors.min_team_size && <p className="mt-1 text-[12px] text-destructive">{errors.min_team_size}</p>}
+            </div>
+            <div>
+              <label className="mb-1.5 block text-[13px] font-medium text-foreground">
+                Max team size <span className="text-destructive">*</span>
+              </label>
+              <input type="number" min={1} max={20} value={form.max_team_size}
+                onChange={(e) => set("max_team_size", e.target.value)} className={fi(errors.max_team_size)} />
+              {errors.max_team_size && <p className="mt-1 text-[12px] text-destructive">{errors.max_team_size}</p>}
+            </div>
+          </div>
+
+          {/* Website */}
+          <div>
+            <label className="mb-1.5 block text-[13px] font-medium text-foreground">
+              Website URL <span className="font-normal text-muted-foreground">(optional)</span>
+            </label>
+            <input value={form.website_url} onChange={(e) => set("website_url", e.target.value)}
+              placeholder="https://…" className={fi()} />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <button type="button" onClick={handleClose} disabled={loading}
+            className="rounded-md border border-border px-4 py-2 text-[13px] font-medium text-foreground hover:bg-muted disabled:opacity-50">
+            Cancel
+          </button>
+          <button type="button" onClick={handleCreate} disabled={loading}
+            className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-[13px] font-semibold text-primary-foreground hover:opacity-90 disabled:opacity-60">
+            {loading && <Loader2 size={13} className="animate-spin" />}
+            Create hackathon
+          </button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/hackathons/CreateTeamDialog.tsx
+++ b/frontend/src/components/hackathons/CreateTeamDialog.tsx
@@ -1,0 +1,126 @@
+import { useState } from "react";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { hackathonsService } from "@/services";
+
+interface Props {
+  hackathonId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Called after team is successfully created */
+  onCreated: () => void;
+}
+
+export function CreateTeamDialog({ hackathonId, open, onOpenChange, onCreated }: Props) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [nameError, setNameError] = useState("");
+
+  function handleClose() {
+    setName("");
+    setDescription("");
+    setNameError("");
+    onOpenChange(false);
+  }
+
+  async function handleCreate() {
+    const trimmed = name.trim();
+    if (!trimmed) { setNameError("Team name is required."); return; }
+    if (trimmed.length < 2) { setNameError("Must be at least 2 characters."); return; }
+
+    setNameError("");
+    setLoading(true);
+    try {
+      await hackathonsService.createTeam(hackathonId, {
+        name: trimmed,
+        description: description.trim() || undefined,
+      });
+      toast.success(`Team "${trimmed}" created!`);
+      setName("");
+      setDescription("");
+      onCreated();
+    } catch {
+      toast.error("Failed to create team. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Create a team</DialogTitle>
+          <DialogDescription>
+            Name your team and optionally describe what you're building.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div>
+            <label htmlFor="team-name" className="mb-1.5 block text-[13px] font-medium text-foreground">
+              Team name <span className="text-destructive">*</span>
+            </label>
+            <input
+              id="team-name"
+              value={name}
+              onChange={(e) => { setName(e.target.value); setNameError(""); }}
+              onKeyDown={(e) => e.key === "Enter" && handleCreate()}
+              placeholder="e.g. Neural Nexus"
+              maxLength={100}
+              className={`w-full rounded-md border bg-surface px-3 py-2 text-[13px] outline-none focus:ring-2 focus:ring-primary/20 ${
+                nameError ? "border-destructive focus:border-destructive" : "border-border focus:border-primary"
+              }`}
+              autoFocus
+            />
+            {nameError && <p className="mt-1 text-[12px] text-destructive">{nameError}</p>}
+          </div>
+
+          <div>
+            <label htmlFor="team-desc" className="mb-1.5 block text-[13px] font-medium text-foreground">
+              Description <span className="font-normal text-muted-foreground">(optional)</span>
+            </label>
+            <textarea
+              id="team-desc"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={3}
+              placeholder="What are you planning to build?"
+              maxLength={500}
+              className="w-full resize-none rounded-md border border-border bg-surface px-3 py-2 text-[13px] outline-none focus:border-primary focus:ring-2 focus:ring-primary/20"
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <button
+            type="button"
+            onClick={handleClose}
+            disabled={loading}
+            className="rounded-md border border-border px-4 py-2 text-[13px] font-medium text-foreground hover:bg-muted disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleCreate}
+            disabled={loading || !name.trim()}
+            className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-[13px] font-semibold text-primary-foreground hover:opacity-90 disabled:opacity-60"
+          >
+            {loading && <Loader2 size={13} className="animate-spin" />}
+            Create team
+          </button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/hackathons/LeaderboardTab.tsx
+++ b/frontend/src/components/hackathons/LeaderboardTab.tsx
@@ -1,0 +1,201 @@
+import { useQuery } from "@tanstack/react-query";
+import { Award, Medal } from "lucide-react";
+import { Card, EmptyState } from "@/components/shared/primitives";
+import { hackathonsService } from "@/services";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  hackathonId: string;
+}
+
+const RANK_STYLES: Record<number, { bg: string; text: string; label: string }> = {
+  1: { bg: "bg-warning/10 border-warning/30", text: "text-warning", label: "1st" },
+  2: { bg: "bg-muted border-border", text: "text-muted-foreground", label: "2nd" },
+  3: { bg: "bg-primary/10 border-primary/30", text: "text-primary", label: "3rd" },
+};
+
+function getRankStyle(rank: number) {
+  return (
+    RANK_STYLES[rank] ?? {
+      bg: "bg-muted/50 border-border",
+      text: "text-muted-foreground",
+      label: `${rank}th`,
+    }
+  );
+}
+
+export function LeaderboardTab({ hackathonId }: Props) {
+  const { data: entries = [], isLoading } = useQuery({
+    queryKey: ["hackathon-leaderboard", hackathonId],
+    queryFn: () => hackathonsService.getLeaderboard(hackathonId),
+    enabled: !!hackathonId,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2" aria-busy="true">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Card key={i} className="h-16 animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  if (entries.length === 0) {
+    return (
+      <Card className="p-8">
+        <EmptyState
+          title="No scores yet"
+          desc="The leaderboard will be populated after judging begins."
+          icon={Award}
+        />
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-[13px] text-muted-foreground">
+        Ranked by average judge score · {entries.length} team
+        {entries.length !== 1 ? "s" : ""}
+      </p>
+
+      {/* Desktop table */}
+      <div className="hidden w-full overflow-x-auto rounded-xl border border-border sm:block">
+        <table className="w-full min-w-max border-collapse text-[13px]">
+          <thead>
+            <tr className="border-b border-border bg-muted">
+              <th
+                scope="col"
+                className="whitespace-nowrap px-4 py-3 text-left font-semibold text-foreground"
+              >
+                Rank
+              </th>
+              <th
+                scope="col"
+                className="whitespace-nowrap px-4 py-3 text-left font-semibold text-foreground"
+              >
+                Team
+              </th>
+              <th
+                scope="col"
+                className="whitespace-nowrap px-4 py-3 text-left font-semibold text-foreground"
+              >
+                Project
+              </th>
+              <th
+                scope="col"
+                className="whitespace-nowrap px-4 py-3 text-right font-semibold text-foreground"
+              >
+                Avg score
+              </th>
+              <th
+                scope="col"
+                className="whitespace-nowrap px-4 py-3 text-right font-semibold text-foreground"
+              >
+                Judges
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map((entry) => {
+              const style = getRankStyle(entry.rank);
+              return (
+                <tr
+                  key={entry.team_id}
+                  className="border-b border-border transition-colors last:border-0 hover:bg-muted/50"
+                >
+                  <td className="px-4 py-3">
+                    <span
+                      className={cn(
+                        "inline-flex h-7 w-7 items-center justify-center rounded-full border text-[12px] font-bold",
+                        style.bg,
+                        style.text,
+                      )}
+                      aria-label={`Rank ${style.label}`}
+                    >
+                      {entry.rank <= 3 ? (
+                        <Medal size={13} />
+                      ) : (
+                        entry.rank
+                      )}
+                    </span>
+                  </td>
+                  <td className="break-words px-4 py-3 font-medium text-foreground">
+                    {entry.team_name}
+                  </td>
+                  <td className="break-words px-4 py-3 text-muted-foreground">
+                    {entry.submission_title}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <ScoreBar score={entry.avg_score} />
+                  </td>
+                  <td className="px-4 py-3 text-right text-muted-foreground">
+                    {entry.judge_count}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Mobile card list */}
+      <div className="space-y-2 sm:hidden">
+        {entries.map((entry) => {
+          const style = getRankStyle(entry.rank);
+          return (
+            <Card key={entry.team_id} className="p-4">
+              <div className="flex items-start gap-3">
+                <span
+                  className={cn(
+                    "grid h-9 w-9 shrink-0 place-items-center rounded-full border text-[13px] font-bold",
+                    style.bg,
+                    style.text,
+                  )}
+                  aria-label={`Rank ${style.label}`}
+                >
+                  {entry.rank <= 3 ? <Medal size={14} /> : entry.rank}
+                </span>
+                <div className="min-w-0 flex-1">
+                  <p className="text-[14px] font-semibold text-foreground">{entry.team_name}</p>
+                  <p className="mt-0.5 text-[12px] text-muted-foreground">
+                    {entry.submission_title}
+                  </p>
+                  <div className="mt-2 flex items-center justify-between">
+                    <ScoreBar score={entry.avg_score} />
+                    <span className="text-[11px] text-muted-foreground">
+                      {entry.judge_count} judge{entry.judge_count !== 1 ? "s" : ""}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </Card>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function ScoreBar({ score }: { score: number }) {
+  const pct = Math.min(100, Math.max(0, score));
+  const color =
+    pct >= 80 ? "bg-success" : pct >= 60 ? "bg-primary" : pct >= 40 ? "bg-warning" : "bg-destructive";
+
+  return (
+    <div className="inline-flex items-center gap-2">
+      <div
+        className="h-1.5 w-20 overflow-hidden rounded-full bg-muted"
+        role="progressbar"
+        aria-valuenow={score}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={`Score: ${score}`}
+      >
+        <div className={cn("h-full rounded-full", color)} style={{ width: `${pct}%` }} />
+      </div>
+      <span className="text-[13px] font-semibold text-foreground tabular-nums">{score}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/hackathons/RegisterDialog.tsx
+++ b/frontend/src/components/hackathons/RegisterDialog.tsx
@@ -1,0 +1,98 @@
+import { useState } from "react";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { hackathonsService } from "@/services";
+
+interface Props {
+  hackathonId: string;
+  hackathonName: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Called only on successful registration — not on cancel */
+  onRegistered: () => void;
+}
+
+export function RegisterDialog({ hackathonId, hackathonName, open, onOpenChange, onRegistered }: Props) {
+  const [motivation, setMotivation] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  function handleClose() {
+    setMotivation("");
+    onOpenChange(false);
+  }
+
+  async function handleRegister() {
+    setLoading(true);
+    try {
+      await hackathonsService.register(hackathonId, {
+        motivation: motivation.trim() || undefined,
+      });
+      toast.success("You're registered! Welcome to the hackathon.");
+      setMotivation("");
+      onRegistered(); // closes dialog AND marks registered
+    } catch {
+      toast.error("Registration failed. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Register for {hackathonName}</DialogTitle>
+          <DialogDescription>
+            You'll be able to form or join a team after registering.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div>
+          <label
+            htmlFor="motivation"
+            className="mb-1.5 block text-[13px] font-medium text-foreground"
+          >
+            What are you hoping to build?{" "}
+            <span className="font-normal text-muted-foreground">(optional)</span>
+          </label>
+          <textarea
+            id="motivation"
+            value={motivation}
+            onChange={(e) => setMotivation(e.target.value)}
+            rows={4}
+            placeholder="Describe your idea or what you want to learn…"
+            className="w-full resize-none rounded-md border border-border bg-surface px-3 py-2 text-[13px] outline-none focus:border-primary focus:ring-2 focus:ring-primary/20"
+          />
+        </div>
+
+        <DialogFooter>
+          <button
+            type="button"
+            onClick={handleClose}
+            disabled={loading}
+            className="rounded-md border border-border px-4 py-2 text-[13px] font-medium text-foreground hover:bg-muted disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleRegister}
+            disabled={loading}
+            className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-[13px] font-semibold text-primary-foreground hover:opacity-90 disabled:opacity-60"
+          >
+            {loading && <Loader2 size={13} className="animate-spin" />}
+            Register
+          </button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/hackathons/SubmissionsTab.tsx
+++ b/frontend/src/components/hackathons/SubmissionsTab.tsx
@@ -1,0 +1,154 @@
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { GitBranch, ExternalLink, Plus, Clock, CheckCircle2, XCircle, Eye } from "lucide-react";
+import { Card, EmptyState, TagChip } from "@/components/shared/primitives";
+import { SubmitProjectDialog } from "./SubmitProjectDialog";
+import { hackathonsService } from "@/services";
+import type { HackathonSubmission, HackathonTeam } from "@/services";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  hackathonId: string;
+  teams: HackathonTeam[];
+}
+
+const STATUS_META: Record<
+  HackathonSubmission["status"],
+  { label: string; cls: string; icon: React.ReactNode }
+> = {
+  draft:     { label: "Draft",     cls: "border-border bg-muted text-muted-foreground",        icon: <Clock size={10} /> },
+  submitted: { label: "Submitted", cls: "border-primary/30 bg-primary/10 text-primary",        icon: <CheckCircle2 size={10} /> },
+  in_review: { label: "In review", cls: "border-warning/30 bg-warning/10 text-warning",        icon: <Eye size={10} /> },
+  accepted:  { label: "Accepted",  cls: "border-success/30 bg-success/10 text-success",        icon: <CheckCircle2 size={10} /> },
+  rejected:  { label: "Rejected",  cls: "border-destructive/30 bg-destructive/10 text-destructive", icon: <XCircle size={10} /> },
+};
+
+export function SubmissionsTab({ hackathonId, teams }: Props) {
+  const queryClient = useQueryClient();
+  const [submitOpen, setSubmitOpen] = useState(false);
+
+  const { data: submissions = [], isLoading } = useQuery({
+    queryKey: ["hackathon-submissions", hackathonId],
+    queryFn: () => hackathonsService.getSubmissions(hackathonId),
+  });
+
+  async function handleSubmitted() {
+    setSubmitOpen(false);
+    await queryClient.invalidateQueries({ queryKey: ["hackathon-submissions", hackathonId] });
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        {[1, 2].map((i) => <Card key={i} className="h-28 animate-pulse" />)}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <p className="text-[13px] text-muted-foreground">
+          {submissions.length === 0
+            ? "No submissions yet."
+            : `${submissions.length} submission${submissions.length !== 1 ? "s" : ""}`}
+        </p>
+        {teams.length > 0 && (
+          <button
+            onClick={() => setSubmitOpen(true)}
+            className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-[12px] font-semibold text-primary-foreground hover:opacity-90"
+          >
+            <Plus size={13} /> Submit project
+          </button>
+        )}
+      </div>
+
+      {/* Empty */}
+      {submissions.length === 0 ? (
+        <Card className="p-10">
+          <EmptyState
+            title="No submissions yet"
+            desc={teams.length > 0 ? "Submit your project when you're ready." : "Join a team first to submit a project."}
+            icon={GitBranch}
+            action={
+              teams.length > 0 ? (
+                <button
+                  onClick={() => setSubmitOpen(true)}
+                  className="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 text-[13px] font-semibold text-primary-foreground hover:opacity-90"
+                >
+                  <Plus size={14} /> Submit project
+                </button>
+              ) : undefined
+            }
+          />
+        </Card>
+      ) : (
+        <div className="space-y-3">
+          {submissions.map((sub) => (
+            <SubmissionCard key={sub.id} submission={sub} teams={teams} />
+          ))}
+        </div>
+      )}
+
+      <SubmitProjectDialog
+        hackathonId={hackathonId}
+        teams={teams}
+        open={submitOpen}
+        onOpenChange={setSubmitOpen}
+        onSubmitted={handleSubmitted}
+      />
+    </div>
+  );
+}
+
+function SubmissionCard({ submission, teams }: { submission: HackathonSubmission; teams: HackathonTeam[] }) {
+  const meta = STATUS_META[submission.status];
+  const team = teams.find((t) => t.id === submission.team_id);
+
+  return (
+    <Card className="p-4">
+      <div className="flex min-w-0 items-start gap-3">
+        <span className="mt-0.5 grid h-9 w-9 shrink-0 place-items-center rounded-md bg-primary-soft text-primary">
+          <GitBranch size={15} />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="text-[14px] font-semibold text-foreground">{submission.title}</h3>
+            <TagChip className={cn("inline-flex items-center gap-1", meta.cls)}>
+              {meta.icon} {meta.label}
+            </TagChip>
+          </div>
+          {team && <p className="mt-0.5 text-[12px] text-muted-foreground">by {team.name}</p>}
+          <p className="mt-1.5 line-clamp-3 text-[13px] text-foreground/80">
+            {submission.description}
+          </p>
+          {(submission.repo_url || submission.demo_url) && (
+            <div className="mt-2 flex flex-wrap gap-3">
+              {submission.repo_url && (
+                <a
+                  href={submission.repo_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-[12px] font-medium text-primary hover:underline"
+                >
+                  <GitBranch size={11} /> Repo <ExternalLink size={10} />
+                </a>
+              )}
+              {submission.demo_url && (
+                <a
+                  href={submission.demo_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-[12px] font-medium text-primary hover:underline"
+                >
+                  <ExternalLink size={11} /> Demo
+                </a>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/hackathons/SubmitProjectDialog.tsx
+++ b/frontend/src/components/hackathons/SubmitProjectDialog.tsx
@@ -1,0 +1,195 @@
+import { useState } from "react";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import type { HackathonTeam } from "@/services";
+import { hackathonsService } from "@/services";
+
+interface Props {
+  hackathonId: string;
+  teams: HackathonTeam[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmitted: () => void;
+}
+
+interface Errors {
+  team_id?: string;
+  title?: string;
+  description?: string;
+  repo_url?: string;
+  demo_url?: string;
+}
+
+function isUrl(v: string) {
+  try { new URL(v); return true; } catch { return false; }
+}
+
+export function SubmitProjectDialog({ hackathonId, teams, open, onOpenChange, onSubmitted }: Props) {
+  const [teamId, setTeamId] = useState("");
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [repoUrl, setRepoUrl] = useState("");
+  const [demoUrl, setDemoUrl] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [errors, setErrors] = useState<Errors>({});
+
+  function clrErr(k: keyof Errors) {
+    setErrors((p) => ({ ...p, [k]: undefined }));
+  }
+
+  function validate(): boolean {
+    const e: Errors = {};
+    if (!teamId) e.team_id = "Select your team.";
+    if (!title.trim()) e.title = "Title is required.";
+    else if (title.trim().length < 3) e.title = "At least 3 characters.";
+    if (!description.trim()) e.description = "Description is required.";
+    else if (description.trim().length < 20) e.description = "At least 20 characters.";
+    if (repoUrl && !isUrl(repoUrl)) e.repo_url = "Enter a valid URL.";
+    if (demoUrl && !isUrl(demoUrl)) e.demo_url = "Enter a valid URL.";
+    setErrors(e);
+    return Object.keys(e).length === 0;
+  }
+
+  function handleClose() {
+    setTeamId(""); setTitle(""); setDescription(""); setRepoUrl(""); setDemoUrl("");
+    setErrors({});
+    onOpenChange(false);
+  }
+
+  async function handleSubmit() {
+    if (!validate()) return;
+    setLoading(true);
+    try {
+      await hackathonsService.createSubmission(hackathonId, {
+        team_id: teamId,
+        title: title.trim(),
+        description: description.trim(),
+        repo_url: repoUrl.trim() || undefined,
+        demo_url: demoUrl.trim() || undefined,
+      });
+      toast.success("Project submitted! Good luck 🚀");
+      setTeamId(""); setTitle(""); setDescription(""); setRepoUrl(""); setDemoUrl("");
+      onSubmitted();
+    } catch {
+      toast.error("Submission failed. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const inp = (err?: string) =>
+    `w-full rounded-md border bg-surface px-3 py-2 text-[13px] outline-none focus:ring-2 focus:ring-primary/20 ${
+      err ? "border-destructive focus:border-destructive" : "border-border focus:border-primary"
+    }`;
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="max-h-[90vh] max-w-lg overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Submit your project</DialogTitle>
+          <DialogDescription>
+            You can update this at any time before the deadline.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* Team */}
+          <div>
+            <label className="mb-1.5 block text-[13px] font-medium text-foreground">
+              Team <span className="text-destructive">*</span>
+            </label>
+            <select
+              value={teamId}
+              onChange={(e) => { setTeamId(e.target.value); clrErr("team_id"); }}
+              className={inp(errors.team_id)}
+            >
+              <option value="">Select your team…</option>
+              {teams.map((t) => (
+                <option key={t.id} value={t.id}>{t.name}</option>
+              ))}
+            </select>
+            {errors.team_id && <p className="mt-1 text-[12px] text-destructive">{errors.team_id}</p>}
+          </div>
+
+          {/* Title */}
+          <div>
+            <label className="mb-1.5 block text-[13px] font-medium text-foreground">
+              Project title <span className="text-destructive">*</span>
+            </label>
+            <input
+              value={title}
+              onChange={(e) => { setTitle(e.target.value); clrErr("title"); }}
+              placeholder="e.g. EcoTracker AI"
+              maxLength={200}
+              className={inp(errors.title)}
+            />
+            {errors.title && <p className="mt-1 text-[12px] text-destructive">{errors.title}</p>}
+          </div>
+
+          {/* Description */}
+          <div>
+            <label className="mb-1.5 block text-[13px] font-medium text-foreground">
+              Description <span className="text-destructive">*</span>
+            </label>
+            <textarea
+              value={description}
+              onChange={(e) => { setDescription(e.target.value); clrErr("description"); }}
+              rows={4}
+              placeholder="What does it do, how was it built, what's the impact?"
+              className={`${inp(errors.description)} resize-none`}
+            />
+            {errors.description && <p className="mt-1 text-[12px] text-destructive">{errors.description}</p>}
+          </div>
+
+          {/* URLs */}
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <label className="mb-1.5 block text-[13px] font-medium text-foreground">
+                Repository URL <span className="font-normal text-muted-foreground">(optional)</span>
+              </label>
+              <input
+                value={repoUrl}
+                onChange={(e) => { setRepoUrl(e.target.value); clrErr("repo_url"); }}
+                placeholder="https://github.com/…"
+                className={inp(errors.repo_url)}
+              />
+              {errors.repo_url && <p className="mt-1 text-[12px] text-destructive">{errors.repo_url}</p>}
+            </div>
+            <div>
+              <label className="mb-1.5 block text-[13px] font-medium text-foreground">
+                Demo URL <span className="font-normal text-muted-foreground">(optional)</span>
+              </label>
+              <input
+                value={demoUrl}
+                onChange={(e) => { setDemoUrl(e.target.value); clrErr("demo_url"); }}
+                placeholder="https://…"
+                className={inp(errors.demo_url)}
+              />
+              {errors.demo_url && <p className="mt-1 text-[12px] text-destructive">{errors.demo_url}</p>}
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <button type="button" onClick={handleClose} disabled={loading}
+            className="rounded-md border border-border px-4 py-2 text-[13px] font-medium text-foreground hover:bg-muted disabled:opacity-50">
+            Cancel
+          </button>
+          <button type="button" onClick={handleSubmit} disabled={loading}
+            className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-[13px] font-semibold text-primary-foreground hover:opacity-90 disabled:opacity-60">
+            {loading && <Loader2 size={13} className="animate-spin" />}
+            Submit project
+          </button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/hackathons/TeamsTab.tsx
+++ b/frontend/src/components/hackathons/TeamsTab.tsx
@@ -1,0 +1,187 @@
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Users2, Plus, LogIn, Loader2, Crown } from "lucide-react";
+import { toast } from "sonner";
+import { Card, EmptyState } from "@/components/shared/primitives";
+import { CreateTeamDialog } from "./CreateTeamDialog";
+import { hackathonsService } from "@/services";
+import type { HackathonTeam } from "@/services";
+
+interface Props {
+  hackathonId: string;
+  maxTeamSize: number;
+}
+
+export function TeamsTab({ hackathonId, maxTeamSize }: Props) {
+  const queryClient = useQueryClient();
+  const [createOpen, setCreateOpen] = useState(false);
+  const [joiningId, setJoiningId] = useState<string | null>(null);
+
+  const { data: teams = [], isLoading } = useQuery({
+    queryKey: ["hackathon-teams", hackathonId],
+    queryFn: () => hackathonsService.getTeams(hackathonId),
+  });
+
+  async function handleJoin(team: HackathonTeam) {
+    setJoiningId(team.id);
+    try {
+      await hackathonsService.joinTeam(team.id);
+      toast.success(`Joined ${team.name}!`);
+      await queryClient.invalidateQueries({ queryKey: ["hackathon-teams", hackathonId] });
+    } catch {
+      toast.error("Could not join team. You may already be in one.");
+    } finally {
+      setJoiningId(null);
+    }
+  }
+
+  async function handleTeamCreated() {
+    setCreateOpen(false);
+    await queryClient.invalidateQueries({ queryKey: ["hackathon-teams", hackathonId] });
+    // Also refresh the stats card on the detail page
+    await queryClient.invalidateQueries({ queryKey: ["hackathon", hackathonId] });
+  }
+
+  if (isLoading) {
+    return (
+      <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+        {[1, 2, 3].map((i) => (
+          <Card key={i} className="h-28 animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <p className="text-[13px] text-muted-foreground">
+          {teams.length === 0
+            ? "No teams yet — be the first to create one."
+            : `${teams.length} team${teams.length !== 1 ? "s" : ""} · up to ${maxTeamSize} members each`}
+        </p>
+        <button
+          onClick={() => setCreateOpen(true)}
+          className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-[12px] font-semibold text-primary-foreground hover:opacity-90"
+        >
+          <Plus size={13} /> Create team
+        </button>
+      </div>
+
+      {/* Empty */}
+      {teams.length === 0 ? (
+        <Card className="p-10">
+          <EmptyState
+            title="No teams yet"
+            desc="Create a team to start recruiting members."
+            icon={Users2}
+            action={
+              <button
+                onClick={() => setCreateOpen(true)}
+                className="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 text-[13px] font-semibold text-primary-foreground hover:opacity-90"
+              >
+                <Plus size={14} /> Create team
+              </button>
+            }
+          />
+        </Card>
+      ) : (
+        <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+          {teams.map((team) => (
+            <TeamCard
+              key={team.id}
+              team={team}
+              maxTeamSize={maxTeamSize}
+              joining={joiningId === team.id}
+              onJoin={() => handleJoin(team)}
+            />
+          ))}
+        </div>
+      )}
+
+      <CreateTeamDialog
+        hackathonId={hackathonId}
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        onCreated={handleTeamCreated}
+      />
+    </div>
+  );
+}
+
+function TeamCard({
+  team,
+  maxTeamSize,
+  joining,
+  onJoin,
+}: {
+  team: HackathonTeam;
+  maxTeamSize: number;
+  joining: boolean;
+  onJoin: () => void;
+}) {
+  const isFull = team.member_count >= maxTeamSize;
+
+  return (
+    <Card interactive className="flex flex-col gap-3 p-4">
+      <div className="flex items-start gap-3">
+        <span className="grid h-10 w-10 shrink-0 place-items-center rounded-md bg-primary-soft text-primary">
+          <Users2 size={16} />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5">
+            <p className="truncate text-[14px] font-semibold text-foreground">{team.name}</p>
+            {team.member_count === 1 && (
+              <Crown size={11} className="shrink-0 text-warning" aria-label="New team" />
+            )}
+          </div>
+          {team.description && (
+            <p className="mt-0.5 line-clamp-2 text-[12px] text-muted-foreground">
+              {team.description}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between">
+        {/* Member bar */}
+        <div className="flex items-center gap-1.5">
+          <div
+            className="flex gap-0.5"
+            role="img"
+            aria-label={`${team.member_count} of ${maxTeamSize} spots filled`}
+          >
+            {Array.from({ length: maxTeamSize }).map((_, i) => (
+              <span
+                key={i}
+                className={`h-2 w-2 rounded-full transition-colors ${
+                  i < team.member_count ? "bg-primary" : "bg-muted"
+                }`}
+              />
+            ))}
+          </div>
+          <span className="text-[11px] text-muted-foreground">
+            {team.member_count}/{maxTeamSize}
+          </span>
+        </div>
+
+        <button
+          onClick={onJoin}
+          disabled={joining || isFull}
+          className="inline-flex items-center gap-1 rounded-md border border-border px-2.5 py-1 text-[11px] font-medium text-foreground transition-colors hover:border-primary hover:bg-primary hover:text-primary-foreground disabled:pointer-events-none disabled:opacity-40"
+        >
+          {joining ? (
+            <Loader2 size={11} className="animate-spin" />
+          ) : isFull ? (
+            "Full"
+          ) : (
+            <>
+              <LogIn size={11} /> Join
+            </>
+          )}
+        </button>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/mocks/hackathonStore.ts
+++ b/frontend/src/mocks/hackathonStore.ts
@@ -1,0 +1,161 @@
+/**
+ * In-memory mock store for hackathon data.
+ * Lets create/join/submit actions actually work in mock mode
+ * so the UI reflects changes without a real backend.
+ */
+
+import type {
+  Hackathon,
+  HackathonTeam,
+  HackathonSubmission,
+  HackathonLeaderboardEntry,
+} from "./seed";
+import {
+  hackathons as seedHackathons,
+  hackathonTeams as seedTeams,
+  hackathonSubmissions as seedSubmissions,
+  hackathonLeaderboard as seedLeaderboard,
+} from "./seed";
+
+// Deep-clone seed data so mutations don't affect the original module
+let hackathons: Hackathon[] = seedHackathons.map((h) => ({ ...h }));
+let teams: HackathonTeam[] = seedTeams.map((t) => ({ ...t }));
+let submissions: HackathonSubmission[] = seedSubmissions.map((s) => ({ ...s }));
+let leaderboard: HackathonLeaderboardEntry[] = seedLeaderboard.map((e) => ({ ...e }));
+const registrations = new Set<string>(); // "hackathonId:userId"
+
+function uuid(): string {
+  return "mock-" + Math.random().toString(36).slice(2, 10) + Date.now().toString(36);
+}
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+const delay = (ms = 300) => new Promise<void>((r) => setTimeout(r, ms));
+
+export const hackathonStore = {
+  // ── Hackathons ────────────────────────────────────────────────────────────
+  getAll() {
+    return hackathons;
+  },
+  getById(id: string) {
+    return hackathons.find((h) => h.id === id) ?? null;
+  },
+  async create(body: Partial<Hackathon>): Promise<Hackathon> {
+    await delay();
+    const h: Hackathon = {
+      id: uuid(),
+      name: body.name ?? "Untitled Hackathon",
+      description: body.description ?? "",
+      theme: body.theme ?? "",
+      prize: body.prize ?? "",
+      starts_at: body.starts_at ?? now(),
+      ends_at: body.ends_at ?? now(),
+      min_team_size: body.min_team_size ?? 1,
+      max_team_size: body.max_team_size ?? 4,
+      status: body.status ?? "registration_open",
+      is_published: body.is_published ?? true,
+      website_url: body.website_url,
+      created_by: "me",
+      created_at: now(),
+      updated_at: now(),
+    };
+    hackathons = [...hackathons, h];
+    return h;
+  },
+
+  // ── Teams ─────────────────────────────────────────────────────────────────
+  getTeams(hackathonId: string): HackathonTeam[] {
+    return teams.filter((t) => t.hackathon_id === hackathonId);
+  },
+
+  async createTeam(
+    hackathonId: string,
+    body: { name: string; description?: string },
+  ): Promise<HackathonTeam> {
+    await delay();
+    const team: HackathonTeam = {
+      id: uuid(),
+      hackathon_id: hackathonId,
+      name: body.name,
+      description: body.description,
+      created_by: "me",
+      member_count: 1,
+      created_at: now(),
+      updated_at: now(),
+    };
+    teams = [...teams, team];
+    return team;
+  },
+
+  async joinTeam(teamId: string): Promise<void> {
+    await delay();
+    teams = teams.map((t) =>
+      t.id === teamId ? { ...t, member_count: t.member_count + 1 } : t,
+    );
+  },
+
+  async leaveTeam(teamId: string): Promise<void> {
+    await delay();
+    teams = teams.map((t) =>
+      t.id === teamId ? { ...t, member_count: Math.max(0, t.member_count - 1) } : t,
+    );
+  },
+
+  // ── Registrations ─────────────────────────────────────────────────────────
+  isRegistered(hackathonId: string): boolean {
+    return registrations.has(`${hackathonId}:me`);
+  },
+
+  async register(hackathonId: string): Promise<void> {
+    await delay();
+    registrations.add(`${hackathonId}:me`);
+  },
+
+  async cancelRegistration(hackathonId: string): Promise<void> {
+    await delay();
+    registrations.delete(`${hackathonId}:me`);
+  },
+
+  // ── Submissions ───────────────────────────────────────────────────────────
+  getSubmissions(hackathonId: string): HackathonSubmission[] {
+    return submissions.filter((s) => s.hackathon_id === hackathonId);
+  },
+
+  async createSubmission(
+    hackathonId: string,
+    body: {
+      team_id: string;
+      title: string;
+      description: string;
+      repo_url?: string;
+      demo_url?: string;
+    },
+  ): Promise<HackathonSubmission> {
+    await delay();
+    const sub: HackathonSubmission = {
+      id: uuid(),
+      hackathon_id: hackathonId,
+      team_id: body.team_id,
+      submitted_by: "me",
+      title: body.title,
+      description: body.description,
+      repo_url: body.repo_url,
+      demo_url: body.demo_url,
+      status: "submitted",
+      created_at: now(),
+      updated_at: now(),
+    };
+    submissions = [...submissions, sub];
+    return sub;
+  },
+
+  // ── Leaderboard ───────────────────────────────────────────────────────────
+  getLeaderboard(hackathonId: string): HackathonLeaderboardEntry[] {
+    const hackathonTeamIds = teams
+      .filter((t) => t.hackathon_id === hackathonId)
+      .map((t) => t.id);
+    return leaderboard.filter((e) => hackathonTeamIds.includes(e.team_id));
+  },
+};

--- a/frontend/src/mocks/seed.ts
+++ b/frontend/src/mocks/seed.ts
@@ -143,6 +143,29 @@ export interface HackathonTeam {
   created_at: string;
   updated_at: string;
 }
+
+export interface HackathonSubmission {
+  id: ID;
+  hackathon_id: string;
+  team_id: string;
+  submitted_by: string;
+  title: string;
+  description: string;
+  repo_url?: string;
+  demo_url?: string;
+  status: "draft" | "submitted" | "in_review" | "accepted" | "rejected";
+  created_at: string;
+  updated_at: string;
+}
+
+export interface HackathonLeaderboardEntry {
+  rank: number;
+  team_id: string;
+  team_name: string;
+  submission_title: string;
+  avg_score: number;
+  judge_count: number;
+}
 export interface Deadline {
   id: ID;
   project: string;
@@ -630,6 +653,109 @@ export const hackathons: Hackathon[] = [
     created_by: "u2",
     created_at: "2025-12-15T00:00:00Z",
     updated_at: "2026-01-23T00:00:00Z",
+  },
+];
+
+export const hackathonTeams: HackathonTeam[] = [
+  {
+    id: "ht1",
+    hackathon_id: "h1",
+    name: "Neural Nexus",
+    description: "Building an AI tool to help NGOs manage volunteer coordination.",
+    created_by: "u1",
+    member_count: 3,
+    created_at: "2025-08-10T10:00:00Z",
+    updated_at: "2025-08-10T10:00:00Z",
+  },
+  {
+    id: "ht2",
+    hackathon_id: "h1",
+    name: "Green Coders",
+    description: "Using computer vision to detect and classify waste for recycling.",
+    created_by: "u2",
+    member_count: 2,
+    created_at: "2025-08-11T14:00:00Z",
+    updated_at: "2025-08-11T14:00:00Z",
+  },
+  {
+    id: "ht3",
+    hackathon_id: "h1",
+    name: "AccessAI",
+    description: "AI-powered accessibility tools for visually impaired users.",
+    created_by: "u3",
+    member_count: 4,
+    created_at: "2025-08-12T09:00:00Z",
+    updated_at: "2025-08-12T09:00:00Z",
+  },
+  {
+    id: "ht4",
+    hackathon_id: "h3",
+    name: "DeFi Degen Squad",
+    description: "A yield aggregator with gas optimization on Ethereum L2.",
+    created_by: "u2",
+    member_count: 3,
+    created_at: "2026-01-05T10:00:00Z",
+    updated_at: "2026-01-05T10:00:00Z",
+  },
+  {
+    id: "ht5",
+    hackathon_id: "h3",
+    name: "Zero Knowledge Labs",
+    description: "ZK-proof based identity verification without exposing personal data.",
+    created_by: "u4",
+    member_count: 2,
+    created_at: "2026-01-06T12:00:00Z",
+    updated_at: "2026-01-06T12:00:00Z",
+  },
+];
+
+export const hackathonSubmissions: HackathonSubmission[] = [
+  {
+    id: "hs1",
+    hackathon_id: "h3",
+    team_id: "ht4",
+    submitted_by: "u2",
+    title: "YieldMax Protocol",
+    description:
+      "A multi-strategy yield aggregator that automatically routes funds to the highest APY protocols on Arbitrum and Optimism, saving up to 40% on gas.",
+    repo_url: "https://github.com/defidegen/yieldmax",
+    demo_url: "https://yieldmax.demo.xyz",
+    status: "accepted",
+    created_at: "2026-01-21T20:00:00Z",
+    updated_at: "2026-01-22T10:00:00Z",
+  },
+  {
+    id: "hs2",
+    hackathon_id: "h3",
+    team_id: "ht5",
+    submitted_by: "u4",
+    title: "ZKident",
+    description:
+      "Privacy-preserving identity verification using zk-SNARKs. Prove you are over 18 or a citizen of a country without revealing your actual documents.",
+    repo_url: "https://github.com/zklabs/zkident",
+    demo_url: "https://zkident.vercel.app",
+    status: "accepted",
+    created_at: "2026-01-22T08:00:00Z",
+    updated_at: "2026-01-22T14:00:00Z",
+  },
+];
+
+export const hackathonLeaderboard: HackathonLeaderboardEntry[] = [
+  {
+    rank: 1,
+    team_id: "ht5",
+    team_name: "Zero Knowledge Labs",
+    submission_title: "ZKident",
+    avg_score: 94,
+    judge_count: 3,
+  },
+  {
+    rank: 2,
+    team_id: "ht4",
+    team_name: "DeFi Degen Squad",
+    submission_title: "YieldMax Protocol",
+    avg_score: 88,
+    judge_count: 3,
   },
 ];
 

--- a/frontend/src/routes/_app.hackathons.$hackathonId.tsx
+++ b/frontend/src/routes/_app.hackathons.$hackathonId.tsx
@@ -1,26 +1,21 @@
 import { useState } from "react";
-import { createFileRoute, notFound, Link } from "@tanstack/react-router";
-import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, notFound } from "@tanstack/react-router";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { hackathonsService } from "@/services";
-import { Card, TagChip, EmptyState, Skeleton } from "@/components/shared/primitives";
-import {
-  ArrowLeft,
-  Trophy,
-  Users2,
-  Clock,
-  Calendar,
-  Award,
-  GitBranch,
-  ExternalLink,
-} from "lucide-react";
+import { Card, TagChip, Skeleton, EmptyState } from "@/components/shared/primitives";
+import { Trophy, Users2, Calendar, ExternalLink, CheckCircle2, Award, GitBranch } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { BackButton } from "@/components/shared/BackButton";
+import { RegisterDialog } from "@/components/hackathons/RegisterDialog";
+import { TeamsTab } from "@/components/hackathons/TeamsTab";
+import { SubmissionsTab } from "@/components/hackathons/SubmissionsTab";
+import { LeaderboardTab } from "@/components/hackathons/LeaderboardTab";
 
 type Tab = "overview" | "teams" | "submissions" | "leaderboard";
 
-function getTabFromURL(): Tab {
-  const params = new URLSearchParams(window.location.search);
-  const tab = params.get("tab");
+function getInitialTab(): Tab {
+  if (typeof window === "undefined") return "overview";
+  const tab = new URLSearchParams(window.location.search).get("tab");
   if (tab === "overview" || tab === "teams" || tab === "submissions" || tab === "leaderboard")
     return tab;
   return "overview";
@@ -36,47 +31,69 @@ export const Route = createFileRoute("/_app/hackathons/$hackathonId")({
   component: HackathonDetail,
 });
 
+const STATUS_META: Record<string, { label: string; className: string }> = {
+  draft: { label: "Draft", className: "border-border bg-muted text-muted-foreground" },
+  registration_open: { label: "Registration open", className: "border-success/30 bg-success/10 text-success" },
+  in_progress: { label: "In progress", className: "border-primary/30 bg-primary/10 text-primary" },
+  judging: { label: "Judging", className: "border-warning/30 bg-warning/10 text-warning" },
+  completed: { label: "Completed", className: "border-border bg-muted text-muted-foreground" },
+  cancelled: { label: "Cancelled", className: "border-destructive/30 bg-destructive/10 text-destructive" },
+};
+
 function HackathonDetail() {
   const { hackathonId } = Route.useParams();
+  const queryClient = useQueryClient();
+  const [tab, setTab] = useState<Tab>(getInitialTab);
+  const [registerOpen, setRegisterOpen] = useState(false);
+  // Track registration locally — persists as long as user stays on page
+  const [registered, setRegistered] = useState(() =>
+    hackathonsService.isRegistered(hackathonId),
+  );
+
   const { data: hackathon, isLoading } = useQuery({
     queryKey: ["hackathon", hackathonId],
     queryFn: () => hackathonsService.get(hackathonId),
   });
+
   const { data: teams = [] } = useQuery({
     queryKey: ["hackathon-teams", hackathonId],
     queryFn: () => hackathonsService.getTeams(hackathonId),
     enabled: !!hackathonId,
   });
-  const [tab, setTab] = useState<Tab>(getTabFromURL);
 
-  const handleTabChange = (value: string) => {
+  function handleTabChange(value: string) {
     setTab(value as Tab);
-    const url = new URL(window.location.href);
-    url.searchParams.set("tab", value);
-    window.history.replaceState({}, "", url.toString());
-  };
+    if (typeof window !== "undefined") {
+      const url = new URL(window.location.href);
+      url.searchParams.set("tab", value);
+      window.history.replaceState({}, "", url.toString());
+    }
+  }
 
+  function handleRegistered() {
+    setRegistered(true);
+    setRegisterOpen(false);
+    queryClient.invalidateQueries({ queryKey: ["hackathon", hackathonId] });
+  }
+
+  // ── Loading ──────────────────────────────────────────────────────────────
   if (isLoading) {
     return (
-      <div className="space-y-4" role="status" aria-busy="true">
+      <div className="space-y-4" aria-busy="true">
         <Skeleton className="h-5 w-32" />
-        <Card className="p-4">
-          <div className="flex flex-wrap items-start gap-5">
-            <Skeleton className="h-24 w-24 shrink-0 rounded-full" />
-            <div className="min-w-0 flex-1">
-              <Skeleton className="h-7 w-40" />
+        <Card className="p-6">
+          <div className="flex flex-wrap gap-5">
+            <Skeleton className="h-20 w-20 shrink-0 rounded-xl" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-7 w-48" />
               <Skeleton className="h-4 w-32" />
-              <Skeleton className="mt-2 h-4 w-64" />
-              <Skeleton className="mt-2 h-3 w-28" />
+              <Skeleton className="h-4 w-64" />
             </div>
           </div>
         </Card>
-        <div className="grid gap-3 lg:grid-cols-3">
+        <div className="grid gap-3 sm:grid-cols-3">
           {[1, 2, 3].map((i) => (
-            <Card key={i} className="p-4">
-              <Skeleton className="h-4 w-24" />
-              <Skeleton className="mt-2 h-9 w-16" />
-            </Card>
+            <Card key={i} className="h-20 animate-pulse" />
           ))}
         </div>
       </div>
@@ -85,168 +102,206 @@ function HackathonDetail() {
 
   if (!hackathon) throw notFound();
 
-  const formatDate = (d: string) =>
+  const fmt = (d: string) =>
     new Date(d).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+
+  const statusMeta = STATUS_META[hackathon.status] ?? {
+    label: hackathon.status.replace(/_/g, " "),
+    className: "border-border bg-muted text-muted-foreground",
+  };
+  const canRegister = !registered && hackathon.status !== "completed" && hackathon.status !== "cancelled";
 
   return (
     <div className="space-y-4">
       <BackButton to="/hackathons" label="Back to hackathons" />
 
-      <Card className="p-4">
-        <div className="flex flex-wrap items-start gap-5">
-          <span className="grid h-24 w-24 shrink-0 place-items-center rounded-lg bg-primary-soft text-primary">
-            <Trophy size={32} />
+      {/* Hero */}
+      <Card className="p-4 sm:p-6">
+        <div className="flex flex-wrap items-start gap-4">
+          <span className="grid h-16 w-16 shrink-0 place-items-center rounded-xl bg-primary-soft text-primary">
+            <Trophy size={28} />
           </span>
+
           <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2">
-              <h1 className="text-[22px] font-bold text-foreground">{hackathon.name}</h1>
-              <TagChip
-                className={
-                  hackathon.status === "completed"
-                    ? "text-muted-foreground border-border bg-muted"
-                    : "text-primary border-primary/30 bg-primary/10"
-                }
-              >
-                {hackathon.status.replace("_", " ")}
-              </TagChip>
+            <div className="flex flex-wrap items-center gap-2">
+              <h1 className="text-[20px] font-bold text-foreground sm:text-[22px]">
+                {hackathon.name}
+              </h1>
+              <TagChip className={statusMeta.className}>{statusMeta.label}</TagChip>
             </div>
             {hackathon.theme && (
               <p className="mt-0.5 text-[13px] text-muted-foreground">{hackathon.theme}</p>
             )}
-            <p className="mt-2 text-[13px] text-foreground line-clamp-3">{hackathon.description}</p>
+            <p className="mt-2 line-clamp-3 text-[13px] text-foreground/80">
+              {hackathon.description}
+            </p>
             <div className="mt-3 flex flex-wrap gap-3 text-[12px] text-muted-foreground">
               <span className="inline-flex items-center gap-1">
-                <Calendar size={12} /> {formatDate(hackathon.starts_at)} —{" "}
-                {formatDate(hackathon.ends_at)}
+                <Calendar size={12} />
+                {fmt(hackathon.starts_at)} — {fmt(hackathon.ends_at)}
               </span>
               <span className="inline-flex items-center gap-1">
-                <Users2 size={12} /> {hackathon.min_team_size}–{hackathon.max_team_size} per team
+                <Users2 size={12} />
+                {hackathon.min_team_size}–{hackathon.max_team_size} per team
               </span>
               {hackathon.prize && (
-                <TagChip className="text-warning border-warning/30 bg-warning/10">
-                  {hackathon.prize}
+                <TagChip className="border-warning/30 bg-warning/10 text-warning">
+                  🏆 {hackathon.prize}
                 </TagChip>
               )}
             </div>
           </div>
-          <div className="flex gap-2">
-            <button className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 text-[13px] font-semibold text-primary-foreground hover:opacity-90">
-              Register
-            </button>
+
+          {/* Actions */}
+          <div className="flex shrink-0 flex-wrap items-start gap-2">
+            {registered ? (
+              <span className="inline-flex items-center gap-1.5 rounded-md border border-success/30 bg-success/10 px-3 py-2 text-[13px] font-semibold text-success">
+                <CheckCircle2 size={14} /> Registered
+              </span>
+            ) : canRegister ? (
+              <button
+                onClick={() => setRegisterOpen(true)}
+                className="rounded-md bg-primary px-4 py-2 text-[13px] font-semibold text-primary-foreground hover:opacity-90"
+              >
+                Register now
+              </button>
+            ) : null}
+            {hackathon.website_url && (
+              <a
+                href={hackathon.website_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-2 text-[13px] font-medium text-foreground hover:bg-muted"
+              >
+                <ExternalLink size={13} /> Website
+              </a>
+            )}
           </div>
         </div>
       </Card>
 
-      <div className="grid gap-3 lg:grid-cols-3">
+      {/* Stats */}
+      <div className="grid gap-3 sm:grid-cols-3">
         <Card className="p-4">
-          <p className="text-[13px] font-semibold text-foreground">Status</p>
-          <p className="mt-2 text-[24px] font-bold capitalize text-foreground">
-            {hackathon.status.replace("_", " ")}
+          <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Status</p>
+          <p className="mt-1 text-[18px] font-bold capitalize text-foreground">
+            {hackathon.status.replace(/_/g, " ")}
           </p>
         </Card>
         <Card className="p-4">
-          <p className="text-[13px] font-semibold text-foreground">Teams</p>
-          <p className="mt-2 text-[24px] font-bold text-foreground">{teams.length}</p>
+          <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Teams</p>
+          <p className="mt-1 text-[18px] font-bold text-foreground">{teams.length}</p>
         </Card>
         <Card className="p-4">
-          <p className="text-[13px] font-semibold text-foreground">Team Size</p>
-          <p className="mt-2 text-[24px] font-bold text-foreground">
+          <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Team size</p>
+          <p className="mt-1 text-[18px] font-bold text-foreground">
             {hackathon.min_team_size}–{hackathon.max_team_size}
           </p>
         </Card>
       </div>
 
+      {/* Tabs */}
       <Tabs value={tab} onValueChange={handleTabChange}>
-        <TabsList className="overflow-x-auto">
+        <TabsList className="w-full overflow-x-auto sm:w-auto">
           <TabsTrigger value="overview">Overview</TabsTrigger>
-          <TabsTrigger value="teams">Teams</TabsTrigger>
+          <TabsTrigger value="teams">
+            Teams
+            {teams.length > 0 && (
+              <span className="ml-1.5 rounded-full bg-primary/15 px-1.5 py-0.5 text-[10px] font-bold text-primary">
+                {teams.length}
+              </span>
+            )}
+          </TabsTrigger>
           <TabsTrigger value="submissions">Submissions</TabsTrigger>
           <TabsTrigger value="leaderboard">Leaderboard</TabsTrigger>
         </TabsList>
 
-        <TabsContent value="overview">
+        {/* ── Overview ── */}
+        <TabsContent value="overview" className="mt-3 space-y-3">
           <Card className="p-4">
-            <p className="text-[13px] font-semibold text-foreground">About</p>
-            <p className="mt-2 text-[13px] text-muted-foreground whitespace-pre-wrap">
+            <h2 className="text-[13px] font-semibold text-foreground">About this hackathon</h2>
+            <p className="mt-2 whitespace-pre-wrap text-[13px] leading-relaxed text-muted-foreground">
               {hackathon.description}
             </p>
           </Card>
-          {hackathon.website_url && (
-            <Card className="mt-3 p-4">
-              <a
-                href={hackathon.website_url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 text-[13px] font-medium text-primary hover:underline"
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Card className="p-4">
+              <h2 className="text-[13px] font-semibold text-foreground">Schedule</h2>
+              <dl className="mt-2 space-y-2 text-[13px]">
+                <div className="flex items-center justify-between gap-2">
+                  <dt className="text-muted-foreground">Starts</dt>
+                  <dd className="font-medium text-foreground">{fmt(hackathon.starts_at)}</dd>
+                </div>
+                <div className="flex items-center justify-between gap-2">
+                  <dt className="text-muted-foreground">Ends</dt>
+                  <dd className="font-medium text-foreground">{fmt(hackathon.ends_at)}</dd>
+                </div>
+              </dl>
+            </Card>
+            <Card className="p-4">
+              <h2 className="text-[13px] font-semibold text-foreground">Team rules</h2>
+              <dl className="mt-2 space-y-2 text-[13px]">
+                <div className="flex items-center justify-between gap-2">
+                  <dt className="text-muted-foreground">Minimum</dt>
+                  <dd className="font-medium text-foreground">{hackathon.min_team_size} member{hackathon.min_team_size !== 1 ? "s" : ""}</dd>
+                </div>
+                <div className="flex items-center justify-between gap-2">
+                  <dt className="text-muted-foreground">Maximum</dt>
+                  <dd className="font-medium text-foreground">{hackathon.max_team_size} members</dd>
+                </div>
+                {hackathon.prize && (
+                  <div className="flex items-center justify-between gap-2">
+                    <dt className="text-muted-foreground">Prize pool</dt>
+                    <dd className="font-medium text-warning">{hackathon.prize}</dd>
+                  </div>
+                )}
+              </dl>
+            </Card>
+          </div>
+
+          {!registered && canRegister && (
+            <Card className="flex items-center justify-between gap-4 p-4">
+              <div>
+                <p className="text-[13px] font-semibold text-foreground">Ready to join?</p>
+                <p className="text-[12px] text-muted-foreground">
+                  Register to form or join a team and submit your project.
+                </p>
+              </div>
+              <button
+                onClick={() => setRegisterOpen(true)}
+                className="shrink-0 rounded-md bg-primary px-4 py-2 text-[13px] font-semibold text-primary-foreground hover:opacity-90"
               >
-                <ExternalLink size={14} /> Visit website
-              </a>
+                Register now
+              </button>
             </Card>
           )}
         </TabsContent>
 
-        <TabsContent value="teams">
-          {teams.length === 0 ? (
-            <Card className="p-8">
-              <EmptyState
-                title="No teams yet"
-                desc="Be the first to create a team for this hackathon."
-                action={<Users2 size={20} className="text-muted-foreground" />}
-              />
-            </Card>
-          ) : (
-            <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
-              {teams.map((team) => (
-                <Card key={team.id} interactive className="p-4">
-                  <div className="flex items-start gap-3">
-                    <span className="grid h-10 w-10 shrink-0 place-items-center rounded-md bg-muted text-xl">
-                      <Users2 size={16} />
-                    </span>
-                    <div className="min-w-0 flex-1">
-                      <p className="truncate text-[14px] font-semibold text-foreground">
-                        {team.name}
-                      </p>
-                      {team.description && (
-                        <p className="mt-0.5 line-clamp-2 text-[12px] text-muted-foreground">
-                          {team.description}
-                        </p>
-                      )}
-                    </div>
-                  </div>
-                  <div className="mt-3 flex items-center justify-between text-[11px] text-muted-foreground">
-                    <span className="inline-flex items-center gap-1">
-                      <Users2 size={12} /> {team.member_count} members
-                    </span>
-                    <button className="rounded-md border border-border px-2 py-1 text-[11px] font-medium hover:bg-muted">
-                      Join
-                    </button>
-                  </div>
-                </Card>
-              ))}
-            </div>
-          )}
+        {/* ── Teams ── */}
+        <TabsContent value="teams" className="mt-3">
+          <TeamsTab hackathonId={hackathonId} maxTeamSize={hackathon.max_team_size} />
         </TabsContent>
 
-        <TabsContent value="submissions">
-          <Card className="p-8">
-            <EmptyState
-              title="No submissions yet"
-              desc="Submissions will appear here once teams start shipping."
-              action={<GitBranch size={20} className="text-muted-foreground" />}
-            />
-          </Card>
+        {/* ── Submissions ── */}
+        <TabsContent value="submissions" className="mt-3">
+          <SubmissionsTab hackathonId={hackathonId} teams={teams} />
         </TabsContent>
 
-        <TabsContent value="leaderboard">
-          <Card className="p-8">
-            <EmptyState
-              title="No scores yet"
-              desc="The leaderboard will be populated after judging begins."
-              action={<Award size={20} className="text-muted-foreground" />}
-            />
-          </Card>
+        {/* ── Leaderboard ── */}
+        <TabsContent value="leaderboard" className="mt-3">
+          <LeaderboardTab hackathonId={hackathonId} />
         </TabsContent>
       </Tabs>
+
+      {/* Register dialog */}
+      <RegisterDialog
+        hackathonId={hackathonId}
+        hackathonName={hackathon.name}
+        open={registerOpen}
+        onOpenChange={setRegisterOpen}
+        onRegistered={handleRegistered}
+      />
     </div>
   );
 }

--- a/frontend/src/routes/_app.hackathons.$hackathonId.tsx
+++ b/frontend/src/routes/_app.hackathons.$hackathonId.tsx
@@ -2,14 +2,15 @@ import { useState } from "react";
 import { createFileRoute, notFound } from "@tanstack/react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { hackathonsService } from "@/services";
-import { Card, TagChip, Skeleton, EmptyState } from "@/components/shared/primitives";
-import { Trophy, Users2, Calendar, ExternalLink, CheckCircle2, Award, GitBranch } from "lucide-react";
+import { Card, TagChip, Skeleton } from "@/components/shared/primitives";
+import { Trophy, Users2, Calendar, ExternalLink, CheckCircle2 } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { BackButton } from "@/components/shared/BackButton";
 import { RegisterDialog } from "@/components/hackathons/RegisterDialog";
 import { TeamsTab } from "@/components/hackathons/TeamsTab";
 import { SubmissionsTab } from "@/components/hackathons/SubmissionsTab";
 import { LeaderboardTab } from "@/components/hackathons/LeaderboardTab";
+import { cn } from "@/lib/utils";
 
 type Tab = "overview" | "teams" | "submissions" | "leaderboard";
 
@@ -31,21 +32,11 @@ export const Route = createFileRoute("/_app/hackathons/$hackathonId")({
   component: HackathonDetail,
 });
 
-const STATUS_META: Record<string, { label: string; className: string }> = {
-  draft: { label: "Draft", className: "border-border bg-muted text-muted-foreground" },
-  registration_open: { label: "Registration open", className: "border-success/30 bg-success/10 text-success" },
-  in_progress: { label: "In progress", className: "border-primary/30 bg-primary/10 text-primary" },
-  judging: { label: "Judging", className: "border-warning/30 bg-warning/10 text-warning" },
-  completed: { label: "Completed", className: "border-border bg-muted text-muted-foreground" },
-  cancelled: { label: "Cancelled", className: "border-destructive/30 bg-destructive/10 text-destructive" },
-};
-
 function HackathonDetail() {
   const { hackathonId } = Route.useParams();
   const queryClient = useQueryClient();
   const [tab, setTab] = useState<Tab>(getInitialTab);
   const [registerOpen, setRegisterOpen] = useState(false);
-  // Track registration locally — persists as long as user stays on page
   const [registered, setRegistered] = useState(() =>
     hackathonsService.isRegistered(hackathonId),
   );
@@ -76,24 +67,27 @@ function HackathonDetail() {
     queryClient.invalidateQueries({ queryKey: ["hackathon", hackathonId] });
   }
 
-  // ── Loading ──────────────────────────────────────────────────────────────
   if (isLoading) {
     return (
-      <div className="space-y-4" aria-busy="true">
+      <div className="space-y-4" role="status" aria-busy="true">
         <Skeleton className="h-5 w-32" />
-        <Card className="p-6">
-          <div className="flex flex-wrap gap-5">
-            <Skeleton className="h-20 w-20 shrink-0 rounded-xl" />
-            <div className="flex-1 space-y-2">
-              <Skeleton className="h-7 w-48" />
+        <Card className="p-4">
+          <div className="flex flex-wrap items-start gap-5">
+            <Skeleton className="h-24 w-24 shrink-0 rounded-full" />
+            <div className="min-w-0 flex-1">
+              <Skeleton className="h-7 w-40" />
               <Skeleton className="h-4 w-32" />
-              <Skeleton className="h-4 w-64" />
+              <Skeleton className="mt-2 h-4 w-64" />
+              <Skeleton className="mt-2 h-3 w-28" />
             </div>
           </div>
         </Card>
-        <div className="grid gap-3 sm:grid-cols-3">
+        <div className="grid gap-3 lg:grid-cols-3">
           {[1, 2, 3].map((i) => (
-            <Card key={i} className="h-20 animate-pulse" />
+            <Card key={i} className="p-4">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="mt-2 h-9 w-16" />
+            </Card>
           ))}
         </div>
       </div>
@@ -102,58 +96,64 @@ function HackathonDetail() {
 
   if (!hackathon) throw notFound();
 
-  const fmt = (d: string) =>
+  const formatDate = (d: string) =>
     new Date(d).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
 
-  const statusMeta = STATUS_META[hackathon.status] ?? {
-    label: hackathon.status.replace(/_/g, " "),
-    className: "border-border bg-muted text-muted-foreground",
-  };
-  const canRegister = !registered && hackathon.status !== "completed" && hackathon.status !== "cancelled";
+  const canRegister =
+    !registered &&
+    hackathon.status !== "completed" &&
+    hackathon.status !== "cancelled";
 
   return (
     <div className="space-y-4">
       <BackButton to="/hackathons" label="Back to hackathons" />
 
-      {/* Hero */}
-      <Card className="p-4 sm:p-6">
-        <div className="flex flex-wrap items-start gap-4">
-          <span className="grid h-16 w-16 shrink-0 place-items-center rounded-xl bg-primary-soft text-primary">
-            <Trophy size={28} />
+      <Card className="p-4">
+        <div className="flex flex-wrap items-start gap-5">
+          <span className="grid h-24 w-24 shrink-0 place-items-center rounded-full bg-muted text-4xl">
+            🏆
           </span>
-
           <div className="min-w-0 flex-1">
-            <div className="flex flex-wrap items-center gap-2">
-              <h1 className="text-[20px] font-bold text-foreground sm:text-[22px]">
-                {hackathon.name}
-              </h1>
-              <TagChip className={statusMeta.className}>{statusMeta.label}</TagChip>
+            <div className="flex items-center gap-2">
+              <h1 className="text-[22px] font-bold text-foreground">{hackathon.name}</h1>
+              <TagChip
+                className={cn(
+                  hackathon.status === "registration_open"
+                    ? "border-success/30 bg-success/10 text-success"
+                    : hackathon.status === "in_progress"
+                      ? "border-primary/30 bg-primary/10 text-primary"
+                      : hackathon.status === "judging"
+                        ? "border-warning/30 bg-warning/10 text-warning"
+                        : hackathon.status === "completed"
+                          ? "border-success/30 bg-success/10 text-success"
+                          : "border-border bg-muted text-muted-foreground",
+                )}
+              >
+                {hackathon.status.replace(/_/g, " ")}
+              </TagChip>
             </div>
             {hackathon.theme && (
               <p className="mt-0.5 text-[13px] text-muted-foreground">{hackathon.theme}</p>
             )}
-            <p className="mt-2 line-clamp-3 text-[13px] text-foreground/80">
+            <p className="mt-2 text-[13px] text-foreground line-clamp-3">
               {hackathon.description}
             </p>
             <div className="mt-3 flex flex-wrap gap-3 text-[12px] text-muted-foreground">
               <span className="inline-flex items-center gap-1">
-                <Calendar size={12} />
-                {fmt(hackathon.starts_at)} — {fmt(hackathon.ends_at)}
+                <Calendar size={12} /> {formatDate(hackathon.starts_at)} —{" "}
+                {formatDate(hackathon.ends_at)}
               </span>
               <span className="inline-flex items-center gap-1">
-                <Users2 size={12} />
-                {hackathon.min_team_size}–{hackathon.max_team_size} per team
+                <Users2 size={12} /> {hackathon.min_team_size}–{hackathon.max_team_size} per team
               </span>
               {hackathon.prize && (
                 <TagChip className="border-warning/30 bg-warning/10 text-warning">
-                  🏆 {hackathon.prize}
+                  {hackathon.prize}
                 </TagChip>
               )}
             </div>
           </div>
-
-          {/* Actions */}
-          <div className="flex shrink-0 flex-wrap items-start gap-2">
+          <div className="flex gap-2">
             {registered ? (
               <span className="inline-flex items-center gap-1.5 rounded-md border border-success/30 bg-success/10 px-3 py-2 text-[13px] font-semibold text-success">
                 <CheckCircle2 size={14} /> Registered
@@ -161,9 +161,9 @@ function HackathonDetail() {
             ) : canRegister ? (
               <button
                 onClick={() => setRegisterOpen(true)}
-                className="rounded-md bg-primary px-4 py-2 text-[13px] font-semibold text-primary-foreground hover:opacity-90"
+                className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 text-[13px] font-semibold text-primary-foreground hover:opacity-90"
               >
-                Register now
+                Register
               </button>
             ) : null}
             {hackathon.website_url && (
@@ -180,29 +180,27 @@ function HackathonDetail() {
         </div>
       </Card>
 
-      {/* Stats */}
-      <div className="grid gap-3 sm:grid-cols-3">
+      <div className="grid gap-3 lg:grid-cols-3">
         <Card className="p-4">
-          <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Status</p>
-          <p className="mt-1 text-[18px] font-bold capitalize text-foreground">
+          <p className="text-[13px] font-semibold text-foreground">Status</p>
+          <p className="mt-2 text-[24px] font-bold capitalize text-foreground">
             {hackathon.status.replace(/_/g, " ")}
           </p>
         </Card>
         <Card className="p-4">
-          <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Teams</p>
-          <p className="mt-1 text-[18px] font-bold text-foreground">{teams.length}</p>
+          <p className="text-[13px] font-semibold text-foreground">Teams</p>
+          <p className="mt-2 text-[24px] font-bold text-foreground">{teams.length}</p>
         </Card>
         <Card className="p-4">
-          <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Team size</p>
-          <p className="mt-1 text-[18px] font-bold text-foreground">
+          <p className="text-[13px] font-semibold text-foreground">Team Size</p>
+          <p className="mt-2 text-[24px] font-bold text-foreground">
             {hackathon.min_team_size}–{hackathon.max_team_size}
           </p>
         </Card>
       </div>
 
-      {/* Tabs */}
       <Tabs value={tab} onValueChange={handleTabChange}>
-        <TabsList className="w-full overflow-x-auto sm:w-auto">
+        <TabsList className="overflow-x-auto">
           <TabsTrigger value="overview">Overview</TabsTrigger>
           <TabsTrigger value="teams">
             Teams
@@ -216,85 +214,40 @@ function HackathonDetail() {
           <TabsTrigger value="leaderboard">Leaderboard</TabsTrigger>
         </TabsList>
 
-        {/* ── Overview ── */}
-        <TabsContent value="overview" className="mt-3 space-y-3">
+        <TabsContent value="overview">
           <Card className="p-4">
-            <h2 className="text-[13px] font-semibold text-foreground">About this hackathon</h2>
-            <p className="mt-2 whitespace-pre-wrap text-[13px] leading-relaxed text-muted-foreground">
+            <p className="text-[13px] font-semibold text-foreground">About</p>
+            <p className="mt-2 text-[13px] text-muted-foreground whitespace-pre-wrap">
               {hackathon.description}
             </p>
           </Card>
-
-          <div className="grid gap-3 sm:grid-cols-2">
-            <Card className="p-4">
-              <h2 className="text-[13px] font-semibold text-foreground">Schedule</h2>
-              <dl className="mt-2 space-y-2 text-[13px]">
-                <div className="flex items-center justify-between gap-2">
-                  <dt className="text-muted-foreground">Starts</dt>
-                  <dd className="font-medium text-foreground">{fmt(hackathon.starts_at)}</dd>
-                </div>
-                <div className="flex items-center justify-between gap-2">
-                  <dt className="text-muted-foreground">Ends</dt>
-                  <dd className="font-medium text-foreground">{fmt(hackathon.ends_at)}</dd>
-                </div>
-              </dl>
-            </Card>
-            <Card className="p-4">
-              <h2 className="text-[13px] font-semibold text-foreground">Team rules</h2>
-              <dl className="mt-2 space-y-2 text-[13px]">
-                <div className="flex items-center justify-between gap-2">
-                  <dt className="text-muted-foreground">Minimum</dt>
-                  <dd className="font-medium text-foreground">{hackathon.min_team_size} member{hackathon.min_team_size !== 1 ? "s" : ""}</dd>
-                </div>
-                <div className="flex items-center justify-between gap-2">
-                  <dt className="text-muted-foreground">Maximum</dt>
-                  <dd className="font-medium text-foreground">{hackathon.max_team_size} members</dd>
-                </div>
-                {hackathon.prize && (
-                  <div className="flex items-center justify-between gap-2">
-                    <dt className="text-muted-foreground">Prize pool</dt>
-                    <dd className="font-medium text-warning">{hackathon.prize}</dd>
-                  </div>
-                )}
-              </dl>
-            </Card>
-          </div>
-
-          {!registered && canRegister && (
-            <Card className="flex items-center justify-between gap-4 p-4">
-              <div>
-                <p className="text-[13px] font-semibold text-foreground">Ready to join?</p>
-                <p className="text-[12px] text-muted-foreground">
-                  Register to form or join a team and submit your project.
-                </p>
-              </div>
-              <button
-                onClick={() => setRegisterOpen(true)}
-                className="shrink-0 rounded-md bg-primary px-4 py-2 text-[13px] font-semibold text-primary-foreground hover:opacity-90"
+          {hackathon.website_url && (
+            <Card className="mt-3 p-4">
+              <a
+                href={hackathon.website_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 text-[13px] font-medium text-primary hover:underline"
               >
-                Register now
-              </button>
+                <ExternalLink size={14} /> Visit website
+              </a>
             </Card>
           )}
         </TabsContent>
 
-        {/* ── Teams ── */}
-        <TabsContent value="teams" className="mt-3">
+        <TabsContent value="teams">
           <TeamsTab hackathonId={hackathonId} maxTeamSize={hackathon.max_team_size} />
         </TabsContent>
 
-        {/* ── Submissions ── */}
-        <TabsContent value="submissions" className="mt-3">
+        <TabsContent value="submissions">
           <SubmissionsTab hackathonId={hackathonId} teams={teams} />
         </TabsContent>
 
-        {/* ── Leaderboard ── */}
-        <TabsContent value="leaderboard" className="mt-3">
+        <TabsContent value="leaderboard">
           <LeaderboardTab hackathonId={hackathonId} />
         </TabsContent>
       </Tabs>
 
-      {/* Register dialog */}
       <RegisterDialog
         hackathonId={hackathonId}
         hackathonName={hackathon.name}

--- a/frontend/src/routes/_app.hackathons.tsx
+++ b/frontend/src/routes/_app.hackathons.tsx
@@ -1,10 +1,11 @@
-import { createFileRoute, Link, Outlet, useRouterState } from "@tanstack/react-router";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, Outlet, useRouterState, Link } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
 import { hackathonsService } from "@/services";
-import { Card, TagChip, Skeleton } from "@/components/shared/primitives";
-import { Trophy, Users2, Clock, Plus, ArrowRight } from "lucide-react";
+import { Card, TagChip } from "@/components/shared/primitives";
+import { Trophy, Users2, Clock, Plus } from "lucide-react";
 import { useState } from "react";
 import { CreateHackathonDialog } from "@/components/hackathons/CreateHackathonDialog";
+import { cn } from "@/lib/utils";
 
 export const Route = createFileRoute("/_app/hackathons")({
   head: () => ({
@@ -13,32 +14,11 @@ export const Route = createFileRoute("/_app/hackathons")({
       { name: "description", content: "Discover hackathons, form teams and ship in a weekend." },
     ],
   }),
-  component: HackathonsLayout,
+  component: HackathonsPage,
 });
 
-const STATUS_COLOR: Record<string, string> = {
-  registration_open: "text-success border-success/30 bg-success/10",
-  in_progress: "text-primary border-primary/30 bg-primary/10",
-  judging: "text-warning border-warning/30 bg-warning/10",
-  completed: "text-muted-foreground border-border bg-muted",
-  cancelled: "text-destructive border-destructive/30 bg-destructive/10",
-  draft: "text-muted-foreground border-border bg-muted",
-};
-
-// Layout component — shows list on /hackathons, delegates child routes via Outlet
-function HackathonsLayout() {
-  const pathname = useRouterState({ select: (s) => s.location.pathname });
-
-  // If we're on a child route (e.g. /hackathons/h1), render the child
-  if (pathname !== "/hackathons" && !pathname.endsWith("/hackathons")) {
-    return <Outlet />;
-  }
-
-  return <HackathonsList />;
-}
-
-function HackathonsList() {
-  const queryClient = useQueryClient();
+function HackathonsPage() {
+  const pathname = useRouterState({ select: (state) => state.location.pathname });
   const [createOpen, setCreateOpen] = useState(false);
 
   const { data = [], isLoading } = useQuery({
@@ -46,122 +26,110 @@ function HackathonsList() {
     queryFn: hackathonsService.list,
   });
 
+  if (pathname !== "/hackathons" && pathname !== "/hackathons/") {
+    return <Outlet />;
+  }
+
   const formatDate = (d: string) =>
-    new Date(d).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    new Date(d).toLocaleDateString("en-US", { month: "short", day: "numeric" });
 
   return (
     <div className="space-y-4">
-      {/* Header */}
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <h1 className="text-[22px] font-bold tracking-tight text-foreground">Hackathons</h1>
           <p className="text-[13px] text-muted-foreground">
-            Join a jam, build a team, and ship something new.
+            Join a jam, build a team, ship something new.
           </p>
         </div>
         <button
           onClick={() => setCreateOpen(true)}
           className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 text-[13px] font-semibold text-primary-foreground hover:opacity-90"
         >
-          <Plus size={14} /> Create hackathon
+          <Plus size={14} /> New hackathon
         </button>
+        <CreateHackathonDialog open={createOpen} onOpenChange={setCreateOpen} />
       </div>
 
-      {/* Loading skeletons */}
-      {isLoading && (
+      {isLoading ? (
         <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
-          {[1, 2, 3].map((i) => (
-            <Card key={i} className="h-52 animate-pulse" />
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Card key={i} className="h-40 animate-pulse" />
           ))}
         </div>
-      )}
-
-      {/* Empty state */}
-      {!isLoading && data.length === 0 && (
-        <Card className="p-12 text-center">
-          <div className="mx-auto mb-3 grid h-12 w-12 place-items-center rounded-2xl bg-primary-soft text-primary">
-            <Trophy size={22} />
+      ) : data.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <div className="mb-3 grid h-12 w-12 place-items-center rounded-full bg-muted text-muted-foreground">
+            🏆
           </div>
           <p className="text-[14px] font-semibold text-foreground">No hackathons yet</p>
-          <p className="mt-1 text-[13px] text-muted-foreground">Be the first to create one.</p>
+          <p className="mt-1 text-[13px] text-muted-foreground">
+            Be the first to create one.
+          </p>
           <button
             onClick={() => setCreateOpen(true)}
-            className="mt-4 inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 text-[13px] font-semibold text-primary-foreground hover:opacity-90"
+            className="mt-3 text-[13px] font-medium text-primary hover:underline"
           >
-            <Plus size={14} /> Create hackathon
+            Create hackathon
           </button>
-        </Card>
-      )}
-
-      {/* Hackathon cards */}
-      {!isLoading && data.length > 0 && (
+        </div>
+      ) : (
         <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
           {data.map((h) => (
             <Link
               key={h.id}
               to="/hackathons/$hackathonId"
               params={{ hackathonId: h.id }}
-              className="block rounded-2xl focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+              className="block"
             >
-              <Card interactive className="flex h-full flex-col p-4">
-                {/* Top row */}
-                <div className="flex items-start justify-between gap-2">
-                  <span className="grid h-10 w-10 shrink-0 place-items-center rounded-md bg-primary-soft text-primary">
-                    <Trophy size={16} />
+              <Card interactive className="p-4">
+                <div className="flex items-start gap-3">
+                  <span className="grid h-10 w-10 shrink-0 place-items-center rounded-md bg-muted text-xl">
+                    🏆
                   </span>
-                  <TagChip className={STATUS_COLOR[h.status] ?? STATUS_COLOR.draft}>
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-[14px] font-semibold text-foreground">{h.name}</p>
+                    <p className="mt-0.5 line-clamp-2 text-[12px] text-muted-foreground">
+                      {h.description}
+                    </p>
+                  </div>
+                </div>
+                <div className="mt-3 flex flex-wrap gap-1">
+                  {h.theme && <TagChip>{h.theme}</TagChip>}
+                  <TagChip
+                    className={cn(
+                      h.status === "registration_open"
+                        ? "border-success/30 bg-success/10 text-success"
+                        : h.status === "in_progress"
+                          ? "border-primary/30 bg-primary/10 text-primary"
+                          : h.status === "judging"
+                            ? "border-warning/30 bg-warning/10 text-warning"
+                            : h.status === "completed"
+                              ? "border-success/30 bg-success/10 text-success"
+                              : "border-border bg-muted text-muted-foreground",
+                    )}
+                  >
                     {h.status.replace(/_/g, " ")}
                   </TagChip>
-                </div>
-
-                {/* Title + theme */}
-                <p className="mt-3 line-clamp-1 text-[15px] font-semibold text-foreground">
-                  {h.name}
-                </p>
-                {h.theme && (
-                  <p className="mt-0.5 line-clamp-1 text-[12px] text-muted-foreground">
-                    {h.theme}
-                  </p>
-                )}
-
-                {/* Description */}
-                <p className="mt-1.5 line-clamp-2 flex-1 text-[12px] text-muted-foreground">
-                  {h.description}
-                </p>
-
-                {/* Meta */}
-                <div className="mt-3 flex flex-wrap gap-2 text-[11px] text-muted-foreground">
-                  <span className="inline-flex items-center gap-1">
-                    <Clock size={11} /> {formatDate(h.starts_at)}
-                  </span>
-                  <span className="inline-flex items-center gap-1">
-                    <Users2 size={11} /> {h.min_team_size}–{h.max_team_size}
-                  </span>
                   {h.prize && (
                     <TagChip className="border-warning/30 bg-warning/10 text-warning">
-                      🏆 {h.prize}
+                      {h.prize}
                     </TagChip>
                   )}
                 </div>
-
-                {/* Footer */}
-                <div className="mt-4 flex items-center justify-between border-t border-border/60 pt-3">
-                  <span className="text-[12px] font-medium text-primary">View details</span>
-                  <ArrowRight size={13} className="text-primary" />
+                <div className="mt-3 flex items-center justify-between text-[11px] text-muted-foreground">
+                  <span className="inline-flex items-center gap-1">
+                    <Clock size={12} /> {formatDate(h.starts_at)}
+                  </span>
+                  <span className="inline-flex items-center gap-1">
+                    <Users2 size={12} /> {h.min_team_size}–{h.max_team_size} members
+                  </span>
                 </div>
               </Card>
             </Link>
           ))}
         </div>
       )}
-
-      <CreateHackathonDialog
-        open={createOpen}
-        onOpenChange={(open) => {
-          setCreateOpen(open);
-          if (!open) queryClient.invalidateQueries({ queryKey: ["hackathons"] });
-        }}
-      />
     </div>
   );
 }

--- a/frontend/src/routes/_app.hackathons.tsx
+++ b/frontend/src/routes/_app.hackathons.tsx
@@ -1,8 +1,10 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
-import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, Link, Outlet, useRouterState } from "@tanstack/react-router";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { hackathonsService } from "@/services";
-import { Card, TagChip } from "@/components/shared/primitives";
-import { Trophy, Users2, Clock } from "lucide-react";
+import { Card, TagChip, Skeleton } from "@/components/shared/primitives";
+import { Trophy, Users2, Clock, Plus, ArrowRight } from "lucide-react";
+import { useState } from "react";
+import { CreateHackathonDialog } from "@/components/hackathons/CreateHackathonDialog";
 
 export const Route = createFileRoute("/_app/hackathons")({
   head: () => ({
@@ -11,63 +13,155 @@ export const Route = createFileRoute("/_app/hackathons")({
       { name: "description", content: "Discover hackathons, form teams and ship in a weekend." },
     ],
   }),
-  component: HackathonsPage,
+  component: HackathonsLayout,
 });
 
-function HackathonsPage() {
-  const { data = [] } = useQuery({ queryKey: ["hackathons"], queryFn: hackathonsService.list });
+const STATUS_COLOR: Record<string, string> = {
+  registration_open: "text-success border-success/30 bg-success/10",
+  in_progress: "text-primary border-primary/30 bg-primary/10",
+  judging: "text-warning border-warning/30 bg-warning/10",
+  completed: "text-muted-foreground border-border bg-muted",
+  cancelled: "text-destructive border-destructive/30 bg-destructive/10",
+  draft: "text-muted-foreground border-border bg-muted",
+};
+
+// Layout component — shows list on /hackathons, delegates child routes via Outlet
+function HackathonsLayout() {
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+
+  // If we're on a child route (e.g. /hackathons/h1), render the child
+  if (pathname !== "/hackathons" && !pathname.endsWith("/hackathons")) {
+    return <Outlet />;
+  }
+
+  return <HackathonsList />;
+}
+
+function HackathonsList() {
+  const queryClient = useQueryClient();
+  const [createOpen, setCreateOpen] = useState(false);
+
+  const { data = [], isLoading } = useQuery({
+    queryKey: ["hackathons"],
+    queryFn: hackathonsService.list,
+  });
 
   const formatDate = (d: string) =>
-    new Date(d).toLocaleDateString("en-US", { month: "short", day: "numeric" });
+    new Date(d).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
 
   return (
     <div className="space-y-4">
-      <div>
-        <h1 className="text-[22px] font-bold tracking-tight text-foreground">Hackathons</h1>
-        <p className="text-[13px] text-muted-foreground">
-          Join a jam, build a team, ship something new.
-        </p>
+      {/* Header */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-[22px] font-bold tracking-tight text-foreground">Hackathons</h1>
+          <p className="text-[13px] text-muted-foreground">
+            Join a jam, build a team, and ship something new.
+          </p>
+        </div>
+        <button
+          onClick={() => setCreateOpen(true)}
+          className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 text-[13px] font-semibold text-primary-foreground hover:opacity-90"
+        >
+          <Plus size={14} /> Create hackathon
+        </button>
       </div>
-      <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
-        {data.map((h) => (
-          <Link key={h.id} to="/hackathons/$hackathonId" params={{ hackathonId: h.id }}>
-            <Card interactive className="p-4">
-              <div className="flex items-start justify-between">
-                <span className="grid h-10 w-10 place-items-center rounded-md bg-primary-soft text-primary">
-                  <Trophy size={16} />
-                </span>
-                <TagChip
-                  className={
-                    h.status === "completed"
-                      ? "text-muted-foreground border-border bg-muted"
-                      : "text-primary border-primary/30 bg-primary/10"
-                  }
-                >
-                  {h.status.replace("_", " ")}
-                </TagChip>
-              </div>
-              <p className="mt-3 text-[15px] font-semibold text-foreground">{h.name}</p>
-              <p className="mt-0.5 text-[12px] text-muted-foreground">{h.theme}</p>
-              <div className="mt-3 flex flex-wrap gap-2 text-[11px] text-muted-foreground">
-                <span className="inline-flex items-center gap-1">
-                  <Clock size={11} /> {formatDate(h.starts_at)}
-                </span>
-                <span className="inline-flex items-center gap-1">
-                  <Users2 size={11} /> {h.min_team_size}–{h.max_team_size}
-                </span>
-                {h.prize && (
-                  <TagChip className="text-warning border-warning/30 bg-warning/10">
-                    {h.prize}
+
+      {/* Loading skeletons */}
+      {isLoading && (
+        <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+          {[1, 2, 3].map((i) => (
+            <Card key={i} className="h-52 animate-pulse" />
+          ))}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!isLoading && data.length === 0 && (
+        <Card className="p-12 text-center">
+          <div className="mx-auto mb-3 grid h-12 w-12 place-items-center rounded-2xl bg-primary-soft text-primary">
+            <Trophy size={22} />
+          </div>
+          <p className="text-[14px] font-semibold text-foreground">No hackathons yet</p>
+          <p className="mt-1 text-[13px] text-muted-foreground">Be the first to create one.</p>
+          <button
+            onClick={() => setCreateOpen(true)}
+            className="mt-4 inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 text-[13px] font-semibold text-primary-foreground hover:opacity-90"
+          >
+            <Plus size={14} /> Create hackathon
+          </button>
+        </Card>
+      )}
+
+      {/* Hackathon cards */}
+      {!isLoading && data.length > 0 && (
+        <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+          {data.map((h) => (
+            <Link
+              key={h.id}
+              to="/hackathons/$hackathonId"
+              params={{ hackathonId: h.id }}
+              className="block rounded-2xl focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+            >
+              <Card interactive className="flex h-full flex-col p-4">
+                {/* Top row */}
+                <div className="flex items-start justify-between gap-2">
+                  <span className="grid h-10 w-10 shrink-0 place-items-center rounded-md bg-primary-soft text-primary">
+                    <Trophy size={16} />
+                  </span>
+                  <TagChip className={STATUS_COLOR[h.status] ?? STATUS_COLOR.draft}>
+                    {h.status.replace(/_/g, " ")}
                   </TagChip>
+                </div>
+
+                {/* Title + theme */}
+                <p className="mt-3 line-clamp-1 text-[15px] font-semibold text-foreground">
+                  {h.name}
+                </p>
+                {h.theme && (
+                  <p className="mt-0.5 line-clamp-1 text-[12px] text-muted-foreground">
+                    {h.theme}
+                  </p>
                 )}
-              </div>
-              <button className="mt-4 w-full rounded-md bg-primary py-1.5 text-[12px] font-semibold text-primary-foreground hover:opacity-90">
-                View details
-              </button>
-            </Card>
-          </Link>
-        ))}
-      </div>
+
+                {/* Description */}
+                <p className="mt-1.5 line-clamp-2 flex-1 text-[12px] text-muted-foreground">
+                  {h.description}
+                </p>
+
+                {/* Meta */}
+                <div className="mt-3 flex flex-wrap gap-2 text-[11px] text-muted-foreground">
+                  <span className="inline-flex items-center gap-1">
+                    <Clock size={11} /> {formatDate(h.starts_at)}
+                  </span>
+                  <span className="inline-flex items-center gap-1">
+                    <Users2 size={11} /> {h.min_team_size}–{h.max_team_size}
+                  </span>
+                  {h.prize && (
+                    <TagChip className="border-warning/30 bg-warning/10 text-warning">
+                      🏆 {h.prize}
+                    </TagChip>
+                  )}
+                </div>
+
+                {/* Footer */}
+                <div className="mt-4 flex items-center justify-between border-t border-border/60 pt-3">
+                  <span className="text-[12px] font-medium text-primary">View details</span>
+                  <ArrowRight size={13} className="text-primary" />
+                </div>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      )}
+
+      <CreateHackathonDialog
+        open={createOpen}
+        onOpenChange={(open) => {
+          setCreateOpen(open);
+          if (!open) queryClient.invalidateQueries({ queryKey: ["hackathons"] });
+        }}
+      />
     </div>
   );
 }

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -7,6 +7,7 @@
 // switch to the real endpoints automatically.
 
 import * as seed from "@/mocks/seed";
+import { hackathonStore } from "@/mocks/hackathonStore";
 import {
   isBackendConfigured,
   projectsApi,
@@ -215,23 +216,65 @@ export const notificationsService = {
 };
 
 export const hackathonsService = {
-  list: () => withFallback(() => hackathonsApi.list(), seed.hackathons),
+  list: () =>
+    isBackendConfigured()
+      ? hackathonsApi.list().catch(() => hackathonStore.getAll())
+      : mock(hackathonStore.getAll()),
+
   get: (id: string) =>
-    withFallback(() => hackathonsApi.get(id), seed.hackathons.find((h) => h.id === id) ?? null),
-  create: (body: Partial<Hackathon>) => withFallback(() => hackathonsApi.create(body), null),
+    isBackendConfigured()
+      ? hackathonsApi.get(id).catch(() => hackathonStore.getById(id))
+      : mock(hackathonStore.getById(id)),
+
+  create: (body: Partial<Hackathon>) =>
+    isBackendConfigured()
+      ? hackathonsApi.create(body).catch(() => hackathonStore.create(body))
+      : hackathonStore.create(body),
+
   update: (id: string, body: Partial<Hackathon>) =>
     withFallback(() => hackathonsApi.update(id, body), null),
-  delete: (id: string) => withFallback(() => hackathonsApi.delete(id), undefined),
+
+  delete: (id: string) =>
+    withFallback(() => hackathonsApi.delete(id), undefined),
+
   register: (id: string, body?: { motivation?: string }) =>
-    withFallback(() => hackathonsApi.register(id, body), undefined),
+    isBackendConfigured()
+      ? hackathonsApi.register(id, body)
+      : hackathonStore.register(id),
+
   cancelRegistration: (id: string) =>
-    withFallback(() => hackathonsApi.cancelRegistration(id), undefined),
-  getTeams: (id: string) => withFallback(() => hackathonsApi.getTeams(id), []),
+    isBackendConfigured()
+      ? hackathonsApi.cancelRegistration(id)
+      : hackathonStore.cancelRegistration(id),
+
+  isRegistered: (id: string) =>
+    !isBackendConfigured() && hackathonStore.isRegistered(id),
+
+  getTeams: (id: string) =>
+    isBackendConfigured()
+      ? hackathonsApi.getTeams(id).catch(() => hackathonStore.getTeams(id))
+      : mock(hackathonStore.getTeams(id)),
+
   createTeam: (id: string, body: { name: string; description?: string }) =>
-    withFallback(() => hackathonsApi.createTeam(id, body), null),
-  joinTeam: (teamId: string) => withFallback(() => hackathonsApi.joinTeam(teamId), undefined),
-  leaveTeam: (teamId: string) => withFallback(() => hackathonsApi.leaveTeam(teamId), undefined),
-  getSubmissions: (id: string) => withFallback(() => hackathonsApi.getSubmissions(id), []),
+    isBackendConfigured()
+      ? hackathonsApi.createTeam(id, body)
+      : hackathonStore.createTeam(id, body),
+
+  joinTeam: (teamId: string) =>
+    isBackendConfigured()
+      ? hackathonsApi.joinTeam(teamId)
+      : hackathonStore.joinTeam(teamId),
+
+  leaveTeam: (teamId: string) =>
+    isBackendConfigured()
+      ? hackathonsApi.leaveTeam(teamId)
+      : hackathonStore.leaveTeam(teamId),
+
+  getSubmissions: (id: string) =>
+    isBackendConfigured()
+      ? hackathonsApi.getSubmissions(id).catch(() => hackathonStore.getSubmissions(id))
+      : mock(hackathonStore.getSubmissions(id)),
+
   createSubmission: (
     id: string,
     body: {
@@ -241,8 +284,15 @@ export const hackathonsService = {
       repo_url?: string;
       demo_url?: string;
     },
-  ) => withFallback(() => hackathonsApi.createSubmission(id, body), null),
-  getLeaderboard: (id: string) => withFallback(() => hackathonsApi.getLeaderboard(id), []),
+  ) =>
+    isBackendConfigured()
+      ? hackathonsApi.createSubmission(id, body)
+      : hackathonStore.createSubmission(id, body),
+
+  getLeaderboard: (id: string) =>
+    isBackendConfigured()
+      ? hackathonsApi.getLeaderboard(id).catch(() => hackathonStore.getLeaderboard(id))
+      : mock(hackathonStore.getLeaderboard(id)),
 };
 
 export const techStackService = {
@@ -294,6 +344,9 @@ export type {
   Conversation,
   Notification,
   Hackathon,
+  HackathonTeam,
+  HackathonSubmission,
+  HackathonLeaderboardEntry,
   Deadline,
 } from "@/mocks/seed";
 


### PR DESCRIPTION
## Summary

Implements a fully integrated Hackathon Platform inside DevLink, covering the complete lifecycle from discovery to judging.

## Features

### Hackathon Management
- Create hackathons with name, description, theme, prize, dates, team size rules, and website URL
- Browse all hackathons with status badges, prize info, and date display
- Full detail page with hero card, stats row, and tabbed navigation

###  Team Formation
- Create a team with name and optional description
- Join any open team — member count bar updates live
- Visual slot indicator showing filled vs available spots
- Full-team state disables join button automatically

###  Registration
- Register for any hackathon with an optional motivation message
- Cancel-safe — pressing Cancel does not mark you as registered
- "Registered ✓" badge persists within the session

###  Project Submissions
- Submit a project linked to your team
- Fields: title, description, repository URL, demo URL
- Client-side validation with inline error messages
- Submission cards show status badges (Draft / Submitted / In Review / Accepted / Rejected)

###  Judging
- Score endpoint fully wired on the backend
- Judges can be assigned per hackathon by the organiser
- Upsert scoring — judges can update their score

###  Leaderboard
- Ranked by average judge score
- Desktop: responsive table with score progress bars and medal icons
- Mobile: card list layout
- Shows team name, submission title, avg score, judge count

## Technical Changes

### Frontend
- `components/hackathons/` — 7 new components (CreateHackathonDialog, CreateTeamDialog, RegisterDialog, TeamsTab, SubmissionsTab, SubmitProjectDialog, LeaderboardTab)
- Fixed missing `<Outlet />` in hackathons layout route — child routes now render correctly
- Fixed `<button>` inside `<Link>` blocking card navigation
- `hackathonStore.ts` — in-memory mock store so all mutations work without a backend
- Extended `seed.ts` with typed interfaces and mock data for teams, submissions, leaderboard
- Rewrote `hackathonsService` to use live store for all mutations in mock mode

### Backend
- Fixed `alembic/env.py` — added `import app.models` so `Base.metadata` is populated (tables were never being created)
- Fixed duplicate migration revision `a1b2c3d4e5f6` — renamed to `b2e4f6a8c0d1` and chained correctly
- Added merge migration `ffff00000001` to unify 9 detached heads into a single linear chain
- Fixed leaderboard schema mismatch — now returns `rank`, `avg_score`, `submission_title`, `judge_count` to match frontend expectations
- Updated `get_leaderboard` SQL query to use `AVG` instead of `SUM` and include submission title

## Testing

- Fully functional in mock mode (no backend required) — create hackathon, register, create/join teams, submit projects all work
- Zero TypeScript errors across all new and modified files
- Backend imports cleanly, all 11 hackathon API endpoints verified via OpenAPI schema
- Single Alembic migration head confirmed

### Closes

Closes #686

## Screenshots

<img width="1470" height="956" alt="Screenshot 2026-07-28 at 6 25 32 PM" src="https://github.com/user-attachments/assets/5dc804d7-9d02-4555-a666-58de3f625404" />

