### PR TITLE
feat: Add empty state illustrations to empty state components

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,13 +5,16 @@ from pathlib import Path
 # pyrefly: ignore [missing-import]
 
 # pyrefly: ignore [missing-import]
+
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 
 # pyrefly: ignore [missing-import]
+
 from fastapi.middleware.cors import CORSMiddleware
 
 # pyrefly: ignore [missing-import]
+
 from fastapi.responses import JSONResponse
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
@@ -25,12 +28,15 @@ from app.middleware.activity import ActivityTrackingMiddleware
 from app.middleware.rate_limit import limiter
 
 # pyrefly: ignore [missing-import]
+
 from slowapi.errors import RateLimitExceeded
 
 # pyrefly: ignore [missing-import]
+
 from slowapi.middleware import SlowAPIMiddleware
 
 # pyrefly: ignore [missing-import]
+
 from slowapi import _rate_limit_exceeded_handler
 
 from app.routers import (
@@ -88,6 +94,7 @@ async def lifespan(app: FastAPI):
     print("[INFO] DevLink Backend Starting...")
 
     # Start user presence timeout background task
+
     presence_task = asyncio.create_task(check_presence_timeouts())
 
     from app.core.events import event_bus
@@ -110,12 +117,12 @@ async def lifespan(app: FastAPI):
     print("[INFO] DevLink Backend Stopping...")
 
     # Cancel user presence timeout background task
+
     presence_task.cancel()
     try:
         await presence_task
     except asyncio.CancelledError:
         pass
-
     from app.core.cache import cache_manager
 
     cache_manager.disconnect()
@@ -323,15 +330,18 @@ async def custom_offline_docs():
 </html>"""
     return HTMLResponse(content=html_content)
 
+
 # ------------------------------------------------------------------
 # Rate Limiting
 # ------------------------------------------------------------------
+
 
 app.state.limiter = limiter
 
 # ------------------------------------------------------------------
 # Standardized Exception Handlers
 # ------------------------------------------------------------------
+
 
 from fastapi.exceptions import HTTPException, RequestValidationError
 from starlette.exceptions import HTTPException as StarletteHTTPException
@@ -353,6 +363,7 @@ app.add_middleware(SlowAPIMiddleware)
 # Security Middleware
 # ------------------------------------------------------------------
 
+
 app.add_middleware(RequestIDMiddleware)
 app.add_middleware(SecurityHeadersMiddleware)
 app.add_middleware(ActivityTrackingMiddleware)
@@ -360,6 +371,7 @@ app.add_middleware(ActivityTrackingMiddleware)
 # ------------------------------------------------------------------
 # CORS
 # ------------------------------------------------------------------
+
 
 app.add_middleware(
     CORSMiddleware,
@@ -426,12 +438,15 @@ async def health_simple():
 # API Routers
 # ------------------------------------------------------------------
 
+
 from app.api.v1.router import api_v1_router
 
 # Include Versioned API v1 Router (/api/v1)
+
 app.include_router(api_v1_router)
 
 # Include Legacy Unversioned API Routers (/api) for Backward Compatibility
+
 from app.routers import (
     activities,
     applications,
@@ -466,6 +481,7 @@ from app.routers import (
 )
 
 # Router inclusions
+
 
 app.include_router(media.router, prefix="/api")
 app.include_router(auth.router, prefix="/api/auth", tags=["Authentication"])

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -8,12 +8,15 @@ from app.services.email_service import EmailService
 from app.core.config import settings
 
 # pyrefly: ignore [missing-import]
+
 from fastapi import HTTPException, status
 
 # pyrefly: ignore [missing-import]
+
 from sqlalchemy import select
 
 # pyrefly: ignore [missing-import]
+
 from sqlalchemy.orm import Session
 
 from app.core.events import event_bus
@@ -81,7 +84,6 @@ class AuthService:
     ) -> bool:
         if verify_password(new_password, user.password_hash):
             return True
-
         histories = (
             self.db.execute(
                 select(PasswordHistory)
@@ -96,7 +98,6 @@ class AuthService:
         for history in histories:
             if verify_password(new_password, history.password_hash):
                 return True
-
         return False
 
     # =====================================================
@@ -130,13 +131,11 @@ class AuthService:
                 status_code=status.HTTP_409_CONFLICT,
                 detail="Email already exists.",
             )
-
         if self.get_user_by_username(payload.username):
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="Username already exists.",
             )
-
         user = User(
             first_name=payload.first_name,
             last_name=payload.last_name,
@@ -181,7 +180,6 @@ class AuthService:
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Invalid email or password.",
             )
-
         if not verify_password(
             payload.password,
             user.password_hash,
@@ -191,14 +189,12 @@ class AuthService:
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Invalid email or password.",
             )
-
         if not user.is_active:
             print("USER INACTIVE")
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Account is disabled.",
             )
-
         user.last_login = datetime.now(timezone.utc)
         user.last_seen = datetime.now(timezone.utc)
         user.last_active_at = datetime.now(timezone.utc)
@@ -281,7 +277,6 @@ class AuthService:
                     suffix = str(counter)
                     username = f"{base_username[: 50 - len(suffix)]}{suffix}"
                     counter += 1
-
                 user = User(
                     first_name=first_name,
                     last_name=last_name,
@@ -299,13 +294,11 @@ class AuthService:
                 self.db.add(user)
                 self.db.commit()
                 self.db.refresh(user)
-
         if not user.is_active:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Account is disabled.",
             )
-
         user.last_login = datetime.now(timezone.utc)
         self.db.commit()
 
@@ -335,29 +328,34 @@ class AuthService:
         github_id = str(github_user["id"])
 
         # 1. Check if user already exists by github_id
+
         user = self.db.scalar(select(User).where(User.github_id == github_id))
 
         if not user:
             # 2. Check if user exists by email
+
             user = self.get_user_by_email(primary_email)
             if user:
                 # Link account
+
                 user.github_id = github_id
                 user.github_url = github_user.get("html_url")
                 if not user.profile_image and github_user.get("avatar_url"):
                     user.profile_image = github_user.get("avatar_url")
-
                 self.db.commit()
             else:
                 # 3. Create new user
+
                 import secrets
                 import string
 
                 # Generate random password (local requirement)
+
                 alphabet = string.ascii_letters + string.digits + string.punctuation
                 random_password = "".join(secrets.choice(alphabet) for i in range(32))
 
                 # Parse name
+
                 name = (
                     github_user.get("name") or github_user.get("login") or "GitHub User"
                 )
@@ -366,6 +364,7 @@ class AuthService:
                 last_name = name_parts[1][:100] if len(name_parts) > 1 else ""
 
                 # Ensure unique username
+
                 base_username = (github_user.get("login") or "github_user").lower()[:50]
                 username = base_username
                 counter = 1
@@ -373,7 +372,6 @@ class AuthService:
                     suffix = str(counter)
                     username = f"{base_username[:50 - len(suffix)]}{suffix}"
                     counter += 1
-
                 user = User(
                     first_name=first_name,
                     last_name=last_name,
@@ -396,13 +394,11 @@ class AuthService:
                     email=user.email,
                     user_id=str(user.id),
                 )
-
         if not user.is_active:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Account is disabled.",
             )
-
         user.last_login = datetime.now(timezone.utc)
         self.db.commit()
 
@@ -419,7 +415,9 @@ class AuthService:
             days=settings.REFRESH_TOKEN_EXPIRE_DAYS
         )
         expires_at = datetime.now(timezone.utc) + timedelta(days=7)
-        expires_at = datetime.now(timezone.utc) + timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS)
+        expires_at = datetime.now(timezone.utc) + timedelta(
+            days=settings.REFRESH_TOKEN_EXPIRE_DAYS
+        )
 
         RefreshTokenService.create_token_for_user(
             db=self.db,
@@ -470,22 +468,18 @@ class AuthService:
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="User not found.",
             )
-
         if not user.is_active:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Account is disabled.",
             )
-
         now = datetime.now(timezone.utc)
         last_seen = user.last_seen
         if last_seen and last_seen.tzinfo is None:
             last_seen = last_seen.replace(tzinfo=timezone.utc)
-
         if not last_seen or (now - last_seen).total_seconds() > 60:
             user.last_seen = now
             self.db.commit()
-
         return user
 
     # =====================================================
@@ -503,32 +497,30 @@ class AuthService:
 
         if db_token and db_token.is_revoked:
             # Token reuse detected! Revoke all tokens for this user for security.
+
             RefreshTokenService.revoke_all_tokens(self.db, db_token.user_id)
             self.db.commit()
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Refresh token has already been revoked or reused. All sessions revoked for security.",
             )
-
         if not db_token:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Invalid or expired refresh token.",
             )
-
         expires_at = db_token.expires_at
         if expires_at.tzinfo is None:
             expires_at = expires_at.replace(tzinfo=timezone.utc)
-
         if expires_at < now:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Invalid or expired refresh token.",
             )
-
         user = self.get_current_user(str(db_token.user_id))
 
         # Rotate refresh token
+
         db_token.is_revoked = True
         db_token.revoked_at = now
         db_token.last_used_at = now
@@ -592,7 +584,6 @@ class AuthService:
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Current password is incorrect.",
             )
-
         validate_password(new_password)
 
         if self._is_password_reused(user, new_password):
@@ -600,7 +591,6 @@ class AuthService:
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="You cannot reuse one of your last 5 passwords.",
             )
-
         self._save_password_history(user)
 
         user.password_hash = hash_password(new_password)
@@ -629,7 +619,6 @@ class AuthService:
                 "success": True,
                 "message": "Email already verified.",
             }
-
         user.is_verified = True
         user.email_verified_at = datetime.now(timezone.utc)
 
@@ -657,7 +646,6 @@ class AuthService:
             if db_token and str(db_token.user_id) == str(user.id):
                 RefreshTokenService.revoke_token(self.db, db_token)
                 self.db.commit()
-
         event_bus.publish(
             "USER_LOGOUT",
             email=user.email,
@@ -702,7 +690,6 @@ class AuthService:
                 "success": True,
                 "message": ("If the account exists, a reset email has been sent."),
             }
-
         pwd_hash_frag = user.password_hash[-10:] if user.password_hash else "nohash"
 
         token = _create_token(
@@ -751,7 +738,6 @@ class AuthService:
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Invalid or expired reset token.",
             )
-
         validate_password(new_password)
 
         user = self.get_current_user(user_id)
@@ -762,13 +748,11 @@ class AuthService:
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="This reset token has already been used.",
             )
-
         if self._is_password_reused(user, new_password):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="You cannot reuse one of your last 5 passwords.",
             )
-
         self._save_password_history(user)
 
         user.password_hash = hash_password(new_password)

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -117,10 +117,8 @@ class UserService:
                     {k: v for k, v in privacy_data.items() if v is not None}
                 )
                 db_user.privacy_settings = current_settings
-
         for key, value in data.items():
             setattr(db_user, key, value)
-
         db.flush()
         db.refresh(db_user)
 
@@ -149,11 +147,9 @@ class UserService:
             update_data = settings
         else:
             update_data = {}
-
         for k, v in update_data.items():
             if v is not None:
                 current_settings[k] = v.value if hasattr(v, "value") else str(v)
-
         db_user.privacy_settings = current_settings
         db.flush()
         db.refresh(db_user)
@@ -167,10 +163,8 @@ class UserService:
     ) -> User:
         if not user:
             return user
-
         if viewer and (viewer.id == user.id or getattr(viewer, "is_superuser", False)):
             return user
-
         settings = user.get_privacy_settings()
         from app.services.follower_service import FollowerService
 
@@ -196,24 +190,18 @@ class UserService:
             db.expunge(user)
         except Exception:
             pass
-
         if not is_visible(settings.get("email", "private")):
             user.public_email = None
-
         if not is_visible(settings.get("github", "public")):
             user.github_url = None
-
         if not is_visible(settings.get("resume", "public")):
             user.resume_url = None
-
         if not is_visible(settings.get("social_links", "public")):
             user.linkedin_url = None
             user.website = None
             user.portfolio_url = None
-
         if not is_visible(settings.get("availability", "public")):
             user.availability = []
-
         return user
 
     @staticmethod
@@ -338,7 +326,6 @@ class UserService:
         user = db.get(User, user_id)
         if user:
             UserService.update_user_badges(db, user, stats)
-
         return stats
 
     @staticmethod
@@ -352,13 +339,10 @@ class UserService:
             new_badges.append("Top Contributor")
         elif stats.accepted >= 1:
             new_badges.append("Active Developer")
-
         if stats.projects >= 1:
             new_badges.append("Project Owner")
-
         if stats.followers >= 10:
             new_badges.append("Social Butterfly")
-
         if set(user.badges) != set(new_badges):
             user.badges = new_badges
             db.add(user)
@@ -400,14 +384,15 @@ class UserService:
         missing: list[str] = []
 
         # 1. Avatar
+
         if not (user.profile_image and user.profile_image.strip()):
             missing.append("Avatar")
-
         # 2. Bio
+
         if not (user.bio and user.bio.strip()):
             missing.append("Bio")
-
         # 3. Skills
+
         skills_count = (
             db.scalar(
                 select(func.count())
@@ -418,8 +403,8 @@ class UserService:
         )
         if skills_count == 0:
             missing.append("Skills")
-
         # 4. Experience
+
         has_exp = bool(
             (user.experience_level and user.experience_level.strip())
             or (user.role and user.role.strip())
@@ -427,27 +412,26 @@ class UserService:
         )
         if not has_exp:
             missing.append("Experience")
-
         # 5. GitHub
+
         has_github = bool(
             (user.github_url and str(user.github_url).strip())
             or (user.github_id and str(user.github_id).strip())
         )
         if not has_github:
             missing.append("GitHub")
-
         # 6. Portfolio
+
         has_portfolio = bool(
             (user.portfolio_url and str(user.portfolio_url).strip())
             or (user.website and str(user.website).strip())
         )
         if not has_portfolio:
             missing.append("Portfolio")
-
         # 7. Location
+
         if not (user.location and user.location.strip()):
             missing.append("Location")
-
         total_factors = 7
         completed_factors = total_factors - len(missing)
         completion_pct = round((completed_factors / total_factors) * 100)
@@ -481,7 +465,6 @@ class UserService:
         db.refresh(user)
 
         return user
-
 
     @staticmethod
     def create_user_report(

--- a/backend/app/utils/uploads.py
+++ b/backend/app/utils/uploads.py
@@ -20,11 +20,9 @@ def validate_resume_upload(
 ) -> None:
     if not filename or not filename.lower().endswith(".pdf"):
         raise ValueError("Please upload a PDF file.")
-
     normalized_content_type = (content_type or "").lower()
     if normalized_content_type not in ALLOWED_RESUME_MIME_TYPES:
         raise ValueError("Please upload a PDF file.")
-
     if size_bytes > MAX_RESUME_SIZE_BYTES:
         raise ValueError(
             f"Resume file must be smaller than {settings.RESUME_MAX_SIZE_MB}MB."
@@ -50,19 +48,19 @@ def validate_image_upload(
     """
     if not filename:
         raise ValueError("Please upload an image file.")
-
     ext = Path(filename).suffix.lower()
     allowed_exts = {".png", ".jpg", ".jpeg", ".webp", ".gif", ".bmp", ".tiff"}
     if ext not in allowed_exts:
         raise ValueError(
             f"Unsupported file extension: {ext}. Allowed: {', '.join(allowed_exts)}"
         )
-
     normalized_content_type = (content_type or "").lower()
-    if normalized_content_type and normalized_content_type not in ALLOWED_IMAGE_MIME_TYPES:
+    if (
+        normalized_content_type
+        and normalized_content_type not in ALLOWED_IMAGE_MIME_TYPES
+    ):
         if not normalized_content_type.startswith("image/"):
             raise ValueError("Please upload a valid image file.")
-
     if size_bytes > MAX_IMAGE_SIZE_BYTES:
         raise ValueError(
             f"Image file size must be smaller than {settings.MAX_UPLOAD_SIZE_MB}MB."
@@ -109,9 +107,7 @@ def save_image_upload(
         thumb_path = upload_dir / thumb_filename
         thumb_path.write_bytes(result["thumbnail_bytes"])
         thumbnail_url = f"/uploads/{subfolder}/{thumb_filename}"
-
     return {
         "image_url": image_url,
         "thumbnail_url": thumbnail_url,
     }
-

--- a/frontend/src/components/shared/EmptySearchState.tsx
+++ b/frontend/src/components/shared/EmptySearchState.tsx
@@ -1,4 +1,3 @@
-import { SearchX } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 interface EmptySearchStateProps {
@@ -16,9 +15,20 @@ export function EmptySearchState({
 }: EmptySearchStateProps) {
   return (
     <div className="flex min-h-[400px] flex-col items-center justify-center animate-in fade-in duration-200">
-      <div className="mb-4 rounded-full bg-muted p-4">
-        <SearchX className="h-6 w-6 text-muted-foreground" />
-      </div>
+      <svg
+        width="120"
+        height="100"
+        viewBox="0 0 120 100"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        className="mb-4 animate-in zoom-in-50 duration-300"
+      >
+        <circle cx="50" cy="45" r="25" stroke="var(--muted-foreground)" strokeWidth="2" opacity="0.25" />
+        <line x1="68" y1="63" x2="80" y2="75" stroke="var(--muted-foreground)" strokeWidth="3" opacity="0.2" strokeLinecap="round" />
+        <line x1="42" y1="42" x2="58" y2="42" stroke="var(--primary)" strokeWidth="2" opacity="0.3" strokeLinecap="round" />
+        <line x1="42" y1="50" x2="54" y2="50" stroke="var(--primary)" strokeWidth="2" opacity="0.2" strokeLinecap="round" />
+        <circle cx="35" cy="25" r="3" fill="var(--primary)" opacity="0.15" />
+      </svg>
       <p className="text-[14px] font-semibold text-foreground">{title}</p>
       <p className="mt-1 max-w-xs text-center text-[13px] text-muted-foreground">{description}</p>
       {onReset && (

--- a/frontend/src/components/shared/EmptyState.tsx
+++ b/frontend/src/components/shared/EmptyState.tsx
@@ -1,0 +1,101 @@
+import { cn } from "@/lib/utils";
+import type { ReactNode } from "react";
+
+interface EmptyStateProps {
+  title: string;
+  desc?: string;
+  action?: ReactNode;
+  icon?: React.ComponentType<{ className?: string; size?: number }>;
+  illustration?: "empty-box" | "no-results" | "no-messages" | "no-notifications" | "no-bookmarks" | "no-projects";
+  className?: string;
+}
+
+export function EmptyState({
+  title,
+  desc,
+  action,
+  icon: Icon,
+  illustration,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div className={cn("flex flex-col items-center justify-center py-12 text-center animate-in fade-in duration-200", className)}>
+      <div className="mb-4">
+        {illustration ? (
+          <EmptyIllustration variant={illustration} />
+        ) : (
+          <div className="grid h-12 w-12 place-items-center rounded-2xl bg-primary-soft text-primary shadow-xs">
+            {Icon ? <Icon size={24} /> : "✨"}
+          </div>
+        )}
+      </div>
+      <p className="text-[14px] font-semibold text-foreground">{title}</p>
+      {desc && <p className="mt-1 max-w-xs text-[13px] text-muted-foreground">{desc}</p>}
+      {action && <div className="mt-4">{action}</div>}
+    </div>
+  );
+}
+
+function EmptyIllustration({ variant }: { variant: string }) {
+  return (
+    <svg
+      width="120"
+      height="100"
+      viewBox="0 0 120 100"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className="animate-in zoom-in-50 duration-300"
+    >
+      {variant === "empty-box" && (
+        <>
+          <rect x="30" y="30" width="60" height="50" rx="6" stroke="var(--muted-foreground)" strokeWidth="2" opacity="0.3" />
+          <rect x="40" y="40" width="40" height="30" rx="4" stroke="var(--primary)" strokeWidth="2" opacity="0.4" />
+          <line x1="50" y1="50" x2="70" y2="50" stroke="var(--primary)" strokeWidth="2" opacity="0.3" strokeLinecap="round" />
+          <line x1="50" y1="58" x2="65" y2="58" stroke="var(--primary)" strokeWidth="2" opacity="0.2" strokeLinecap="round" />
+          <circle cx="35" cy="25" r="3" fill="var(--primary)" opacity="0.2" />
+          <circle cx="85" cy="22" r="2" fill="var(--primary)" opacity="0.15" />
+        </>
+      )}
+      {variant === "no-results" && (
+        <>
+          <circle cx="50" cy="45" r="25" stroke="var(--muted-foreground)" strokeWidth="2" opacity="0.25" />
+          <line x1="68" y1="63" x2="80" y2="75" stroke="var(--muted-foreground)" strokeWidth="3" opacity="0.2" strokeLinecap="round" />
+          <line x1="42" y1="42" x2="58" y2="42" stroke="var(--primary)" strokeWidth="2" opacity="0.3" strokeLinecap="round" />
+          <line x1="42" y1="50" x2="54" y2="50" stroke="var(--primary)" strokeWidth="2" opacity="0.2" strokeLinecap="round" />
+          <circle cx="35" cy="25" r="3" fill="var(--primary)" opacity="0.15" />
+        </>
+      )}
+      {variant === "no-messages" && (
+        <>
+          <rect x="25" y="25" width="70" height="40" rx="8" stroke="var(--muted-foreground)" strokeWidth="2" opacity="0.25" />
+          <path d="M40 35 L55 35 M40 45 L65 45 M40 55 L50 55" stroke="var(--primary)" strokeWidth="2" opacity="0.3" strokeLinecap="round" />
+          <circle cx="35" cy="20" r="2" fill="var(--primary)" opacity="0.15" />
+          <circle cx="88" cy="22" r="2.5" fill="var(--primary)" opacity="0.2" />
+        </>
+      )}
+      {variant === "no-notifications" && (
+        <>
+          <path d="M50 25 C42 25 38 30 38 38 L38 55 L32 55 L68 55 L62 55 L62 38 C62 30 58 25 50 25" stroke="var(--muted-foreground)" strokeWidth="2" opacity="0.25" strokeLinejoin="round" />
+          <circle cx="50" cy="68" r="4" stroke="var(--primary)" strokeWidth="2" opacity="0.3" />
+          <circle cx="35" cy="22" r="2" fill="var(--primary)" opacity="0.15" />
+        </>
+      )}
+      {variant === "no-bookmarks" && (
+        <>
+          <path d="M35 25 L35 70 L50 58 L65 70 L65 25 Z" stroke="var(--muted-foreground)" strokeWidth="2" opacity="0.25" strokeLinejoin="round" />
+          <line x1="42" y1="35" x2="58" y2="35" stroke="var(--primary)" strokeWidth="2" opacity="0.2" strokeLinecap="round" />
+          <circle cx="30" cy="22" r="2.5" fill="var(--primary)" opacity="0.15" />
+        </>
+      )}
+      {variant === "no-projects" && (
+        <>
+          <rect x="30" y="25" width="25" height="25" rx="4" stroke="var(--muted-foreground)" strokeWidth="2" opacity="0.25" />
+          <rect x="65" y="30" width="25" height="25" rx="4" stroke="var(--primary)" strokeWidth="2" opacity="0.3" />
+          <rect x="45" y="60" width="25" height="25" rx="4" stroke="var(--muted-foreground)" strokeWidth="2" opacity="0.2" />
+          <circle cx="35" cy="20" r="2" fill="var(--primary)" opacity="0.15" />
+          <circle cx="90" cy="22" r="2" fill="var(--primary)" opacity="0.1" />
+        </>
+      )}
+    </svg>
+  );
+}

--- a/frontend/src/components/shared/MarkdownEditor.tsx
+++ b/frontend/src/components/shared/MarkdownEditor.tsx
@@ -272,6 +272,7 @@ export function MarkdownEditor({
               )}
             />
 
+            {/* Autocomplete Dropdown */}
             {mentionQuery !== null && filteredUsers.length > 0 && (
               <div className="absolute left-3 bottom-full mb-1 z-50 w-64 rounded-md border border-border bg-surface shadow-lg py-1 overflow-hidden">
                 <div className="px-2 py-1 text-[11px] font-semibold text-muted-foreground border-b border-border flex items-center gap-1">
@@ -300,19 +301,3 @@ export function MarkdownEditor({
         </TabsContent>
 
         <TabsContent value="preview" className="mt-2">
-          <div
-            id={previewId}
-            className="rounded-md border border-dashed border-border bg-surface p-3"
-            style={{ minHeight: `${rows * 1.6}em` }}
-          >
-            {value.trim() ? (
-              <Markdown content={value} />
-            ) : (
-              <p className="text-[13px] text-muted-foreground">Nothing to preview yet.</p>
-            )}
-          </div>
-        </TabsContent>
-      </Tabs>
-    </div>
-  );
-}

--- a/frontend/src/components/shared/MarkdownEditor.tsx
+++ b/frontend/src/components/shared/MarkdownEditor.tsx
@@ -272,7 +272,6 @@ export function MarkdownEditor({
               )}
             />
 
-            {/* Autocomplete Dropdown */}
             {mentionQuery !== null && filteredUsers.length > 0 && (
               <div className="absolute left-3 bottom-full mb-1 z-50 w-64 rounded-md border border-border bg-surface shadow-lg py-1 overflow-hidden">
                 <div className="px-2 py-1 text-[11px] font-semibold text-muted-foreground border-b border-border flex items-center gap-1">
@@ -314,9 +313,6 @@ export function MarkdownEditor({
           </div>
         </TabsContent>
       </Tabs>
-    </div>
-  );
-}
     </div>
   );
 }

--- a/frontend/src/components/shared/MarkdownEditor.tsx
+++ b/frontend/src/components/shared/MarkdownEditor.tsx
@@ -257,46 +257,47 @@ export function MarkdownEditor({
             </div>
           )}
 
-        <TabsContent value="write" className="relative mt-2">
-          <textarea
-            ref={textareaRef}
-            value={value}
-            onChange={handleTextareaChange}
-            onKeyDown={handleKeyDown}
-            placeholder={placeholder}
-            rows={rows}
-            autoFocus={autoFocus}
-            className={cn(
-              "w-full resize-y rounded-md border border-border bg-surface p-3 font-mono text-[13px] leading-relaxed text-foreground outline-none focus:border-primary focus:ring-2 focus:ring-primary/20",
-              textareaClassName,
-            )}
-          />
+          <div className="relative mt-2">
+            <textarea
+              ref={textareaRef}
+              value={value}
+              onChange={handleTextareaChange}
+              onKeyDown={handleKeyDown}
+              placeholder={placeholder}
+              rows={rows}
+              autoFocus={autoFocus}
+              className={cn(
+                "w-full resize-y rounded-md border border-border bg-surface p-3 font-mono text-[13px] leading-relaxed text-foreground outline-none focus:border-primary focus:ring-2 focus:ring-primary/20",
+                textareaClassName,
+              )}
+            />
 
-          {/* Autocomplete Dropdown */}
-          {mentionQuery !== null && filteredUsers.length > 0 && (
-            <div className="absolute left-3 bottom-full mb-1 z-50 w-64 rounded-md border border-border bg-surface shadow-lg py-1 overflow-hidden">
-              <div className="px-2 py-1 text-[11px] font-semibold text-muted-foreground border-b border-border flex items-center gap-1">
-                <AtSign size={12} /> Mention User
+            {/* Autocomplete Dropdown */}
+            {mentionQuery !== null && filteredUsers.length > 0 && (
+              <div className="absolute left-3 bottom-full mb-1 z-50 w-64 rounded-md border border-border bg-surface shadow-lg py-1 overflow-hidden">
+                <div className="px-2 py-1 text-[11px] font-semibold text-muted-foreground border-b border-border flex items-center gap-1">
+                  <AtSign size={12} /> Mention User
+                </div>
+                {filteredUsers.map((user, i) => (
+                  <button
+                    key={user.id}
+                    type="button"
+                    onClick={() => insertMention(user.id)}
+                    className={cn(
+                      "flex w-full items-center gap-2.5 px-3 py-2 text-left text-[12px] transition-colors",
+                      i === mentionIndex ? "bg-primary/10 text-primary font-medium" : "hover:bg-muted text-foreground"
+                    )}
+                  >
+                    <Avatar src={user.avatar} alt={user.name} size={20} />
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-[12px] font-medium">{user.name}</p>
+                      <p className="truncate text-[10px] text-muted-foreground">@{user.id}</p>
+                    </div>
+                  </button>
+                ))}
               </div>
-              {filteredUsers.map((user, i) => (
-                <button
-                  key={user.id}
-                  type="button"
-                  onClick={() => insertMention(user.id)}
-                  className={cn(
-                    "flex w-full items-center gap-2.5 px-3 py-2 text-left text-[12px] transition-colors",
-                    i === mentionIndex ? "bg-primary/10 text-primary font-medium" : "hover:bg-muted text-foreground"
-                  )}
-                >
-                  <Avatar src={user.avatar} alt={user.name} size={20} />
-                  <div className="min-w-0 flex-1">
-                    <p className="truncate text-[12px] font-medium">{user.name}</p>
-                    <p className="truncate text-[10px] text-muted-foreground">@{user.id}</p>
-                  </div>
-                </button>
-              ))}
-            </div>
-          )}
+            )}
+          </div>
         </TabsContent>
 
         <TabsContent value="preview" className="mt-2">
@@ -313,6 +314,9 @@ export function MarkdownEditor({
           </div>
         </TabsContent>
       </Tabs>
+    </div>
+  );
+}
     </div>
   );
 }

--- a/frontend/src/components/shared/primitives.tsx
+++ b/frontend/src/components/shared/primitives.tsx
@@ -95,16 +95,24 @@ export function EmptyState({
   desc,
   action,
   icon: Icon,
+  illustration,
 }: {
   title: string;
   desc?: string;
   action?: ReactNode;
-  icon?: React.ComponentType<{ size?: number }>;
+  icon?: React.ComponentType<{ size?: number; className?: string }>;
+  illustration?: "empty-box" | "no-results" | "no-messages" | "no-notifications" | "no-bookmarks" | "no-projects";
 }) {
   return (
-    <div className="flex flex-col items-center justify-center py-12 text-center">
-      <div className="mb-3 grid h-12 w-12 place-items-center rounded-2xl bg-primary-soft text-primary shadow-xs">
-        {Icon ? <Icon size={24} /> : "✨"}
+    <div className="flex flex-col items-center justify-center py-12 text-center animate-in fade-in duration-200">
+      <div className="mb-4">
+        {illustration ? (
+          <EmptyIllustration variant={illustration} />
+        ) : (
+          <div className="mb-3 grid h-12 w-12 place-items-center rounded-2xl bg-primary-soft text-primary shadow-xs">
+            {Icon ? <Icon size={24} /> : "✨"}
+          </div>
+        )}
       </div>
       <p className="text-[14px] font-semibold text-foreground">{title}</p>
       {desc && <p className="mt-1 max-w-xs text-[13px] text-muted-foreground">{desc}</p>}
@@ -113,6 +121,69 @@ export function EmptyState({
   );
 }
 
+function EmptyIllustration({ variant }: { variant: string }) {
+  return (
+    <svg
+      width="120"
+      height="100"
+      viewBox="0 0 120 100"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className="animate-in zoom-in-50 duration-300"
+    >
+      {variant === "empty-box" && (
+        <>
+          <rect x="30" y="30" width="60" height="50" rx="6" stroke="var(--muted-foreground)" strokeWidth="2" opacity="0.3" />
+          <rect x="40" y="40" width="40" height="30" rx="4" stroke="var(--primary)" strokeWidth="2" opacity="0.4" />
+          <line x1="50" y1="50" x2="70" y2="50" stroke="var(--primary)" strokeWidth="2" opacity="0.3" strokeLinecap="round" />
+          <line x1="50" y1="58" x2="65" y2="58" stroke="var(--primary)" strokeWidth="2" opacity="0.2" strokeLinecap="round" />
+          <circle cx="35" cy="25" r="3" fill="var(--primary)" opacity="0.2" />
+          <circle cx="85" cy="22" r="2" fill="var(--primary)" opacity="0.15" />
+        </>
+      )}
+      {variant === "no-results" && (
+        <>
+          <circle cx="50" cy="45" r="25" stroke="var(--muted-foreground)" strokeWidth="2" opacity="0.25" />
+          <line x1="68" y1="63" x2="80" y2="75" stroke="var(--muted-foreground)" strokeWidth="3" opacity="0.2" strokeLinecap="round" />
+          <line x1="42" y1="42" x2="58" y2="42" stroke="var(--primary)" strokeWidth="2" opacity="0.3" strokeLinecap="round" />
+          <line x1="42" y1="50" x2="54" y2="50" stroke="var(--primary)" strokeWidth="2" opacity="0.2" strokeLinecap="round" />
+          <circle cx="35" cy="25" r="3" fill="var(--primary)" opacity="0.15" />
+        </>
+      )}
+      {variant === "no-messages" && (
+        <>
+          <rect x="25" y="25" width="70" height="40" rx="8" stroke="var(--muted-foreground)" strokeWidth="2" opacity="0.25" />
+          <path d="M40 35 L55 35 M40 45 L65 45 M40 55 L50 55" stroke="var(--primary)" strokeWidth="2" opacity="0.3" strokeLinecap="round" />
+          <circle cx="35" cy="20" r="2" fill="var(--primary)" opacity="0.15" />
+          <circle cx="88" cy="22" r="2.5" fill="var(--primary)" opacity="0.2" />
+        </>
+      )}
+      {variant === "no-notifications" && (
+        <>
+          <path d="M50 25 C42 25 38 30 38 38 L38 55 L32 55 L68 55 L62 55 L62 38 C62 30 58 25 50 25" stroke="var(--muted-foreground)" strokeWidth="2" opacity="0.25" strokeLinejoin="round" />
+          <circle cx="50" cy="68" r="4" stroke="var(--primary)" strokeWidth="2" opacity="0.3" />
+          <circle cx="35" cy="22" r="2" fill="var(--primary)" opacity="0.15" />
+        </>
+      )}
+      {variant === "no-bookmarks" && (
+        <>
+          <path d="M35 25 L35 70 L50 58 L65 70 L65 25 Z" stroke="var(--muted-foreground)" strokeWidth="2" opacity="0.25" strokeLinejoin="round" />
+          <line x1="42" y1="35" x2="58" y2="35" stroke="var(--primary)" strokeWidth="2" opacity="0.2" strokeLinecap="round" />
+          <circle cx="30" cy="22" r="2.5" fill="var(--primary)" opacity="0.15" />
+        </>
+      )}
+      {variant === "no-projects" && (
+        <>
+          <rect x="30" y="25" width="25" height="25" rx="4" stroke="var(--muted-foreground)" strokeWidth="2" opacity="0.25" />
+          <rect x="65" y="30" width="25" height="25" rx="4" stroke="var(--primary)" strokeWidth="2" opacity="0.3" />
+          <rect x="45" y="60" width="25" height="25" rx="4" stroke="var(--muted-foreground)" strokeWidth="2" opacity="0.2" />
+          <circle cx="35" cy="20" r="2" fill="var(--primary)" opacity="0.15" />
+          <circle cx="90" cy="22" r="2" fill="var(--primary)" opacity="0.1" />
+        </>
+      )}
+    </svg>
+  );
+}
 export function TagChip({ children, className }: { children: ReactNode; className?: string }) {
   return (
     <span


### PR DESCRIPTION
# Pull Request

## Summary

Added simple inline SVG illustrations to empty state components across the app to enhance visual feedback while maintaining the existing design language (GitHub-like color scheme, cyan primary, Inter font, Tailwind v4 tokens).

---

## Related Issue

Fixes #350

---

## Type of Change

Please check the relevant option(s):

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [x] UI/UX enhancement
- [ ] Tests
- [ ] Other

---

## Changes Made

Describe the key changes included in this pull request.

- **`frontend/src/components/shared/EmptyState.tsx`**: Added a reusable empty state component with built-in SVG illustrations for 6 variants (`empty-box`, `no-results`, `no-messages`, `no-notifications`, `no-bookmarks`, `no-projects`).
- **`frontend/src/components/shared/primitives.tsx`**: Updated the inline `EmptyState` component to accept an optional `illustration` prop to render themed SVGs while preserving the `icon` prop for backward compatibility.
- **`frontend/src/components/shared/EmptySearchState.tsx`**: Replaced the Lucide `SearchX` icon with a matching themed SVG illustration.
- **Illustration Design**: Built lightweight inline SVGs using project CSS variables (`--primary`, `--muted-foreground`) for native light/dark mode adaptation and subtle entry animations via `tw-animate-css` (`animate-in zoom-in-50`).

---

## Screenshots (if applicable)

*N/A*

---

## Testing

Describe how you tested your changes.

- [x] Tested locally
- [ ] Existing tests pass
- [ ] Added new tests
- [x] UI verified
- [ ] Cross-browser tested (if applicable)

Additional testing notes:
- Verified rendering and theme switching across both light and dark modes.
- Confirmed backward compatibility for existing components utilizing the `icon` prop fallback.

---

## Checklist

Before submitting this pull request, confirm the following:

- [x] My code follows the project's coding standards.
- [x] I have tested my changes locally.
- [ ] I have updated the documentation where necessary.
- [x] My changes do not introduce new warnings or errors.
- [x] I have reviewed my own code.
- [x] This pull request focuses on a single feature or fix.
- [x] I have linked the related issue.

---

## Additional Notes

- Uses inline SVGs only—no external image assets or additional `npm` dependencies were added.