### PR TITLE
fix(security): scope idempotency keys per-user to prevent cross-user cache hits

### DIFF
--- a/backend/app/middleware/idempotency.py
+++ b/backend/app/middleware/idempotency.py
@@ -5,6 +5,7 @@ from typing import Callable
 import redis
 from fastapi import Request, Response
 from fastapi.routing import APIRoute
+from jose import JWTError, jwt
 
 from app.core.config import settings
 
@@ -16,6 +17,23 @@ try:
 except Exception as e:
     logger.error(f"Failed to connect to Redis for idempotency: {e}")
     redis_client = None
+
+
+def _extract_user_id(request: Request) -> str:
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.startswith("Bearer "):
+        try:
+            payload = jwt.decode(
+                auth_header[7:],
+                settings.SECRET_KEY,
+                algorithms=[settings.JWT_ALGORITHM],
+            )
+            sub = payload.get("sub")
+            if sub:
+                return str(sub)
+        except JWTError:
+            pass
+    return "anonymous"
 
 
 class IdempotentRoute(APIRoute):
@@ -41,10 +59,7 @@ class IdempotentRoute(APIRoute):
                 )
                 return await original_route_handler(request)
 
-            # Ensure uniqueness by user if auth exists, otherwise just key
-            user_id = "anonymous"
-            if "Authorization" in request.headers:
-                user_id = "authenticated"
+            user_id = _extract_user_id(request)
 
             cache_key = f"idempotent:{user_id}:{idempotency_key}"
 


### PR DESCRIPTION
## Description

This PR fixes a security vulnerability in the idempotency middleware (\ackend/app/middleware/idempotency.py\) where **all authenticated users shared the same cache key** (\"authenticated"\). Two users sending requests with the same \Idempotency-Key\ header would receive each other's cached responses.

**Fix:** Added \_extract_user_id()\ helper that decodes the JWT from the \Authorization\ header and scopes the idempotency cache key to the actual user ID. Unauthenticated requests fall back to \"anonymous"\.

---

## Related Issue

* Closes #773

---

## Component(s) Affected

* [x] Backend (\ackend/\)
* [ ] Mobile app (\hythma_flutter/\)
* [ ] Web app (\web/\)
* [ ] Landing page (\landing-page/\)
* [ ] Docs only (README, CONTRIBUTING, architecture, etc.)
* [ ] CI / tooling

---

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor (no behavior change)
* [ ] Tests
* [ ] Other:

---

## Testing Performed

### Commands executed

* [ ] \lutter analyze\ _(not applicable)_
* [ ] \dart format --output=none --set-exit-if-changed .\ _(not applicable)_
* [ ] \lutter test\ _(not applicable)_
* [x] \pytest -v\
* [ ] \
pm run lint\ _(not applicable)_
* [ ] \
pm run build\ _(not applicable)_

### Manually verified

* Idempotency keys are now scoped per user.
* Different users using the same \Idempotency-Key\ header receive independent cached responses.
* Unauthenticated requests continue to work using the \"anonymous"\ scope.
* Invalid or malformed JWTs correctly fall back to the \"anonymous"\ scope.

### Edge cases considered

* Missing \Authorization\ header.
* Invalid or expired JWT tokens.
* Redis unavailable (falls through to handler).

---

## Screenshots / Videos (required for any UI change)

* [x] Not applicable � no UI change
* [ ] Included below

---

## API Documentation (required for any new/changed backend endpoint)

No API contract changes. The internal cache key format has changed from:

\\\	ext
idempotent:authenticated:{key}
\\\

to:

\\\	ext
idempotent:{user_id}:{key}
\\\

---

## Documentation Updates

* [x] Not applicable
* [ ] Updated \README.md\
* [ ] Updated Project Status table
* [ ] Updated \docs/architecture.md\
* [ ] Updated \.env.example\
* [ ] Added new localization strings

---

## Out of Scope

* No changes to idempotency key TTL (24 hours).
* No changes to rate limiting.

---

## Checklist

* [x] I have read \CONTRIBUTING.md\
* [ ] I rebased/merged the latest \main\ into this branch
* [x] I tested my changes locally (see Testing Performed above)
* [ ] Any behavior change includes a new or updated test
* [x] I removed debug prints, commented-out dead code, and unused imports I introduced
* [x] This PR is scoped to one logical change
* [x] I did not commit any secrets, credentials, or real \.env\ files