### PR TITLE
chore: configure pre-commit hooks (fixes #472)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+
+  - repo: https://github.com/psf/black
+    rev: 24.2.0
+    hooks:
+      - id: black
+        language_version: python3
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.2.1
+    hooks:
+      - id: ruff
+        args: [ --fix ]
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.1.0
+    hooks:
+      - id: prettier
+        types_or: [javascript, jsx, ts, tsx, css, json]
+
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v8.56.0
+    hooks:
+      - id: eslint
+        files: \.[jt]sx?$
+        types: [file]
+        additional_dependencies:
+          - eslint@8.56.0
+          - typescript


### PR DESCRIPTION
# Description

This PR configures Pre-Commit Hooks, addressing issue #472.

## Summary
Adds a `.pre-commit-config.yaml` file to enforce code quality locally before commits are pushed.

## Changes Made
- Added Black and Ruff hooks for Python formatting and linting.
- Added ESLint and Prettier hooks for JavaScript/TypeScript and web formatting.
- Added standard pre-commit hooks (trailing whitespace, end of file fixer, yaml check).

## Acceptance Criteria
- [x] Use Black
- [x] Use Ruff
- [x] Use ESLint
- [x] Use Prettier
- [x] Reject commits with formatting issues (via pre-commit)

## Outcode
Pre-commit is fully configured and ready to be installed by developers via `pre-commit install`.
