### PR TITLE
feat(presence): implement real-time user presence with WebSocket and inactivity timeouts #643

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -61,6 +61,19 @@ from app.routers import (
 )
 
 
+import asyncio
+
+async def check_presence_timeouts():
+    """Background task to scan for inactive WebSocket connections and set status to away."""
+    from app.routers.websockets import manager
+    try:
+        while True:
+            await asyncio.sleep(15)  # scan every 15 seconds
+            await manager.check_timeouts(timeout_seconds=300)  # 5 minutes
+    except asyncio.CancelledError:
+        pass
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """
@@ -68,6 +81,9 @@ async def lifespan(app: FastAPI):
     """
 
     print("🚀 DevLink Backend Starting...")
+
+    # Start user presence timeout background task
+    presence_task = asyncio.create_task(check_presence_timeouts())
 
     from app.core.events import event_bus
     from app.core.event_handlers import register_all_handlers
@@ -87,6 +103,13 @@ async def lifespan(app: FastAPI):
     yield
 
     print("🛑 DevLink Backend Stopping...")
+
+    # Cancel user presence timeout background task
+    presence_task.cancel()
+    try:
+        await presence_task
+    except asyncio.CancelledError:
+        pass
 
     from app.core.cache import cache_manager
 

--- a/backend/app/routers/websockets.py
+++ b/backend/app/routers/websockets.py
@@ -33,12 +33,15 @@ Architecture:
 
 import json
 import logging
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Set
 
-from fastapi import APIRouter, WebSocket, WebSocketDisconnect, status
+from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect, status
 from jose import JWTError, jwt
 
 from app.core.config import settings
+from app.dependencies import get_current_user
+from app.models.user import User
 
 router = APIRouter(prefix="/ws", tags=["WebSockets"])
 logger = logging.getLogger(__name__)
@@ -52,8 +55,8 @@ def authenticate_ws_token(token: str) -> Optional[str]:
 
     Returns ``None`` if the token is invalid, expired, or missing the
     ``sub`` claim.  This is the WebSocket equivalent of
-    ``dependencies.get_current_user`` — browsers cannot send
-    ``Authorization`` headers on WebSocket handshakes, so the token is
+    `dependencies.get_current_user` — browsers cannot send
+    `Authorization` headers on WebSocket handshakes, so the token is
     passed as a query parameter instead.
     """
     try:
@@ -74,7 +77,7 @@ def authenticate_ws_token(token: str) -> Optional[str]:
 
 
 class ConnectionManager:
-    """Manages WebSocket connections with project-scoped rooms.
+    """Manages WebSocket connections with project-scoped rooms and user presence.
 
     A "room" is identified by a project UUID string.  Users join rooms
     to receive project-scoped broadcasts (member joins/leaves, project
@@ -88,20 +91,34 @@ class ConnectionManager:
         self.active_connections: Dict[str, List[WebSocket]] = {}
         # room_id (project UUID string) → set of user_ids currently in room
         self.rooms: Dict[str, Set[str]] = {}
+        # user_id → presence status ("online", "away", "busy", "offline")
+        self.presence_states: Dict[str, str] = {}
+        # user_id → timestamp of last activity
+        self.last_activity: Dict[str, datetime] = {}
 
     # ── Connection lifecycle ─────────────────────────────────────────────
 
     async def connect(self, websocket: WebSocket, user_id: str) -> None:
         """Accept the WebSocket and register it under ``user_id``."""
         await websocket.accept()
+        is_first_connection = user_id not in self.active_connections
         self.active_connections.setdefault(user_id, []).append(websocket)
+
+        self.last_activity[user_id] = datetime.now(timezone.utc)
+        if is_first_connection:
+            self.presence_states[user_id] = "online"
+            await self.broadcast_to_all(
+                _event("presence.status_changed", user_id=user_id, status="online"),
+                exclude_user_id=user_id,
+            )
+
         logger.info(
             "User %s connected. Active sessions: %d",
             user_id,
             len(self.active_connections[user_id]),
         )
 
-    def disconnect(self, websocket: WebSocket, user_id: str) -> None:
+    async def disconnect(self, websocket: WebSocket, user_id: str) -> None:
         """Remove a single WebSocket connection for ``user_id``."""
         conns = self.active_connections.get(user_id)
         if conns and websocket in conns:
@@ -111,6 +128,16 @@ class ConnectionManager:
             # Remove user from all rooms they were in.
             for room_users in self.rooms.values():
                 room_users.discard(user_id)
+
+            # Set user offline and notify others
+            self.presence_states[user_id] = "offline"
+            await self.broadcast_to_all(
+                _event("presence.status_changed", user_id=user_id, status="offline"),
+                exclude_user_id=user_id,
+            )
+            self.presence_states.pop(user_id, None)
+            self.last_activity.pop(user_id, None)
+
         logger.info("User %s disconnected a session.", user_id)
 
     # ── Room management ──────────────────────────────────────────────────
@@ -131,6 +158,40 @@ class ConnectionManager:
         """Return the set of user_ids currently in ``room_id``."""
         return self.rooms.get(room_id, set()).copy()
 
+    # ── Presence Helpers ─────────────────────────────────────────────────
+
+    async def update_activity(self, user_id: str) -> None:
+        """Update last activity timestamp for user, and wake up from away status."""
+        self.last_activity[user_id] = datetime.now(timezone.utc)
+        current_status = self.presence_states.get(user_id)
+        if current_status == "away":
+            self.presence_states[user_id] = "online"
+            await self.broadcast_to_all(
+                _event("presence.status_changed", user_id=user_id, status="online")
+            )
+
+    async def update_presence_status(self, user_id: str, status: str) -> None:
+        """Manually update user's presence status."""
+        allowed_statuses = {"online", "away", "busy", "offline"}
+        if status not in allowed_statuses:
+            raise ValueError(f"Invalid presence status: {status}")
+
+        self.presence_states[user_id] = status
+        await self.broadcast_to_all(
+            _event("presence.status_changed", user_id=user_id, status=status)
+        )
+
+    async def check_timeouts(self, timeout_seconds: int = 300) -> None:
+        """Check for inactive users and transition them to away status."""
+        now = datetime.now(timezone.utc)
+        for user_id, last_act in list(self.last_activity.items()):
+            if self.presence_states.get(user_id) == "online":
+                if (now - last_act).total_seconds() > timeout_seconds:
+                    self.presence_states[user_id] = "away"
+                    await self.broadcast_to_all(
+                        _event("presence.status_changed", user_id=user_id, status="away")
+                    )
+
     # ── Message delivery ─────────────────────────────────────────────────
 
     async def send_personal_message(self, message: dict, user_id: str) -> None:
@@ -143,7 +204,7 @@ class ConnectionManager:
             except Exception:
                 dead.append(conn)
         for conn in dead:
-            self.disconnect(conn, user_id)
+            await self.disconnect(conn, user_id)
 
     async def broadcast_to_room(self, room_id: str, message: dict) -> None:
         """Broadcast ``message`` to every user currently in room ``room_id``."""
@@ -151,13 +212,31 @@ class ConnectionManager:
         for user_id in members:
             await self.send_personal_message(message, user_id)
 
-    async def broadcast_to_all(self, message: dict) -> None:
+    async def broadcast_to_all(self, message: dict, exclude_user_id: Optional[str] = None) -> None:
         """Broadcast ``message`` to every connected user (use sparingly)."""
         for user_id in list(self.active_connections.keys()):
+            if user_id == exclude_user_id:
+                continue
             await self.send_personal_message(message, user_id)
 
 
 manager = ConnectionManager()
+
+
+# ── HTTP REST Endpoints ─────────────────────────────────────────────────────
+
+
+@router.get("/presence", response_model=Dict[str, str])
+def get_all_presences(current_user: User = Depends(get_current_user)):
+    """Retrieve active presence states for all connected users."""
+    return manager.presence_states.copy()
+
+
+@router.get("/presence/{user_id}", response_model=Dict[str, str])
+def get_user_presence(user_id: str, current_user: User = Depends(get_current_user)):
+    """Retrieve presence status of a specific user."""
+    status = manager.presence_states.get(user_id, "offline")
+    return {"user_id": user_id, "status": status}
 
 
 # ── Event helpers ────────────────────────────────────────────────────────────
@@ -235,6 +314,8 @@ async def websocket_collab(websocket: WebSocket, token: str = ""):
                 )
                 continue
 
+            await manager.update_activity(user_id)
+
             msg_type = data.get("type", "")
             project_id = data.get("project_id", "")
 
@@ -302,6 +383,33 @@ async def websocket_collab(websocket: WebSocket, token: str = ""):
                     ),
                 )
 
+            # ── Presence Update ─────────────────────────────────────────
+            elif msg_type == "presence_update":
+                status_val = data.get("status")
+                try:
+                    await manager.update_presence_status(user_id, status_val)
+                except ValueError as exc:
+                    await manager.send_personal_message(
+                        _event("error", message=str(exc)),
+                        user_id,
+                    )
+
+            # ── Presence Query ──────────────────────────────────────────
+            elif msg_type == "presence_query":
+                queried_ids = data.get("user_ids")
+                if isinstance(queried_ids, list):
+                    presences = {
+                        uid: manager.presence_states.get(uid, "offline")
+                        for uid in queried_ids
+                    }
+                else:
+                    presences = manager.presence_states.copy()
+
+                await manager.send_personal_message(
+                    _event("presence.query_response", presences=presences),
+                    user_id,
+                )
+
             # ── Unknown message type ─────────────────────────────────────
             else:
                 await manager.send_personal_message(
@@ -313,7 +421,7 @@ async def websocket_collab(websocket: WebSocket, token: str = ""):
                 )
 
     except WebSocketDisconnect:
-        manager.disconnect(websocket, user_id)
+        await manager.disconnect(websocket, user_id)
         # Notify all rooms the user was in that they left.
         for room_id in list(manager.rooms.keys()):
             if user_id in manager.rooms[room_id]:
@@ -361,7 +469,7 @@ async def websocket_chat(websocket: WebSocket, user_id: str):
                 await manager.broadcast_to_all(payload)
 
     except WebSocketDisconnect:
-        manager.disconnect(websocket, user_id)
+        await manager.disconnect(websocket, user_id)
         await manager.broadcast_to_all(
             {"sender_id": user_id, "type": "status", "content": "offline"}
         )

--- a/backend/tests/test_presence.py
+++ b/backend/tests/test_presence.py
@@ -1,0 +1,152 @@
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlencode
+import pytest
+from fastapi.testclient import TestClient
+from app.routers.websockets import manager, _event
+
+
+def _ws_url(client: TestClient, token: str) -> str:
+    base = "ws://testserver/ws/collab"
+    return f"{base}?{urlencode({'token': token})}"
+
+
+def test_presence_connect_disconnect(client: TestClient, register_and_login):
+    # Ensure manager state is clean
+    manager.active_connections.clear()
+    manager.presence_states.clear()
+    manager.last_activity.clear()
+
+    user_id, token = register_and_login("p1@example.com", "puser1")
+
+    # Connect
+    with client.websocket_connect(_ws_url(client, token)) as ws:
+        # Connected event
+        event = ws.receive_json()
+        assert event["type"] == "connected"
+        assert event["user_id"] == user_id
+
+        # Verify manager holds "online" presence
+        assert manager.presence_states.get(user_id) == "online"
+        assert user_id in manager.last_activity
+
+        # Fetch status via GET REST endpoint
+        headers = {"Authorization": f"Bearer {token}"}
+        resp = client.get(f"/ws/presence/{user_id}", headers=headers)
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "online"
+
+    # Disconnected!
+    # Verify status changed to offline and cleaned up
+    assert user_id not in manager.active_connections
+    assert user_id not in manager.presence_states
+    assert user_id not in manager.last_activity
+
+    # Fetch status via GET REST endpoint should return "offline"
+    resp = client.get(f"/ws/presence/{user_id}", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "offline"
+
+
+def test_presence_manual_update(client: TestClient, register_and_login):
+    manager.active_connections.clear()
+    manager.presence_states.clear()
+    manager.last_activity.clear()
+
+    user_id, token = register_and_login("p2@example.com", "puser2")
+
+    with client.websocket_connect(_ws_url(client, token)) as ws:
+        ws.receive_json()  # connected
+
+        # Update status to busy
+        ws.send_json({"type": "presence_update", "status": "busy"})
+
+        # Should receive broadcast status changed event
+        event = ws.receive_json()
+        assert event["type"] == "presence.status_changed"
+        assert event["user_id"] == user_id
+        assert event["status"] == "busy"
+
+        # Verify manager holds "busy"
+        assert manager.presence_states.get(user_id) == "busy"
+
+        # Try invalid status update, should return error message
+        ws.send_json({"type": "presence_update", "status": "invalid_status"})
+        err_event = ws.receive_json()
+        assert err_event["type"] == "error"
+        assert "Invalid presence status" in err_event["message"]
+
+
+def test_presence_query(client: TestClient, register_and_login):
+    manager.active_connections.clear()
+    manager.presence_states.clear()
+    manager.last_activity.clear()
+
+    user_id1, token1 = register_and_login("p3@example.com", "puser3")
+    user_id2, token2 = register_and_login("p4@example.com", "puser4")
+
+    # Connect user 2 first
+    with client.websocket_connect(_ws_url(client, token2)) as ws2:
+        ws2.receive_json()  # connected
+
+        # Connect user 1
+        with client.websocket_connect(_ws_url(client, token1)) as ws1:
+            ws1.receive_json()  # connected
+
+            # Query all presences
+            ws1.send_json({"type": "presence_query"})
+            response = ws1.receive_json()
+            assert response["type"] == "presence.query_response"
+            assert response["presences"][user_id1] == "online"
+            assert response["presences"][user_id2] == "online"
+
+            # Query specific user
+            ws1.send_json({"type": "presence_query", "user_ids": [user_id2]})
+            response2 = ws1.receive_json()
+            assert response2["type"] == "presence.query_response"
+            assert user_id2 in response2["presences"]
+            assert response2["presences"][user_id2] == "online"
+            assert user_id1 not in response2["presences"]
+
+
+@pytest.mark.asyncio
+async def test_presence_timeout():
+    manager.active_connections.clear()
+    manager.presence_states.clear()
+    manager.last_activity.clear()
+
+    user_id = "test-user-id"
+    manager.presence_states[user_id] = "online"
+    # Set activity to 6 minutes ago
+    manager.last_activity[user_id] = datetime.now(timezone.utc) - timedelta(minutes=6)
+
+    # Run check timeouts (default threshold is 5 mins / 300 secs)
+    await manager.check_timeouts(timeout_seconds=300)
+
+    # Should transition to away
+    assert manager.presence_states.get(user_id) == "away"
+
+    # Any new activity should transition back to online
+    await manager.update_activity(user_id)
+    assert manager.presence_states.get(user_id) == "online"
+
+
+def test_presence_broadcast_to_others(client: TestClient, register_and_login):
+    manager.active_connections.clear()
+    manager.presence_states.clear()
+    manager.last_activity.clear()
+
+    user_id_a, token_a = register_and_login("pa@example.com", "user_a")
+    user_id_b, token_b = register_and_login("pb@example.com", "user_b")
+
+    with client.websocket_connect(_ws_url(client, token_a)) as ws_a:
+        ws_a.receive_json()  # connected event for A
+
+        # Now B connects
+        with client.websocket_connect(_ws_url(client, token_b)) as ws_b:
+            ws_b.receive_json()  # connected event for B
+
+            # A should receive the presence status changed event for B
+            event = ws_a.receive_json()
+            assert event["type"] == "presence.status_changed"
+            assert event["user_id"] == user_id_b
+            assert event["status"] == "online"

--- a/backend/tests/test_websockets.py
+++ b/backend/tests/test_websockets.py
@@ -14,20 +14,20 @@ def _ws_url(client: TestClient, token: str) -> str:
 
 def test_ws_rejects_missing_token(client: TestClient):
     """Connection without a token is closed with policy violation."""
-    with client.websocket_connect("/ws/collab") as ws:
-        try:
+    try:
+        with client.websocket_connect("/ws/collab") as ws:
             ws.receive()
-        except WebSocketDisconnect:
-            pass
+    except WebSocketDisconnect:
+        pass
 
 
 def test_ws_rejects_invalid_token(client: TestClient):
     """Connection with an invalid token is closed."""
-    with client.websocket_connect("/ws/collab?token=invalid-jwt") as ws:
-        try:
+    try:
+        with client.websocket_connect("/ws/collab?token=invalid-jwt") as ws:
             ws.receive()
-        except WebSocketDisconnect:
-            pass
+    except WebSocketDisconnect:
+        pass
 
 
 def test_ws_accepts_valid_token(client: TestClient, register_and_login):


### PR DESCRIPTION
## Description
This PR implements real-time user presence throughout the DevLink application using WebSockets, automated inactivity timeouts, and HTTP status endpoints. It fully satisfies the requirements of issue #643.

It also wraps WebSocket handshake testing in a try-except block to gracefully handle immediate connection rejections in tests, resolving pre-existing test issues.

## Goals Addressed
- [x] **WebSocket Presence States**: Supports `online`, `away`, `busy`, and `offline` presence states.
- [x] **Real-Time Broadcasts**: Broadcasts presence state changes (`presence.status_changed`) to all other active WebSocket connections in real-time.
- [x] **Automatic Timeout Handling**: A background loop task checks inactive connections. If an `online` user has no activity for >5 minutes, their status transitions to `away`.
- [x] **Activity Resumption**: Any client-side interactions over WebSocket (e.g. sending a message or joining a room) update the activity timestamp and transition `away` users back to `online`.
- [x] **REST presence endpoints**: Added `GET /ws/presence` (returns current states of all active users) and `GET /ws/presence/{user_id}` (returns presence of a specific user) to let clients query status easily via REST.
- [x] **WebSocket Event Handlers**:
  - `presence_update`: Enables users to manually request presence status change.
  - `presence_query`: Enables requesting/fetching presence status for a list of user IDs over WebSockets.

---

## Technical Details

### 1. Connection Manager updates (`backend/app/routers/websockets.py`)
- Track `presence_states: Dict[str, str]` and `last_activity: Dict[str, datetime]` in `ConnectionManager`.
- Connects automatically assign `online` status and broadcast it to all other connections (excluding the connecting user to preserve the REST handshake sequence).
- Disconnects automatically assign `offline` status once all tabs/connections for a user close, clean up tracking states, and broadcast it to others.
- Implemented `update_activity`, `update_presence_status`, and `check_timeouts`.

### 2. Timeout Scheduler (`backend/app/main.py`)
- Configured a background task `check_presence_timeouts` that runs every 15 seconds.
- Integrated the task into the FastAPI application lifespan (starts on startup, cancels cleanly on shutdown).

### 3. REST Presence Endpoints (`backend/app/routers/websockets.py`)
- Implemented `GET /ws/presence` and `GET /ws/presence/{user_id}` routes.

---

## Verification & Testing
Added a new test suite under **`backend/tests/test_presence.py`** to assert:
- `test_presence_connect_disconnect`: Validates status transitions to `"online"` on connect and `"offline"` on disconnect.
- `test_presence_manual_update`: Validates manual `"presence_update"` events over WebSocket (like switching to `busy`), as well as validation errors for invalid statuses.
- `test_presence_query`: Validates that clients can query status for other users or all online users over socket using `"presence_query"`.
- `test_presence_timeout`: Mocks an inactive state (>5 minutes) and asserts transition to `"away"`, then asserts that new activity restores `"online"` status.
- `test_presence_broadcast_to_others`: Verifies that when B connects, A receives a real-time broadcast of B's status.

### Test Output:
```bash
tests\test_presence.py .....                                             [ 38%]
tests\test_websockets.py ........                                        [100%]
======================= 13 passed, 14 warnings in 8.28s =======================