### PR TITLE
feat(maintenance): implement scheduled maintenance mode with admin UI and 503 middleware (fixes #651)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,6 +25,7 @@ from app.middleware.rate_limit import limiter
 from app.middleware.structured_logging import StructuredLoggingMiddleware
 from app.middleware.security_headers import SecurityHeadersMiddleware
 from app.middleware.activity import ActivityTrackingMiddleware
+from app.middleware.maintenance import MaintenanceMiddleware
 from app.middleware.rate_limit import limiter
 
 # pyrefly: ignore [missing-import]
@@ -68,6 +69,7 @@ from app.routers import (
     search,
     saved_searches,
     media,
+    maintenance,
 )
 
 
@@ -367,6 +369,7 @@ app.add_middleware(SlowAPIMiddleware)
 app.add_middleware(StructuredLoggingMiddleware)
 app.add_middleware(SecurityHeadersMiddleware)
 app.add_middleware(ActivityTrackingMiddleware)
+app.add_middleware(MaintenanceMiddleware)
 
 from app.middleware.audit_context import AuditContextMiddleware
 app.add_middleware(AuditContextMiddleware)
@@ -547,6 +550,7 @@ app.include_router(
     repository_quality.router, prefix="/api", tags=["Repository Quality"]
 )
 app.include_router(health.router)
+app.include_router(maintenance.router, prefix="/api")
 app.include_router(search.router, prefix="/api/search", tags=["Search"])
 app.include_router(saved_searches.router)
 app.include_router(hackathons.router, prefix="/api/hackathons", tags=["Hackathons"])

--- a/backend/app/middleware/maintenance.py
+++ b/backend/app/middleware/maintenance.py
@@ -1,0 +1,86 @@
+import time
+from datetime import datetime, timezone
+import typing
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from cachetools import TTLCache
+
+from app.database.session import SessionLocal
+from app.models.maintenance import MaintenanceWindow
+from app.models.user import UserRole
+from app.api.deps import verify_token
+
+# Cache the maintenance window state for 30 seconds
+maintenance_cache = TTLCache(maxsize=1, ttl=30)
+CACHE_KEY = "active_maintenance"
+
+
+def get_active_maintenance():
+    if CACHE_KEY in maintenance_cache:
+        return maintenance_cache[CACHE_KEY]
+
+    with SessionLocal() as db:
+        now = datetime.now(timezone.utc)
+        from sqlalchemy import select
+        stmt = (
+            select(MaintenanceWindow)
+            .where(
+                MaintenanceWindow.is_active == True,
+                MaintenanceWindow.start_time <= now,
+                MaintenanceWindow.end_time >= now,
+            )
+            .order_by(MaintenanceWindow.start_time.desc())
+            .limit(1)
+        )
+        window = db.scalar(stmt)
+        result = None
+        if window:
+            result = {
+                "message": window.message,
+                "end_time": window.end_time.isoformat(),
+            }
+        
+        maintenance_cache[CACHE_KEY] = result
+        return result
+
+
+class MaintenanceMiddleware(BaseHTTPMiddleware):
+    """
+    Blocks requests if the system is currently under maintenance, unless the user is an admin.
+    """
+
+    async def dispatch(self, request: Request, call_next) -> typing.Any:
+        # Exclude paths that should always be available
+        if request.url.path.startswith("/api/v1/health") or request.url.path.startswith("/docs") or request.url.path.startswith("/openapi"):
+            return await call_next(request)
+
+        maintenance = get_active_maintenance()
+
+        if maintenance:
+            # System is under maintenance. Check if user is admin.
+            is_admin = False
+            auth_header = request.headers.get("authorization", "")
+            if auth_header.startswith("Bearer "):
+                token = auth_header[7:]
+                try:
+                    payload = verify_token(token)
+                    if payload and payload.get("role") == UserRole.ADMIN:
+                        is_admin = True
+                except Exception:
+                    pass
+            
+            # If not admin, return 503
+            if not is_admin:
+                return JSONResponse(
+                    status_code=503,
+                    content={
+                        "detail": "Maintenance Mode",
+                        "maintenance": maintenance,
+                    },
+                    headers={"Retry-After": "300"},
+                )
+
+        response = await call_next(request)
+        return response

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -70,3 +70,4 @@ from .announcement import Announcement as Announcement
 from .user_report import UserReport
 from .user_skill import UserSkill
 from .verification_request import VerificationRequest  # noqa: F401
+from .maintenance import MaintenanceWindow

--- a/backend/app/models/maintenance.py
+++ b/backend/app/models/maintenance.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+class MaintenanceWindow(Base):
+    __tablename__ = "maintenance_windows"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+    start_time: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+
+    end_time: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+
+    message: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        default="The system is undergoing scheduled maintenance.",
+    )
+
+    is_active: Mapped[bool] = mapped_column(
+        Boolean,
+        default=True,
+        nullable=False,
+    )
+
+    created_by: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=datetime.utcnow,
+        nullable=False,
+    )

--- a/backend/app/routers/maintenance.py
+++ b/backend/app/routers/maintenance.py
@@ -1,0 +1,123 @@
+import uuid
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_user, get_db
+from app.models.maintenance import MaintenanceWindow
+from app.models.user import User, UserRole
+from app.schemas.maintenance import (
+    MaintenanceWindowCreate,
+    MaintenanceWindowResponse,
+    MaintenanceWindowUpdate,
+)
+
+router = APIRouter(prefix="/maintenance", tags=["maintenance"])
+
+
+def require_admin(current_user: User = Depends(get_current_user)) -> User:
+    if current_user.role != UserRole.ADMIN:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only administrators can manage maintenance windows",
+        )
+    return current_user
+
+
+@router.post("/", response_model=MaintenanceWindowResponse)
+def create_maintenance_window(
+    window: MaintenanceWindowCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_admin),
+):
+    if window.start_time >= window.end_time:
+        raise HTTPException(
+            status_code=400, detail="Start time must be before end time"
+        )
+
+    db_window = MaintenanceWindow(
+        start_time=window.start_time,
+        end_time=window.end_time,
+        message=window.message,
+        is_active=window.is_active,
+        created_by=current_user.id,
+    )
+    db.add(db_window)
+    db.commit()
+    db.refresh(db_window)
+    return db_window
+
+
+@router.get("/", response_model=List[MaintenanceWindowResponse])
+def get_maintenance_windows(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_admin),
+):
+    stmt = select(MaintenanceWindow).order_by(MaintenanceWindow.start_time.desc())
+    windows = db.scalars(stmt).all()
+    return windows
+
+
+@router.get("/active", response_model=MaintenanceWindowResponse)
+def get_active_maintenance_window(
+    db: Session = Depends(get_db),
+):
+    # Publicly accessible endpoint to check if maintenance is currently scheduled/active
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc)
+    stmt = (
+        select(MaintenanceWindow)
+        .where(
+            MaintenanceWindow.is_active == True,
+            MaintenanceWindow.start_time <= now,
+            MaintenanceWindow.end_time >= now,
+        )
+        .order_by(MaintenanceWindow.start_time.desc())
+        .limit(1)
+    )
+    window = db.scalar(stmt)
+    if not window:
+        raise HTTPException(status_code=404, detail="No active maintenance")
+    return window
+
+
+@router.patch("/{window_id}", response_model=MaintenanceWindowResponse)
+def update_maintenance_window(
+    window_id: uuid.UUID,
+    window_update: MaintenanceWindowUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_admin),
+):
+    window = db.get(MaintenanceWindow, window_id)
+    if not window:
+        raise HTTPException(status_code=404, detail="Maintenance window not found")
+
+    update_data = window_update.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(window, field, value)
+
+    if window.start_time >= window.end_time:
+        raise HTTPException(
+            status_code=400, detail="Start time must be before end time"
+        )
+
+    db.commit()
+    db.refresh(window)
+    return window
+
+
+@router.delete("/{window_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_maintenance_window(
+    window_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_admin),
+):
+    window = db.get(MaintenanceWindow, window_id)
+    if not window:
+        raise HTTPException(status_code=404, detail="Maintenance window not found")
+
+    db.delete(window)
+    db.commit()
+    return None

--- a/backend/app/schemas/maintenance.py
+++ b/backend/app/schemas/maintenance.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+from typing import Optional
+import uuid
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class MaintenanceWindowBase(BaseModel):
+    start_time: datetime = Field(..., description="Start time of maintenance")
+    end_time: datetime = Field(..., description="End time of maintenance")
+    message: str = Field(
+        default="The system is undergoing scheduled maintenance.",
+        description="Message to display to users",
+    )
+    is_active: bool = Field(default=True, description="Whether the window is active")
+
+
+class MaintenanceWindowCreate(MaintenanceWindowBase):
+    pass
+
+
+class MaintenanceWindowUpdate(BaseModel):
+    start_time: Optional[datetime] = None
+    end_time: Optional[datetime] = None
+    message: Optional[str] = None
+    is_active: Optional[bool] = None
+
+
+class MaintenanceWindowResponse(MaintenanceWindowBase):
+    model_config = ConfigDict(from_attributes=True)
+    id: uuid.UUID
+    created_by: Optional[uuid.UUID] = None
+    created_at: datetime

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -159,6 +159,19 @@ async function coreFetch(path: string, opts: RequestOptions, attempt = 0): Promi
     throw new ApiError(err instanceof Error ? err.message : "Network error", 0, null);
   }
 
+  if (res.status === 503) {
+    try {
+      const payload = await res.clone().json();
+      if (payload?.detail === "Maintenance Mode") {
+        if (window.location.pathname !== "/maintenance") {
+          window.location.href = "/maintenance";
+        }
+      }
+    } catch (e) {
+      // Not JSON, ignore
+    }
+  }
+
   if (res.status === 401 && auth && !path.includes("/auth/")) {
     const newToken = await refreshAccessToken();
     if (newToken) {

--- a/frontend/src/routes/_app.admin.maintenance.tsx
+++ b/frontend/src/routes/_app.admin.maintenance.tsx
@@ -1,0 +1,127 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { useState, useEffect } from 'react';
+import api from '@/lib/api';
+
+export const Route = createFileRoute('/_app/admin/maintenance')({
+  component: AdminMaintenance,
+});
+
+function AdminMaintenance() {
+  const [windows, setWindows] = useState([]);
+  const [startTime, setStartTime] = useState('');
+  const [endTime, setEndTime] = useState('');
+  const [message, setMessage] = useState('The system is undergoing scheduled maintenance.');
+  const [isActive, setIsActive] = useState(true);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    fetchWindows();
+  }, []);
+
+  const fetchWindows = async () => {
+    try {
+      const res = await api.get('/api/maintenance');
+      setWindows(res.data);
+    } catch (error) {
+      console.error('Failed to fetch maintenance windows', error);
+    }
+  };
+
+  const handleCreate = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const payload = {
+        start_time: new Date(startTime).toISOString(),
+        end_time: new Date(endTime).toISOString(),
+        message,
+        is_active: isActive,
+      };
+      await api.post('/api/maintenance', payload);
+      alert('Maintenance window scheduled');
+      fetchWindows();
+    } catch (error) {
+      alert('Failed to schedule maintenance');
+      console.error(error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDelete = async (id) => {
+    if (!confirm('Are you sure you want to delete this maintenance window?')) return;
+    try {
+      await api.delete(`/api/maintenance/${id}`);
+      fetchWindows();
+    } catch (error) {
+      console.error('Failed to delete window', error);
+    }
+  };
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Maintenance Mode Configuration</h1>
+      
+      <div className="bg-white p-6 rounded shadow mb-8">
+        <h2 className="text-xl font-semibold mb-4">Schedule New Window</h2>
+        <form onSubmit={handleCreate} className="flex flex-col gap-4 max-w-md">
+          <div>
+            <label className="block mb-1">Start Time</label>
+            <input type="datetime-local" className="border p-2 w-full rounded" required value={startTime} onChange={(e) => setStartTime(e.target.value)} />
+          </div>
+          <div>
+            <label className="block mb-1">End Time</label>
+            <input type="datetime-local" className="border p-2 w-full rounded" required value={endTime} onChange={(e) => setEndTime(e.target.value)} />
+          </div>
+          <div>
+            <label className="block mb-1">Message</label>
+            <textarea className="border p-2 w-full rounded" rows={3} required value={message} onChange={(e) => setMessage(e.target.value)} />
+          </div>
+          <div>
+            <label className="flex items-center gap-2">
+              <input type="checkbox" checked={isActive} onChange={(e) => setIsActive(e.target.checked)} />
+              Is Active
+            </label>
+          </div>
+          <button type="submit" disabled={loading} className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 w-fit">
+            {loading ? 'Scheduling...' : 'Schedule Maintenance'}
+          </button>
+        </form>
+      </div>
+
+      <div className="bg-white p-6 rounded shadow">
+        <h2 className="text-xl font-semibold mb-4">Scheduled Windows</h2>
+        {windows.length === 0 ? (
+          <p>No maintenance windows scheduled.</p>
+        ) : (
+          <table className="min-w-full text-left">
+            <thead>
+              <tr className="border-b">
+                <th className="p-2">Start Time</th>
+                <th className="p-2">End Time</th>
+                <th className="p-2">Message</th>
+                <th className="p-2">Status</th>
+                <th className="p-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {windows.map((w) => (
+                <tr key={w.id} className="border-b">
+                  <td className="p-2">{new Date(w.start_time).toLocaleString()}</td>
+                  <td className="p-2">{new Date(w.end_time).toLocaleString()}</td>
+                  <td className="p-2 truncate max-w-xs">{w.message}</td>
+                  <td className="p-2">
+                    {w.is_active ? <span className="text-green-600">Active</span> : <span className="text-gray-500">Inactive</span>}
+                  </td>
+                  <td className="p-2">
+                    <button onClick={() => handleDelete(w.id)} className="text-red-500 hover:underline">Delete</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/routes/_app.admin.tsx
+++ b/frontend/src/routes/_app.admin.tsx
@@ -15,6 +15,12 @@ export const Route = createFileRoute("/_app/admin")({
       <div className="flex flex-col gap-2">
         <h1 className="text-3xl font-bold tracking-tight">Admin Console</h1>
         <p className="text-muted-foreground">Manage your platform and view audit logs.</p>
+        
+        <div className="flex gap-4 border-b pb-2 mt-4">
+          <a href="/admin/audit-logs" className="text-blue-600 hover:underline">Audit Logs</a>
+          <a href="/admin/notifications" className="text-blue-600 hover:underline">Notifications</a>
+          <a href="/admin/maintenance" className="text-blue-600 hover:underline">Maintenance Mode</a>
+        </div>
       </div>
       <Outlet />
     </div>

--- a/frontend/src/routes/maintenance.tsx
+++ b/frontend/src/routes/maintenance.tsx
@@ -1,0 +1,72 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { useState, useEffect } from 'react';
+import api from '@/lib/api';
+
+export const Route = createFileRoute('/maintenance')({
+  component: MaintenancePage,
+});
+
+function MaintenancePage() {
+  const [maintenance, setMaintenance] = useState<{ message: string; end_time: string } | null>(null);
+  const [timeLeft, setTimeLeft] = useState<string>('');
+
+  useEffect(() => {
+    // Try to get maintenance info from local storage or an unauthenticated endpoint
+    const checkMaintenance = async () => {
+      try {
+        const res = await api.get('/api/maintenance/active');
+        setMaintenance(res.data);
+      } catch (e) {
+        // If 404, there is no active maintenance. We could redirect to home.
+        if (e.response?.status === 404) {
+          window.location.href = '/';
+        } else if (e.response?.status === 503) {
+           // The middleware caught it and returned 503 with data
+           setMaintenance(e.response.data.maintenance);
+        }
+      }
+    };
+    checkMaintenance();
+  }, []);
+
+  useEffect(() => {
+    if (!maintenance?.end_time) return;
+
+    const interval = setInterval(() => {
+      const now = new Date().getTime();
+      const end = new Date(maintenance.end_time).getTime();
+      const distance = end - now;
+
+      if (distance < 0) {
+        clearInterval(interval);
+        setTimeLeft('Maintenance should be finishing up soon...');
+        return;
+      }
+
+      const hours = Math.floor((distance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+      const minutes = Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60));
+      const seconds = Math.floor((distance % (1000 * 60)) / 1000);
+
+      setTimeLeft(`${hours}h ${minutes}m ${seconds}s remaining`);
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [maintenance]);
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100 p-4">
+      <div className="bg-white shadow-lg rounded-lg p-8 max-w-md w-full text-center">
+        <h1 className="text-3xl font-bold text-gray-800 mb-4">Under Maintenance</h1>
+        <p className="text-gray-600 mb-6">
+          {maintenance?.message || "The system is currently undergoing scheduled maintenance. Please check back later."}
+        </p>
+        
+        {timeLeft && (
+          <div className="bg-blue-50 text-blue-800 p-4 rounded-md">
+            <p className="font-semibold text-lg">{timeLeft}</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# Pull Request

## Summary

Implemented a comprehensive scheduled maintenance mode system that prevents normal user access during maintenance windows, displaying a countdown, while allowing administrators to configure windows and bypass them.

---

## Related Issue

Fixes #651

---

## Type of Change

Please check the relevant option(s):

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [x] UI/UX enhancement
- [ ] Tests
- [ ] Other

---

## Changes Made

- Backend: Added `MaintenanceWindow` model, schema, and admin API endpoints (CRUD).
- Backend: Introduced `MaintenanceMiddleware` utilizing `cachetools` for low-overhead active maintenance checking. It intercepts requests, verifies if they are during a maintenance window, and blocks non-admin traffic with a `503 Service Unavailable` response.
- Frontend: Created an admin UI page (`/admin/maintenance`) to list, create, and delete scheduled maintenance windows.
- Frontend: Developed a public landing page (`/maintenance`) that informs users of the ongoing maintenance and presents a real-time countdown to completion.
- Frontend: Enhanced global API interceptors to gracefully catch 503 Maintenance responses and seamlessly redirect normal users to the maintenance page.

---

## Screenshots (if applicable)

N/A

---

## Testing

- [x] Tested locally
- [x] Existing tests pass
- [ ] Added new tests
- [x] UI verified
- [ ] Cross-browser tested (if applicable)

---

## Checklist

- [x] My code follows the project's coding standards.
- [x] I have tested my changes locally.
- [x] I have updated the documentation where necessary.
- [x] My changes do not introduce new warnings or errors.
- [x] I have reviewed my own code.
- [x] This pull request focuses on a single feature or fix.
- [x] I have linked the related issue.

---

## Additional Notes

The active maintenance status is cached (30s TTL) at the middleware layer to prevent heavy DB hits on every single request during downtime scenarios. Admins retain full API capabilities via JWT Bearer decoding logic in the interceptor.
