### PR TITLE
feat: enable frontend OAuth providers (GitHub + LinkedIn) with CSRF state

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -3,3 +3,6 @@ VITE_API_BASE_URL=
 
 # GitHub OAuth App client ID (used to start the "Continue with GitHub" login)
 VITE_GITHUB_CLIENT_ID=
+
+# LinkedIn OAuth App client ID (used to start the "Continue with LinkedIn" login)
+VITE_LINKEDIN_CLIENT_ID=

--- a/frontend/src/api/modules/auth.ts
+++ b/frontend/src/api/modules/auth.ts
@@ -29,11 +29,22 @@ export const authApi = {
     tokenStore.set(res.access_token, res.refresh_token);
     return res;
   },
-  async githubLogin(code: string) {
-    const res = await api.post<AuthResponse>("/api/auth/github", { code }, { auth: false });
+  async githubLogin(code: string, state: string) {
+    const res = await api.post<AuthResponse>("/api/auth/github", { code, state }, { auth: false });
     tokenStore.set(res.access_token, res.refresh_token);
     return res;
   },
+  async linkedinLogin(code: string, state: string) {
+    const res = await api.post<AuthResponse>(
+      "/api/auth/linkedin",
+      { code, state },
+      { auth: false },
+    );
+    tokenStore.set(res.access_token, res.refresh_token);
+    return res;
+  },
+  oauthAuthorize: (provider: "github" | "linkedin") =>
+    api.get<{ state: string }>(`/api/auth/${provider}/authorize`, { auth: false }),
   async logout() {
     try {
       await api.post<void>("/api/auth/logout", { refresh_token: tokenStore.getRefresh() });

--- a/frontend/src/routes/auth.tsx
+++ b/frontend/src/routes/auth.tsx
@@ -2,7 +2,7 @@
 // @ts-nocheck
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useState, useCallback, useEffect } from "react";
-import { Eye, EyeOff, Github } from "lucide-react";
+import { Eye, EyeOff, Github, Linkedin } from "lucide-react";
 import { APP_LOGO } from "@/lib/logo";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -44,6 +44,7 @@ function AuthScreen() {
   const [showPw, setShowPw] = useState(false);
   const [showConfirm, setShowConfirm] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const [oauthLoading, setOauthLoading] = useState<"github" | "linkedin" | null>(null);
 
   const signInForm = useForm<SignIn>({ resolver: zodResolver(signInSchema) });
   const signUpForm = useForm<SignUp>({ resolver: zodResolver(signUpSchema) });
@@ -54,16 +55,53 @@ function AuthScreen() {
   const lbl = "block text-[13px] font-semibold text-foreground mb-1";
 
   useEffect(() => {
-    const code = new URLSearchParams(window.location.search).get("code");
-    if (!code) return;
-    authApi
-      .githubLogin(code)
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get("code");
+    const state = params.get("state");
+    const provider = sessionStorage.getItem("devlink.oauth.provider");
+    if (!code || !provider) return;
+    const finishOauth =
+      provider === "linkedin"
+        ? authApi.linkedinLogin(code, state ?? "")
+        : authApi.githubLogin(code, state ?? "");
+    finishOauth
       .then(() => {
-        toast.success("Signed in with GitHub");
+        sessionStorage.removeItem("devlink.oauth.provider");
+        toast.success("Signed in successfully");
         navigate({ to: "/dashboard" });
       })
-      .catch(() => toast.error("GitHub sign-in failed"));
+      .catch(() => toast.error("Sign-in failed. Please try again."));
   }, [navigate]);
+
+  const beginOAuth = useCallback(async (provider: "github" | "linkedin") => {
+    setOauthLoading(provider);
+    try {
+      const { state } = await authApi.oauthAuthorize(provider);
+      sessionStorage.setItem("devlink.oauth.provider", provider);
+      const redirectUri = window.location.origin + "/auth";
+      if (provider === "linkedin") {
+        const params = new URLSearchParams({
+          response_type: "code",
+          client_id: import.meta.env.VITE_LINKEDIN_CLIENT_ID ?? "",
+          redirect_uri: redirectUri,
+          scope: "openid profile email",
+          state,
+        });
+        window.location.href = `https://www.linkedin.com/oauth/v2/authorization?${params}`;
+      } else {
+        const params = new URLSearchParams({
+          client_id: import.meta.env.VITE_GITHUB_CLIENT_ID ?? "",
+          redirect_uri: redirectUri,
+          scope: "read:user user:email",
+          state,
+        });
+        window.location.href = `https://github.com/login/oauth/authorize?${params}`;
+      }
+    } catch {
+      setOauthLoading(null);
+      toast.error("Unable to start sign-in. Please try again.");
+    }
+  }, []);
   const onSubmit = useCallback(async () => {
     if (submitting) return;
     setSubmitting(true);
@@ -86,38 +124,31 @@ function AuthScreen() {
       <div className="w-full max-w-[500px] rounded-md border border-border bg-surface px-8 py-6">
         <button
           type="button"
-          onClick={() => {
-            const params = new URLSearchParams({
-              client_id: import.meta.env.VITE_GITHUB_CLIENT_ID ?? "",
-              redirect_uri: window.location.origin + "/auth",
-              scope: "read:user user:email",
-            });
-            window.location.href = `https://github.com/login/oauth/authorize?${params}`;
-          }}
-          className="mb-3 flex w-full items-center justify-center gap-2.5 rounded-md border border-border bg-surface px-3 py-[8px] text-[14px] font-medium text-foreground hover:bg-muted"
+          disabled={oauthLoading !== null}
+          onClick={() => beginOAuth("github")}
+          className="mb-3 flex w-full items-center justify-center gap-2.5 rounded-md border border-border bg-surface px-3 py-[8px] text-[14px] font-medium text-foreground hover:bg-muted disabled:opacity-60"
         >
-          <Github size={16} /> Continue with GitHub
-        </button>{" "}
-        <button className="mb-4 flex w-full items-center justify-center gap-2.5 rounded-md border border-border bg-surface px-3 py-[8px] text-[14px] font-medium text-foreground hover:bg-muted">
-          <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden>
-            <path
-              fill="#4285F4"
-              d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-            />
-            <path
-              fill="#34A853"
-              d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-            />
-            <path
-              fill="#FBBC05"
-              d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"
-            />
-            <path
-              fill="#EA4335"
-              d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-            />
-          </svg>
-          Continue with Google
+          {oauthLoading === "github" ? (
+            "Redirecting..."
+          ) : (
+            <>
+              <Github size={16} /> Continue with GitHub
+            </>
+          )}
+        </button>
+        <button
+          type="button"
+          disabled={oauthLoading !== null}
+          onClick={() => beginOAuth("linkedin")}
+          className="mb-4 flex w-full items-center justify-center gap-2.5 rounded-md border border-border bg-surface px-3 py-[8px] text-[14px] font-medium text-foreground hover:bg-muted disabled:opacity-60"
+        >
+          {oauthLoading === "linkedin" ? (
+            "Redirecting..."
+          ) : (
+            <>
+              <Linkedin size={16} /> Continue with LinkedIn
+            </>
+          )}
         </button>
         <div className="mb-5 flex items-center gap-3">
           <div className="h-px flex-1 bg-border" />


### PR DESCRIPTION
## Description

Wires the frontend authentication screen to the backend OAuth endpoints so the provider buttons initiate a real, working OAuth flow instead of decorative placeholders.

**Changes:**
- **GitHub OAuth** — the "Continue with GitHub" button now requests a CSRF state token from `GET /api/auth/github/authorize`, passes it as the `state` parameter to GitHub, and submits both `code` + `state` to `POST /api/auth/github`. Previously it redirected without a state, which the backend rejects.
- **LinkedIn OAuth** — added a new "Continue with LinkedIn" button that follows the same secure flow via `GET /api/auth/linkedin/authorize` and `POST /api/auth/linkedin` (openid profile/email scopes).
- **Error & loading states** — buttons show a "Redirecting..." state while starting the flow, disable during an active flow, and toast errors if authorization or sign-in fails.
- **Removed placeholder** — removed the non-functional decorative Google button (no backend Google OAuth endpoint exists yet, so it was a dead control).
- **API module** — `authApi.githubLogin(code, state)` now forwards the CSRF state, new `authApi.linkedinLogin(code, state)` and `authApi.oauthAuthorize(provider)` helpers added.
- **Env docs** — added `VITE_LINKEDIN_CLIENT_ID` to `frontend/.env.example`.

## Related Issue

Closes #713

## Component(s) Affected

- Frontend authentication screen (`frontend/src/routes/auth.tsx`)
- Auth API module (`frontend/src/api/modules/auth.ts`)
- Environment template (`frontend/.env.example`)

## Type of Change

- [x] Feature (non-breaking new functionality)

## Testing

- `npx tsc --noEmit` — no new type errors introduced by this change.
- `npx eslint src/routes/auth.tsx src/api/modules/auth.ts` — clean.
- Manual OAuth flow: button → fetch CSRF state → redirect to provider with `state` → callback exchanges `code` + `state` for tokens → redirect to `/dashboard`.

## API Docs

No new backend endpoints; consumes the existing GitHub/LinkedIn OAuth endpoints.

## Checklist

- [x] Code follows project conventions
- [x] No dead/placeholder UI left behind
- [x] Lint/type checks pass for changed files
