### PR TITLE
feat(ui): add reusable error page components

### DIFF
--- a/frontend/src/components/errors/ErrorLayout.tsx
+++ b/frontend/src/components/errors/ErrorLayout.tsx
@@ -1,0 +1,51 @@
+import { Link } from "@tanstack/react-router";
+import type { ReactNode } from "react";
+
+interface ErrorLayoutProps {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  primaryLabel?: string;
+  primaryTo?: string;
+  secondaryLabel?: string;
+  onSecondaryClick?: () => void;
+}
+
+export function ErrorLayout({
+  icon,
+  title,
+  description,
+  primaryLabel = "Go Home",
+  primaryTo = "/",
+  secondaryLabel = "Go Back",
+  onSecondaryClick,
+}: ErrorLayoutProps) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-4">
+      <div className="w-full max-w-md text-center">
+        <div className="mb-6 flex justify-center">{icon}</div>
+
+        <h1 className="text-3xl font-bold text-foreground">{title}</h1>
+
+        <p className="mt-3 text-sm leading-relaxed text-muted-foreground">{description}</p>
+
+        <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+          <Link
+            to={primaryTo}
+            className="inline-flex items-center justify-center rounded-md bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground transition-transform hover:opacity-90 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          >
+            {primaryLabel}
+          </Link>
+
+          <button
+            type="button"
+            onClick={onSecondaryClick ?? (() => window.history.back())}
+            className="inline-flex items-center justify-center rounded-md border border-border bg-surface px-5 py-2.5 text-sm font-medium text-foreground transition-transform hover:bg-muted active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          >
+            {secondaryLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/errors/ForbiddenPage.tsx
+++ b/frontend/src/components/errors/ForbiddenPage.tsx
@@ -1,0 +1,13 @@
+import { ShieldAlert } from "lucide-react";
+
+import { ErrorLayout } from "./ErrorLayout";
+
+export function ForbiddenPage() {
+  return (
+    <ErrorLayout
+      icon={<ShieldAlert className="h-16 w-16 text-destructive" />}
+      title="403 • Forbidden"
+      description="You don't have permission to access this resource."
+    />
+  );
+}

--- a/frontend/src/components/errors/NetworkErrorPage.tsx
+++ b/frontend/src/components/errors/NetworkErrorPage.tsx
@@ -1,0 +1,15 @@
+import { GlobeX } from "lucide-react";
+
+import { ErrorLayout } from "./ErrorLayout";
+
+export function NetworkErrorPage() {
+  return (
+    <ErrorLayout
+      icon={<GlobeX className="h-16 w-16 text-warning" />}
+      title="Network Error"
+      description="We couldn't reach the server. Please try again."
+      primaryLabel="Retry"
+      primaryTo="/"
+    />
+  );
+}

--- a/frontend/src/components/errors/OfflinePage.tsx
+++ b/frontend/src/components/errors/OfflinePage.tsx
@@ -1,0 +1,15 @@
+import { WifiOff } from "lucide-react";
+
+import { ErrorLayout } from "./ErrorLayout";
+
+export function OfflinePage() {
+  return (
+    <ErrorLayout
+      icon={<WifiOff className="h-16 w-16 text-muted-foreground" />}
+      title="You're Offline"
+      description="Please check your internet connection and try again."
+      primaryLabel="Retry"
+      primaryTo="/"
+    />
+  );
+}

--- a/frontend/src/components/errors/ServerErrorPage.tsx
+++ b/frontend/src/components/errors/ServerErrorPage.tsx
@@ -1,0 +1,13 @@
+import { TriangleAlert } from "lucide-react";
+
+import { ErrorLayout } from "./ErrorLayout";
+
+export function ServerErrorPage() {
+  return (
+    <ErrorLayout
+      icon={<TriangleAlert className="h-16 w-16 text-warning" />}
+      title="500 • Server Error"
+      description="Something went wrong on our end. Please try again in a few moments."
+    />
+  );
+}

--- a/frontend/src/components/errors/UnauthorizedPage.tsx
+++ b/frontend/src/components/errors/UnauthorizedPage.tsx
@@ -1,0 +1,15 @@
+import { Lock } from "lucide-react";
+
+import { ErrorLayout } from "./ErrorLayout";
+
+export function UnauthorizedPage() {
+  return (
+    <ErrorLayout
+      icon={<Lock className="h-16 w-16 text-warning" />}
+      title="401 • Unauthorized"
+      description="You need to sign in to access this page."
+      primaryLabel="Go to Login"
+      primaryTo="/auth"
+    />
+  );
+}

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -12,6 +12,13 @@ import { Toaster } from "sonner";
 
 import appCss from "../styles.css?url";
 import { reportLovableError } from "../lib/lovable-error-reporting";
+import { ApiError } from "@/api/client";
+
+import { UnauthorizedPage } from "@/components/errors/UnauthorizedPage";
+import { ForbiddenPage } from "@/components/errors/ForbiddenPage";
+import { ServerErrorPage } from "@/components/errors/ServerErrorPage";
+import { OfflinePage } from "@/components/errors/OfflinePage";
+import { NetworkErrorPage } from "@/components/errors/NetworkErrorPage";
 
 function NotFoundComponent() {
   const ref = useRef<HTMLDivElement>(null);
@@ -73,6 +80,30 @@ function ErrorComponent({ error, reset }: { error: Error; reset: () => void }) {
     reportLovableError(error, { boundary: "tanstack_root_error_component" });
   }, [error]);
 
+  if (error instanceof ApiError) {
+    if (error.status === 401) {
+      return <UnauthorizedPage />;
+    }
+
+    if (error.status === 403) {
+      return <ForbiddenPage />;
+    }
+
+    if (error.status >= 500) {
+      return <ServerErrorPage />;
+    }
+
+    // status 0  -> fetch/network failure (coreFetch's catch block)
+    // status 408 -> request aborted/timed out (coreFetch's AbortError branch)
+    // Both are network-class failures from the user's perspective.
+    if (error.status === 0 || error.status === 408) {
+      // navigator is undefined during SSR; assume online in that case so we
+      // don't render OfflinePage on the server for a purely client-side signal.
+      const isOnline = typeof navigator === "undefined" ? true : navigator.onLine;
+      return isOnline ? <NetworkErrorPage /> : <OfflinePage />;
+    }
+  }
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-background px-4">
       <div className="max-w-md text-center">
@@ -85,19 +116,21 @@ function ErrorComponent({ error, reset }: { error: Error; reset: () => void }) {
         <div className="mt-6 flex flex-wrap justify-center gap-2">
           <button
             onClick={() => {
-              router.invalidate();
+              // router.invalidate() returns a Promise; explicitly discard it
+              // rather than leaving a floating unhandled promise.
+              void router.invalidate();
               reset();
             }}
             className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-opacity hover:opacity-90"
           >
             Try again
           </button>
-          <a
-            href="/"
+          <Link
+            to="/"
             className="inline-flex items-center justify-center rounded-md border border-border bg-surface px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted"
           >
             Go home
-          </a>
+          </Link>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Adds reusable error page components for common application error states (401, 403, 500, Offline, and Network Error) and integrates them into the root error handling while preserving the existing custom 404 page.

---

## Related Issue

Closes #493

---

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [x] UI/UX enhancement
- [ ] Tests
- [ ] Other

---

## Changes Made

- Added a reusable `ErrorLayout` component for consistent error page design.
- Added dedicated error page components:
  - Unauthorized (401)
  - Forbidden (403)
  - Server Error (500)
  - Offline
  - Network Error
- Updated the root error handling to preserve the existing 404 page while supporting the new reusable error pages.

---

## Testing

- [x] Tested locally
- [ ] Existing tests pass
- [ ] Added new tests
- [x] UI verified
- [ ] Cross-browser tested (if applicable)

Additional testing notes:

- Verified the application starts successfully.
- Verified formatting with Prettier.
- Ran ESLint. Existing project lint issues unrelated to this change are still present.

---

## Checklist

- [x] My code follows the project's coding standards.
- [x] I have tested my changes locally.
- [ ] I have updated the documentation where necessary.
- [x] My changes do not introduce new warnings or errors.
- [x] I have reviewed my own code.
- [x] This pull request focuses on a single feature or fix.
- [x] I have linked the related issue.

---

## Additional Notes

This PR introduces reusable error page components while keeping the existing custom 404 page intact. If there is a preferred integration point for handling API-specific errors (e.g., React Query or router-level error boundaries), I'm happy to adjust the implementation based on maintainer feedback.