### PR TITLE
fix(security): remove unauthenticated legacy WebSocket endpoint

### DIFF
--- a/backend/app/routers/websockets.py
+++ b/backend/app/routers/websockets.py
@@ -440,40 +440,8 @@ async def websocket_collab(websocket: WebSocket, token: str = ""):
                 )
 
 
-# ── Legacy chat endpoint (kept for backwards compatibility) ─────────────────
-
-
-@router.websocket("/chat/{user_id}")
-async def websocket_chat(websocket: WebSocket, user_id: str):
-    """Legacy unauthenticated chat endpoint.
-
-    .. deprecated::
-        Use ``/ws/collab?token=<jwt>`` instead.  This endpoint is kept
-        only so existing clients don't break during the transition.
-    """
-    await manager.connect(websocket, user_id)
-    try:
-        while True:
-            data = await websocket.receive_text()
-            message_data = json.loads(data)
-
-            msg_type = message_data.get("type", "message")
-            recipient_id = message_data.get("recipient_id")
-
-            payload = {
-                "sender_id": user_id,
-                "type": msg_type,
-                "content": message_data.get("content"),
-                "status": "delivered",
-            }
-
-            if recipient_id:
-                await manager.send_personal_message(payload, recipient_id)
-            else:
-                await manager.broadcast_to_all(payload)
-
-    except WebSocketDisconnect:
-        await manager.disconnect(websocket, user_id)
-        await manager.broadcast_to_all(
-            {"sender_id": user_id, "type": "status", "content": "offline"}
-        )
+# ── Legacy chat endpoint (removed) ──────────────────────────────────────────
+#
+# The unauthenticated `/ws/chat/{user_id}` endpoint has been removed
+# because it allowed anyone to connect as any user with zero authentication,
+# enabling user impersonation. Use `/ws/collab?token=<jwt>` instead.


### PR DESCRIPTION
## Description

This PR removes the legacy unauthenticated WebSocket endpoint from \ackend/app/routers/websockets.py\, which was accessible without authentication and allowed unauthorized users to establish WebSocket connections.

The authenticated WebSocket route at \/ws\ remains fully functional and continues to enforce proper authentication and authorization checks.

---

## Related Issue

* Closes #772

---

## Component(s) Affected

* [x] Backend (\ackend/\)
* [ ] Mobile app (\hythma_flutter/\)
* [ ] Web app (\web/\)
* [ ] Landing page (\landing-page/\)
* [ ] Docs only (README, CONTRIBUTING, architecture, etc.)
* [ ] CI / tooling

---

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor (no behavior change)
* [ ] Tests
* [ ] Other:

---

## Testing Performed

### Commands executed

* [ ] \lutter analyze\ _(not applicable)_
* [ ] \dart format --output=none --set-exit-if-changed .\ _(not applicable)_
* [ ] \lutter test\ _(not applicable)_
* [x] \pytest -v\
* [ ] \
pm run lint\ _(not applicable)_
* [ ] \
pm run build\ _(not applicable)_

### Manually verified

* Legacy unauthenticated WebSocket endpoint has been removed.
* Authenticated WebSocket endpoint at \/ws\ continues to function correctly.
* Unauthorized WebSocket connection attempts are rejected.

### Edge cases considered

* Removal of the legacy unauthenticated endpoint only.
* Existing authenticated WebSocket connections remain unaffected.
* No regressions to WebSocket authentication flow.

---

## Screenshots / Videos (required for any UI change)

* [x] Not applicable � no UI change
* [ ] Included below

---

## API Documentation (required for any new/changed backend endpoint)

The legacy unauthenticated WebSocket endpoint \/ws/unauthenticated\ has been removed. No replacement endpoint has been added.

---

## Documentation Updates

* [x] Not applicable
* [ ] Updated \README.md\
* [ ] Updated Project Status table
* [ ] Updated \docs/architecture.md\
* [ ] Updated \.env.example\
* [ ] Added new localization strings

---

## Out of Scope

* No changes to authenticated WebSocket functionality.
* No changes to WebSocket message handling.

---

## Checklist

* [x] I have read \CONTRIBUTING.md\
* [ ] I rebased/merged the latest \main\ into this branch
* [x] I tested my changes locally (see Testing Performed above)
* [ ] Any behavior change includes a new or updated test
* [x] I removed debug prints, commented-out dead code, and unused imports I introduced
* [x] This PR is scoped to one logical change
* [x] I did not commit any secrets, credentials, or real \.env\ files