### PR TITLE
feat(editor): add markdown formatting toolbar

### DIFF
--- a/frontend/src/components/shared/MarkdownEditor.tsx
+++ b/frontend/src/components/shared/MarkdownEditor.tsx
@@ -1,5 +1,5 @@
-import { useId, useState } from "react";
-import { Eye, Pencil } from "lucide-react";
+import { useId, useRef, useState } from "react";
+import { Eye, Pencil, Image as ImageIcon, Video, AtSign, Code2 } from "lucide-react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Markdown } from "@/components/shared/Markdown";
 import { cn } from "@/lib/utils";
@@ -15,10 +15,30 @@ export interface MarkdownEditorProps {
 }
 
 /**
+ * Inserts `text` at the current cursor position (replacing any selection),
+ * rather than always appending to the end. Returns the new full value and
+ * the cursor offset where the caret should land afterward.
+ */
+function insertAtCursor(
+  current: string,
+  selectionStart: number,
+  selectionEnd: number,
+  insertion: string,
+  cursorOffsetFromStart = insertion.length,
+): { nextValue: string; nextCursor: number } {
+  const before = current.slice(0, selectionStart);
+  const after = current.slice(selectionEnd);
+  const nextValue = `${before}${insertion}${after}`;
+  const nextCursor = selectionStart + cursorOffsetFromStart;
+  return { nextValue, nextCursor };
+}
+
+/**
  * Write / Preview markdown editor.
- * "Write" is a plain textarea; "Preview" renders the same content through
- * the shared <Markdown> renderer so contributors see exactly what will be
- * published (GFM tables, code blocks, images, lists, headers, etc).
+ * "Write" is a plain textarea with a lightweight formatting toolbar above it;
+ * "Preview" renders the same content through the shared <Markdown> renderer
+ * so contributors see exactly what will be published (GFM tables, code
+ * blocks, images, lists, headers, etc).
  */
 export function MarkdownEditor({
   value,
@@ -31,6 +51,61 @@ export function MarkdownEditor({
 }: MarkdownEditorProps) {
   const [tab, setTab] = useState<"write" | "preview">("write");
   const previewId = useId();
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  /**
+   * Shared entry point for every toolbar button: reads the textarea's
+   * current selection, inserts `insertion` there, updates the value via
+   * onChange, then restores focus and places the caret at `cursorOffset`
+   * (defaults to right after the inserted text).
+   */
+  const insertAtCursorInTextarea = (insertion: string, cursorOffset?: number) => {
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      // Fallback: no ref available yet, append to the end.
+      onChange(`${value}${insertion}`);
+      return;
+    }
+
+    const { selectionStart, selectionEnd } = textarea;
+    const { nextValue, nextCursor } = insertAtCursor(
+      value,
+      selectionStart,
+      selectionEnd,
+      insertion,
+      cursorOffset ?? insertion.length,
+    );
+
+    onChange(nextValue);
+
+    // Restore focus + caret position after React re-renders the new value.
+    requestAnimationFrame(() => {
+      textarea.focus();
+      textarea.setSelectionRange(nextCursor, nextCursor);
+    });
+  };
+
+  const handleEmoji = () => insertAtCursorInTextarea("😀");
+
+  const handleImage = () => {
+    const snippet = "![Alt text](image-url)";
+    // Place caret right after "![" so "Alt text" is easy to overtype.
+    insertAtCursorInTextarea(snippet, 2);
+  };
+
+  const handleVideo = () => {
+    const snippet = "[Watch Video](video-url)";
+    // Cursor remains at the end of the inserted markdown.
+    insertAtCursorInTextarea(snippet);
+  };
+
+  const handleMention = () => insertAtCursorInTextarea("@username");
+
+  const handleCodeBlock = () => {
+    const snippet = "```\n\n```";
+    // Caret lands on the blank line between the two fences.
+    insertAtCursorInTextarea(snippet, 4);
+  };
 
   return (
     <div className={cn("w-full", className)}>
@@ -50,7 +125,58 @@ export function MarkdownEditor({
         </div>
 
         <TabsContent value="write" className="mt-2">
+          {tab === "write" && (
+            <div className="mb-1.5 flex items-center gap-1 rounded-md border border-border bg-surface p-1">
+              <button
+                type="button"
+                onClick={handleEmoji}
+                aria-label="Insert emoji"
+                title="Emoji"
+                className="inline-flex h-7 w-7 items-center justify-center rounded text-[14px] hover:bg-muted"
+              >
+                😀
+              </button>
+              <button
+                type="button"
+                onClick={handleImage}
+                aria-label="Insert image"
+                title="Image"
+                className="inline-flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+              >
+                <ImageIcon size={14} />
+              </button>
+              <button
+                type="button"
+                onClick={handleVideo}
+                aria-label="Insert video"
+                title="Video"
+                className="inline-flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+              >
+                <Video size={14} />
+              </button>
+              <button
+                type="button"
+                onClick={handleMention}
+                aria-label="Insert mention"
+                title="Mention"
+                className="inline-flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+              >
+                <AtSign size={14} />
+              </button>
+              <button
+                type="button"
+                onClick={handleCodeBlock}
+                aria-label="Insert code block"
+                title="Code Block"
+                className="inline-flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+              >
+                <Code2 size={14} />
+              </button>
+            </div>
+          )}
+
           <textarea
+            ref={textareaRef}
             value={value}
             onChange={(e) => onChange(e.target.value)}
             placeholder={placeholder}


### PR DESCRIPTION
## Summary

Adds a lightweight formatting toolbar to the existing `MarkdownEditor` component. Users can now quickly insert Markdown syntax for emoji, images, videos, mentions, and code blocks while preserving the existing Write/Preview workflow and avoiding a full rich-text editor migration.

---

## Related Issue

Closes #492

---

## Type of Change

Please check the relevant option(s):

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [x] UI/UX enhancement
- [ ] Tests
- [ ] Other

---

## Changes Made

- Added a lightweight formatting toolbar above the Markdown editor.
- Implemented cursor-aware insertion so formatting is inserted at the current cursor position.
- Added quick actions for:
  - Emoji
  - Image Markdown
  - Video Markdown link
  - Mentions
  - Code Blocks
- Preserved the existing Write/Preview experience without introducing additional editor dependencies.

---

## Screenshots (if applicable)

_Add screenshots or screen recordings demonstrating the toolbar and inserted markdown._

---

## Testing

Describe how you tested your changes.

- [x] Tested locally
- [ ] Existing tests pass
- [ ] Added new tests
- [x] UI verified
- [ ] Cross-browser tested (if applicable)

**Additional testing notes:**

- Verified toolbar actions insert Markdown at the current cursor position.
- Verified the Preview tab renders the inserted Markdown correctly.
- Verified existing editor functionality remains unchanged.

---

## Checklist

Before submitting this pull request, confirm the following:

- [x] My code follows the project's coding standards.
- [x] I have tested my changes locally.
- [ ] I have updated the documentation where necessary.
- [x] My changes do not introduce new warnings or errors.
- [x] I have reviewed my own code.
- [x] This pull request focuses on a single feature or fix.
- [x] I have linked the related issue.

---

## Additional Notes

This implementation follows the maintainer's guidance to keep the existing `MarkdownEditor` and make incremental improvements instead of migrating to a full rich-text editor such as TipTap, Lexical, or Slate.