### PR TITLE
Fix: Wire up "Continue with GitHub" OAuth button on sign-in page

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,5 @@
 # Backend base URL for the FastAPI service. Leave empty for local mock mode.
 VITE_API_BASE_URL=
+
+# GitHub OAuth App client ID (used to start the "Continue with GitHub" login)
+VITE_GITHUB_CLIENT_ID=

--- a/frontend/src/api/modules/auth.ts
+++ b/frontend/src/api/modules/auth.ts
@@ -24,12 +24,16 @@ export const authApi = {
     tokenStore.set(res.access_token, res.refresh_token);
     return res;
   },
-  async login(input: { email: string; password: string }) {
+async login(input: { email: string; password: string }) {
     const res = await api.post<AuthResponse>("/api/auth/login", input, { auth: false });
     tokenStore.set(res.access_token, res.refresh_token);
     return res;
   },
-  async logout() {
+  async githubLogin(code: string) {
+    const res = await api.post<AuthResponse>("/api/auth/github", { code }, { auth: false });
+    tokenStore.set(res.access_token, res.refresh_token);
+    return res;
+  },  async logout() {
     try {
       await api.post<void>("/api/auth/logout", { refresh_token: tokenStore.getRefresh() });
     } finally {

--- a/frontend/src/routes/auth.tsx
+++ b/frontend/src/routes/auth.tsx
@@ -1,15 +1,14 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { useState, useCallback } from "react";
-import { Eye, EyeOff, Github } from "lucide-react";
+import { useState, useCallback, useEffect } from "react";import { Eye, EyeOff, Github } from "lucide-react";
 import { APP_LOGO } from "@/lib/logo";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { toast } from "sonner";
 import { LoadingButton } from "@/components/shared/LoadingButton";
-
+import { authApi } from "@/api/modules/auth";
 export const Route = createFileRoute("/auth")({
   head: () => ({
     meta: [
@@ -53,6 +52,17 @@ function AuthScreen() {
   const err = "mt-1 text-[12px] text-destructive";
   const lbl = "block text-[13px] font-semibold text-foreground mb-1";
 
+  useEffect(() => {
+    const code = new URLSearchParams(window.location.search).get("code");
+    if (!code) return;
+    authApi
+      .githubLogin(code)
+      .then(() => {
+        toast.success("Signed in with GitHub");
+        navigate({ to: "/dashboard" });
+      })
+      .catch(() => toast.error("GitHub sign-in failed"));
+  }, [navigate]);
   const onSubmit = useCallback(async () => {
     if (submitting) return;
     setSubmitting(true);
@@ -73,10 +83,20 @@ function AuthScreen() {
       </Link>
 
       <div className="w-full max-w-[500px] rounded-md border border-border bg-surface px-8 py-6">
-        <button className="mb-3 flex w-full items-center justify-center gap-2.5 rounded-md border border-border bg-surface px-3 py-[8px] text-[14px] font-medium text-foreground hover:bg-muted">
+<button
+          type="button"
+          onClick={() => {
+            const params = new URLSearchParams({
+              client_id: import.meta.env.VITE_GITHUB_CLIENT_ID ?? "",
+              redirect_uri: window.location.origin + "/auth",
+              scope: "read:user user:email",
+            });
+            window.location.href = `https://github.com/login/oauth/authorize?${params}`;
+          }}
+          className="mb-3 flex w-full items-center justify-center gap-2.5 rounded-md border border-border bg-surface px-3 py-[8px] text-[14px] font-medium text-foreground hover:bg-muted"
+        >
           <Github size={16} /> Continue with GitHub
-        </button>
-        <button className="mb-4 flex w-full items-center justify-center gap-2.5 rounded-md border border-border bg-surface px-3 py-[8px] text-[14px] font-medium text-foreground hover:bg-muted">
+        </button>        <button className="mb-4 flex w-full items-center justify-center gap-2.5 rounded-md border border-border bg-surface px-3 py-[8px] text-[14px] font-medium text-foreground hover:bg-muted">
           <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden>
             <path
               fill="#4285F4"


### PR DESCRIPTION
## What
The "Continue with GitHub" and "Continue with Google" buttons on the
sign-in page had no click handlers — clicking them did nothing.

This PR wires up GitHub sign-in end-to-end, since the backend already
has a working /api/auth/github endpoint that was never being called:

- Added VITE_GITHUB_CLIENT_ID to frontend env config
- Added authApi.githubLogin() to call the existing backend endpoint
- Added an onClick handler that redirects the user to GitHub's OAuth
  authorize page
- Added a handler that reads the returned ?code= param and completes
  login, storing tokens and redirecting to /dashboard

## Out of scope
Google, Microsoft, and LinkedIn are listed as providers in this issue,
but only GitHub currently has a backend OAuth endpoint. Google has
config placeholders (GOOGLE_CLIENT_ID) but no /api/auth/google route,
and Microsoft/LinkedIn have no backend support at all yet. Wiring
those up needs backend work first and is better suited to a follow-up
issue/PR rather than bundling it here.

Closes #527 

@nensii21 
I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.