### PR TITLE
feat(errors): implement React SectionErrorBoundary components with fallback UI, logging hook, and retry options

### DIFF
--- a/frontend/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/frontend/src/components/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { SectionErrorBoundary } from "../errors/SectionErrorBoundary";
+
+function ProblematicComponent({ shouldThrow }: { shouldThrow?: boolean }) {
+  if (shouldThrow) {
+    throw new Error("Test runtime failure");
+  }
+  return <div>Normal Content</div>;
+}
+
+describe("SectionErrorBoundary", () => {
+  const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  afterEach(() => {
+    consoleErrorSpy.mockClear();
+  });
+
+  it("renders children when no error occurs", () => {
+    render(
+      <SectionErrorBoundary sectionName="TestSection">
+        <ProblematicComponent shouldThrow={false} />
+      </SectionErrorBoundary>,
+    );
+
+    expect(screen.getByText("Normal Content")).toBeInTheDocument();
+  });
+
+  it("renders friendly fallback UI when children throw an error", () => {
+    render(
+      <SectionErrorBoundary sectionName="TestSection">
+        <ProblematicComponent shouldThrow={true} />
+      </SectionErrorBoundary>,
+    );
+
+    expect(screen.getByText("Something went wrong in TestSection")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
+  });
+
+  it("calls onRetry callback and attempts to reset error boundary on retry button click", () => {
+    const onRetryMock = vi.fn();
+
+    render(
+      <SectionErrorBoundary sectionName="TestSection" onRetry={onRetryMock}>
+        <ProblematicComponent shouldThrow={true} />
+      </SectionErrorBoundary>,
+    );
+
+    const retryButton = screen.getByRole("button", { name: /try again/i });
+    fireEvent.click(retryButton);
+
+    expect(onRetryMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/errors/SectionErrorBoundary.tsx
+++ b/frontend/src/components/errors/SectionErrorBoundary.tsx
@@ -1,0 +1,124 @@
+import React, { Component, type ReactNode } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import { reportLovableError } from "@/lib/lovable-error-reporting";
+
+export interface SectionErrorBoundaryProps {
+  children: ReactNode;
+  sectionName?: string;
+  fallback?: ReactNode;
+  onRetry?: () => void;
+  onError?: (error: Error, errorInfo: React.ErrorInfo) => void;
+}
+
+interface SectionErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+  errorInfo: React.ErrorInfo | null;
+  showDetails: boolean;
+}
+
+export class SectionErrorBoundary extends Component<
+  SectionErrorBoundaryProps,
+  SectionErrorBoundaryState
+> {
+  public state: SectionErrorBoundaryState = {
+    hasError: false,
+    error: null,
+    errorInfo: null,
+    showDetails: false,
+  };
+
+  public static getDerivedStateFromError(error: Error): Partial<SectionErrorBoundaryState> {
+    return { hasError: true, error };
+  }
+
+  public componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    this.setState({ errorInfo });
+
+    // Execute custom onError callback if passed
+    this.props.onError?.(error, errorInfo);
+
+    // Log to reporting service
+    const sectionName = this.props.sectionName || "section";
+    console.error(`[SectionErrorBoundary:${sectionName}]`, error, errorInfo);
+    reportLovableError(error, {
+      boundary: `SectionErrorBoundary_${sectionName}`,
+      componentStack: errorInfo.componentStack,
+    });
+  }
+
+  public handleReset = (): void => {
+    this.props.onRetry?.();
+    this.setState({ hasError: false, error: null, errorInfo: null, showDetails: false });
+  };
+
+  public toggleDetails = (): void => {
+    this.setState((prev) => ({ showDetails: !prev.showDetails }));
+  };
+
+  public render(): ReactNode {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+
+      const sectionName = this.props.sectionName || "Section";
+      const { error, errorInfo, showDetails } = this.state;
+
+      return (
+        <div className="my-4 rounded-xl border border-destructive/30 bg-destructive/5 p-6 shadow-2xs transition-all">
+          <div className="flex items-start gap-4">
+            <div className="grid h-10 w-10 shrink-0 place-items-center rounded-lg bg-destructive/10 text-destructive">
+              <AlertTriangle size={20} />
+            </div>
+
+            <div className="min-w-0 flex-1">
+              <h3 className="text-[15px] font-semibold tracking-tight text-foreground">
+                Something went wrong in {sectionName}
+              </h3>
+              <p className="mt-1 text-[13px] text-muted-foreground leading-relaxed">
+                An unexpected error occurred while loading this part of the application. You can try
+                reloading this section or refreshing the page.
+              </p>
+
+              <div className="mt-4 flex flex-wrap items-center gap-3">
+                <button
+                  type="button"
+                  onClick={this.handleReset}
+                  className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3.5 py-1.5 text-[12.5px] font-semibold text-primary-foreground transition-opacity hover:opacity-90 active:scale-95 cursor-pointer shadow-2xs"
+                >
+                  <RefreshCw size={14} /> Try again
+                </button>
+
+                {error && (
+                  <button
+                    type="button"
+                    onClick={this.toggleDetails}
+                    className="inline-flex items-center gap-1 rounded-md border border-border bg-surface px-3 py-1.5 text-[12px] font-medium text-foreground transition-colors hover:bg-muted cursor-pointer"
+                  >
+                    {showDetails ? "Hide error details" : "Show error details"}
+                  </button>
+                )}
+              </div>
+
+              {showDetails && error && (
+                <div className="mt-4 rounded-lg border border-border/80 bg-surface p-3 font-mono text-[11px] text-destructive overflow-x-auto">
+                  <p className="font-semibold">
+                    {error.name}: {error.message}
+                  </p>
+                  {errorInfo?.componentStack && (
+                    <pre className="mt-2 text-muted-foreground whitespace-pre-wrap">
+                      {errorInfo.componentStack}
+                    </pre>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/src/components/errors/index.ts
+++ b/frontend/src/components/errors/index.ts
@@ -1,0 +1,7 @@
+export * from "./SectionErrorBoundary";
+export * from "./ErrorLayout";
+export * from "./ForbiddenPage";
+export * from "./NetworkErrorPage";
+export * from "./OfflinePage";
+export * from "./ServerErrorPage";
+export * from "./UnauthorizedPage";

--- a/frontend/src/components/layout/DashboardLayout.tsx
+++ b/frontend/src/components/layout/DashboardLayout.tsx
@@ -6,6 +6,7 @@ import { TopNavbar } from "./TopNavbar";
 import { RightPanel } from "./RightPanel";
 import { BottomNavigation } from "./BottomNavigation";
 import { FAB } from "./FAB";
+import { SectionErrorBoundary } from "@/components/errors/SectionErrorBoundary";
 
 export function DashboardLayout() {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
@@ -38,14 +39,18 @@ export function DashboardLayout() {
               transition={{ duration: 0.18, ease: "easeOut" }}
               className="mx-auto w-full max-w-[1400px] px-4 py-6 sm:px-6"
             >
-              <Outlet />
+              <SectionErrorBoundary sectionName="Page View">
+                <Outlet />
+              </SectionErrorBoundary>
             </motion.div>
           </AnimatePresence>
         </main>
       </div>
 
       {/* ─── Desktop Right Activity Panel ─────────────────────────── */}
-      <RightPanel />
+      <SectionErrorBoundary sectionName="Right Activity Panel">
+        <RightPanel />
+      </SectionErrorBoundary>
 
       {/* ─── Mobile-only: Bottom Navigation & FAB ─────────────────── */}
       <BottomNavigation />

--- a/frontend/src/hooks/useErrorLogger.ts
+++ b/frontend/src/hooks/useErrorLogger.ts
@@ -1,0 +1,26 @@
+import { useCallback } from "react";
+import { reportLovableError } from "@/lib/lovable-error-reporting";
+
+export interface ErrorLogPayload {
+  error: Error;
+  errorInfo?: React.ErrorInfo | { componentStack?: string };
+  sectionName?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export function useErrorLogger() {
+  const logError = useCallback(
+    ({ error, errorInfo, sectionName = "unknown_section", metadata }: ErrorLogPayload) => {
+      console.error(`[ErrorBoundary:${sectionName}] Captured runtime error:`, error, errorInfo);
+
+      reportLovableError(error, {
+        boundary: `section_${sectionName}`,
+        componentStack: errorInfo?.componentStack ?? "",
+        ...metadata,
+      });
+    },
+    [],
+  );
+
+  return { logError };
+}


### PR DESCRIPTION
## Description
This PR implements React Error Boundary components for critical application sections to prevent whole-page crashes when unhandled runtime errors occur.

Closes #577
ECSoc 2026 Contribution

---

## Acceptance Criteria Checklist
- [x] **Friendly Fallback UI**: Designed an error fallback card featuring an alert icon, clear error title, explanatory message, and optional collapsible technical stack trace details.
- [x] **Error Logging Hook**: Created `useErrorLogger` custom hook and integrated error reporting via `reportLovableError` and console diagnostics.
- [x] **Retry Option**: Included a "Try again" button that resets the error boundary state and invokes `onRetry` callback to re-render the section.

---

## Changes Made
- `frontend/src/components/errors/SectionErrorBoundary.tsx`: Created class-based React Error Boundary component with state reset, reporting integration, and fallback UI.
- `frontend/src/hooks/useErrorLogger.ts`: Created error logging hook.
- `frontend/src/components/errors/index.ts`: Exported error boundaries and error pages.
- `frontend/src/components/layout/DashboardLayout.tsx`: Wrapped main page view (`<Outlet />`) and Right Activity Panel (`<RightPanel />`) in `<SectionErrorBoundary>`.
- `frontend/src/components/__tests__/ErrorBoundary.test.tsx`: Added Vitest unit test suite for Error Boundary rendering, error capturing, and retry behavior.

---

## Testing Performed
- Ran `npm test` — Error Boundary Vitest test suite passed.
- Tested component error simulation to verify fallback UI and retry button state reset.
- Ran `npm run typecheck` & `npm run lint` — passed with 0 errors.
