### PR TITLE
Refactor Search Page to Use useGlobalSearch Hook Instead of Local Search State (#823)

### DIFF
--- a/frontend/src/routes/_app.search.tsx
+++ b/frontend/src/routes/_app.search.tsx
@@ -5,9 +5,8 @@ import { builders, projects, flares, conversations, hackathons } from "@/mocks/s
 import { repositories, type RepositoryItem } from "@/mocks/repositories";
 import { useMemo, useState } from "react";
 import { cn } from "@/lib/utils";
-import { Search, X, MessageSquare, Trophy, GitBranch, Rss, Users, FolderGit2 } from "lucide-react";
-import { useDebounce } from "@/hooks/useDebounce";
-import { useEffect } from "react";
+import { Search, X, Trophy, GitBranch, Rss, History } from "lucide-react";
+import { useGlobalSearch } from "@/hooks/useGlobalSearch";
 import api from "@/lib/api";
 
 const tabs = ["Developers", "Projects", "Posts", "Messages", "Hackathons", "Repositories"] as const;
@@ -31,6 +30,10 @@ function SearchPage() {
   const {
     query: q,
     setQuery: setQ,
+    debouncedQuery,
+    loading,
+    error,
+    results,
     recentSearches,
     removeHistoryItem,
     clearHistory,
@@ -39,71 +42,94 @@ function SearchPage() {
 
   const [tab, setTab] = useState<Tab>("Developers");
 
-  const debouncedQ = useDebounce(q, 200);
-  const query = debouncedQ.toLowerCase().trim();
-
-  useEffect(() => {
-    if (query) {
-      // Fire and forget search query to backend for analytics tracking
-      api.get(`/api/search?q=${encodeURIComponent(query)}`).catch(() => {});
-    }
-  }, [query]);
-
   const trackClick = (entityType: string, entityId: string) => {
-    if (query) {
-      api.post('/api/search/track-click', {
-        query,
+    const trimmed = debouncedQuery.trim();
+    if (trimmed) {
+      api.post("/api/search/track-click", {
+        query: trimmed,
         clicked_entity_type: entityType,
-        clicked_entity_id: entityId
+        clicked_entity_id: entityId,
       }).catch(() => {});
     }
   };
 
-  const devs = useMemo(
-    () =>
-      builders.filter((b) =>
-        (b.name + " " + b.role + " " + b.skills.join(" ")).toLowerCase().includes(query),
-      ),
-    [query],
-  );
+  const devs = useMemo(() => {
+    if (results) {
+      return (results.users || []).map((u) => ({
+        id: u.id,
+        name: u.name,
+        username: u.username,
+        role: u.role || "Developer",
+        avatar: u.profile_image || "",
+        skills: [] as string[],
+      }));
+    }
+    const queryLower = q.toLowerCase().trim();
+    return builders
+      .filter((b) =>
+        (b.name + " " + b.role + " " + (b.skills || []).join(" ")).toLowerCase().includes(queryLower),
+      )
+      .map((b) => ({
+        id: b.id,
+        name: b.name,
+        username: b.handle,
+        role: b.role,
+        avatar: b.avatar,
+        skills: b.skills || [],
+      }));
+  }, [results, q]);
 
-  const projs = useMemo(
-    () =>
-      projects.filter((p) =>
-        (p.name + " " + p.description + " " + p.stack.join(" ")).toLowerCase().includes(query),
-      ),
-    [query],
-  );
+  const projs = useMemo(() => {
+    if (results) {
+      return (results.projects || []).map((p) => ({
+        id: p.id,
+        name: p.title,
+        description: p.tagline || p.description || "",
+        stack: p.tags || [],
+        icon: p.logo_url || "🚀",
+      }));
+    }
+    const queryLower = q.toLowerCase().trim();
+    return projects
+      .filter((p) =>
+        (p.name + " " + p.description + " " + (p.stack || []).join(" ")).toLowerCase().includes(queryLower),
+      )
+      .map((p) => ({
+        id: p.id,
+        name: p.name,
+        description: p.description,
+        stack: p.stack || [],
+        icon: p.icon || "🚀",
+      }));
+  }, [results, q]);
 
-  const posts = useMemo(
-    () =>
-      flares.filter((f) =>
-        (f.author.name + " " + f.content + " " + f.tags.join(" ")).toLowerCase().includes(query),
-      ),
-    [query],
-  );
+  const posts = useMemo(() => {
+    const queryLower = q.toLowerCase().trim();
+    return flares.filter((f) =>
+      (f.author.name + " " + f.content + " " + (f.tags || []).join(" ")).toLowerCase().includes(queryLower),
+    );
+  }, [q]);
 
-  const msgs = useMemo(
-    () =>
-      conversations.filter((c) => (c.with.name + " " + c.preview).toLowerCase().includes(query)),
-    [query],
-  );
+  const msgs = useMemo(() => {
+    const queryLower = q.toLowerCase().trim();
+    return conversations.filter((c) =>
+      (c.with.name + " " + c.preview).toLowerCase().includes(queryLower),
+    );
+  }, [q]);
 
-  const hacks = useMemo(
-    () =>
-      hackathons.filter((h) =>
-        (h.name + " " + h.theme + " " + h.description).toLowerCase().includes(query),
-      ),
-    [query],
-  );
+  const hacks = useMemo(() => {
+    const queryLower = q.toLowerCase().trim();
+    return hackathons.filter((h) =>
+      (h.name + " " + h.theme + " " + h.description).toLowerCase().includes(queryLower),
+    );
+  }, [q]);
 
-  const repos = useMemo(
-    () =>
-      repositories.filter((r: RepositoryItem) =>
-        (r.name + " " + r.description + " " + r.language).toLowerCase().includes(query),
-      ),
-    [query],
-  );
+  const repos = useMemo(() => {
+    const queryLower = q.toLowerCase().trim();
+    return repositories.filter((r: RepositoryItem) =>
+      (r.name + " " + r.description + " " + r.language).toLowerCase().includes(queryLower),
+    );
+  }, [q]);
 
   return (
     <div className="space-y-4">
@@ -130,7 +156,7 @@ function SearchPage() {
           <button
             type="button"
             onClick={clear}
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground cursor-pointer"
             aria-label="Clear search"
           >
             <X size={16} />
@@ -147,6 +173,49 @@ function SearchPage() {
           ⚡ Latency: &lt; 1.2ms · BM25 Weighted Ranking
         </span>
       </div>
+
+      {/* Recent Search History Section */}
+      {!q && recentSearches && recentSearches.length > 0 && (
+        <Card className="p-4">
+          <div className="mb-3 flex items-center justify-between">
+            <div className="flex items-center gap-1.5 text-[13px] font-medium text-foreground">
+              <History size={14} className="text-muted-foreground" />
+              <span>Recent Searches</span>
+            </div>
+            <button
+              type="button"
+              onClick={clearHistory}
+              className="text-[12px] font-medium text-muted-foreground hover:text-destructive transition-colors cursor-pointer"
+            >
+              Clear all
+            </button>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {recentSearches.map((item) => (
+              <div
+                key={item.id}
+                className="group flex items-center gap-1.5 rounded-full border border-border bg-background px-3 py-1 text-[12px] text-foreground hover:border-primary/50 transition-colors"
+              >
+                <button
+                  type="button"
+                  onClick={() => setQ(item.query)}
+                  className="hover:underline cursor-pointer"
+                >
+                  {item.query}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => removeHistoryItem(item.id)}
+                  className="text-muted-foreground hover:text-destructive opacity-70 group-hover:opacity-100 transition-opacity cursor-pointer"
+                  aria-label={`Remove ${item.query} from history`}
+                >
+                  <X size={12} />
+                </button>
+              </div>
+            ))}
+          </div>
+        </Card>
+      )}
 
       <div className="flex flex-wrap items-center gap-1 rounded-md border border-border bg-surface p-1 overflow-x-auto">
         {tabs.map((t) => (
@@ -165,197 +234,210 @@ function SearchPage() {
         ))}
       </div>
 
-      {/* Tab Contents */}
-      {tab === "Developers" && (
-        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {devs.length === 0 ? (
-            <EmptyState query={q} label="developers" />
-          ) : (
-            devs.map((b) => (
-              <Link 
-                key={b.id} 
-                to="/profile/$username" 
-                params={{ username: b.username }}
-                onClick={() => trackClick("user", b.id)}
-              >
-                <Card interactive className="p-4 flex items-center gap-3">
-                  <Avatar src={b.avatar} alt={b.name} size={40} />
-                  <div className="min-w-0 flex-1">
-                    <p className="truncate text-[13px] font-semibold text-foreground">
-                      <HighlightText text={b.name} query={q} />
-                    </p>
-                    <p className="truncate text-[12px] text-muted-foreground">{b.role}</p>
-                    <div className="mt-1 flex flex-wrap gap-1">
-                      {b.skills.slice(0, 3).map((s) => (
-                        <TagChip key={s} className="text-[10px]">
-                          <HighlightText text={s} query={q} />
-                        </TagChip>
-                      ))}
-                    </div>
-                  </div>
-                </Card>
-              </Link>
-            ))
-          )}
+      {loading ? (
+        <div className="flex flex-col items-center justify-center p-12 text-center col-span-full">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+          <p className="mt-4 text-[13px] text-muted-foreground">Searching devlink...</p>
         </div>
-      )}
-
-      {tab === "Projects" && (
-        <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
-          {projs.length === 0 ? (
-            <EmptyState query={q} label="projects" />
-          ) : (
-            projs.map((p) => (
-              <Link 
-                key={p.id} 
-                to="/projects/$projectId" 
-                params={{ projectId: p.id }}
-                onClick={() => trackClick("project", p.id)}
-              >
-                <Card interactive className="p-4">
-                  <div className="flex items-start gap-3">
-                    <span className="grid h-10 w-10 place-items-center rounded-md bg-muted text-xl shrink-0">
-                      {p.icon}
-                    </span>
-                    <div className="min-w-0">
-                      <p className="truncate text-[13px] font-semibold text-foreground">
-                        <HighlightText text={p.name} query={q} />
-                      </p>
-                      <p className="truncate text-[12px] text-muted-foreground mt-0.5">
-                        <HighlightText text={p.description} query={q} />
-                      </p>
-                      <div className="mt-2 flex flex-wrap gap-1">
-                        {p.stack.map((s) => (
-                          <TagChip key={s} className="text-[10px]">
-                            <HighlightText text={s} query={q} />
-                          </TagChip>
-                        ))}
+      ) : error ? (
+        <Card className="p-5 text-center text-[13px] text-destructive col-span-full">
+          Error: {error}
+        </Card>
+      ) : (
+        <>
+          {/* Tab Contents */}
+          {tab === "Developers" && (
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {devs.length === 0 ? (
+                <EmptyState query={q} label="developers" />
+              ) : (
+                devs.map((b) => (
+                  <Link 
+                    key={b.id} 
+                    to="/profile/$username" 
+                    params={{ username: b.username }}
+                    onClick={() => trackClick("user", b.id)}
+                  >
+                    <Card interactive className="p-4 flex items-center gap-3">
+                      <Avatar src={b.avatar} alt={b.name} size={40} />
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-[13px] font-semibold text-foreground">
+                          <HighlightText text={b.name} query={q} />
+                        </p>
+                        <p className="truncate text-[12px] text-muted-foreground">{b.role}</p>
+                        <div className="mt-1 flex flex-wrap gap-1">
+                          {b.skills.slice(0, 3).map((s) => (
+                            <TagChip key={s} className="text-[10px]">
+                              <HighlightText text={s} query={q} />
+                            </TagChip>
+                          ))}
+                        </div>
                       </div>
-                    </div>
-                  </div>
-                </Card>
-              </Link>
-            ))
+                    </Card>
+                  </Link>
+                ))
+              )}
+            </div>
           )}
-        </div>
-      )}
 
-      {tab === "Posts" && (
-        <div className="space-y-3">
-          {posts.length === 0 ? (
-            <EmptyState query={q} label="posts" />
-          ) : (
-            posts.map((f) => (
-              <Link key={f.id} to="/flares">
-                <Card interactive className="p-4">
-                  <div className="flex items-start gap-3">
-                    <span className="mt-1 text-amber-500 shrink-0">
-                      <Rss size={16} />
-                    </span>
-                    <div className="min-w-0 flex-1">
-                      <p className="text-[13px] font-semibold text-foreground">
-                        <HighlightText text={f.author.name} query={q} />
-                      </p>
-                      <p className="mt-1 text-[13px] text-foreground">
-                        <HighlightText text={f.content} query={q} />
-                      </p>
-                      <div className="mt-2 flex flex-wrap gap-1">
-                        {f.tags.map((t) => (
-                          <TagChip key={t} className="text-[10px]">
-                            <HighlightText text={`#${t}`} query={q} />
-                          </TagChip>
-                        ))}
+          {tab === "Projects" && (
+            <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+              {projs.length === 0 ? (
+                <EmptyState query={q} label="projects" />
+              ) : (
+                projs.map((p) => (
+                  <Link 
+                    key={p.id} 
+                    to="/projects/$projectId" 
+                    params={{ projectId: p.id }}
+                    onClick={() => trackClick("project", p.id)}
+                  >
+                    <Card interactive className="p-4">
+                      <div className="flex items-start gap-3">
+                        <span className="grid h-10 w-10 place-items-center rounded-md bg-muted text-xl shrink-0">
+                          {p.icon}
+                        </span>
+                        <div className="min-w-0">
+                          <p className="truncate text-[13px] font-semibold text-foreground">
+                            <HighlightText text={p.name} query={q} />
+                          </p>
+                          <p className="truncate text-[12px] text-muted-foreground mt-0.5">
+                            <HighlightText text={p.description} query={q} />
+                          </p>
+                          <div className="mt-2 flex flex-wrap gap-1">
+                            {p.stack.map((s) => (
+                              <TagChip key={s} className="text-[10px]">
+                                <HighlightText text={s} query={q} />
+                              </TagChip>
+                            ))}
+                          </div>
+                        </div>
                       </div>
-                    </div>
-                  </div>
-                </Card>
-              </Link>
-            ))
+                    </Card>
+                  </Link>
+                ))
+              )}
+            </div>
           )}
-        </div>
-      )}
 
-      {tab === "Messages" && (
-        <div className="space-y-3">
-          {msgs.length === 0 ? (
-            <EmptyState query={q} label="messages" />
-          ) : (
-            msgs.map((c) => (
-              <Link key={c.id} to="/messages/$conversationId" params={{ conversationId: c.id }}>
-                <Card interactive className="p-4 flex items-center gap-3">
-                  <Avatar src={c.with.avatar} alt={c.with.name} size={40} />
-                  <div className="min-w-0 flex-1">
-                    <p className="text-[13px] font-semibold text-foreground">
-                      <HighlightText text={`Chat with ${c.with.name}`} query={q} />
-                    </p>
-                    <p className="text-[12px] text-muted-foreground truncate mt-0.5">
-                      <HighlightText text={c.preview} query={q} />
-                    </p>
-                  </div>
-                </Card>
-              </Link>
-            ))
+          {tab === "Posts" && (
+            <div className="space-y-3">
+              {posts.length === 0 ? (
+                <EmptyState query={q} label="posts" />
+              ) : (
+                posts.map((f) => (
+                  <Link key={f.id} to="/flares">
+                    <Card interactive className="p-4">
+                      <div className="flex items-start gap-3">
+                        <span className="mt-1 text-amber-500 shrink-0">
+                          <Rss size={16} />
+                        </span>
+                        <div className="min-w-0 flex-1">
+                          <p className="text-[13px] font-semibold text-foreground">
+                            <HighlightText text={f.author.name} query={q} />
+                          </p>
+                          <p className="mt-1 text-[13px] text-foreground">
+                            <HighlightText text={f.content} query={q} />
+                          </p>
+                          <div className="mt-2 flex flex-wrap gap-1">
+                            {f.tags.map((t) => (
+                              <TagChip key={t} className="text-[10px]">
+                                <HighlightText text={`#${t}`} query={q} />
+                              </TagChip>
+                            ))}
+                          </div>
+                        </div>
+                      </div>
+                    </Card>
+                  </Link>
+                ))
+              )}
+            </div>
           )}
-        </div>
-      )}
 
-      {tab === "Hackathons" && (
-        <div className="grid gap-3 md:grid-cols-2">
-          {hacks.length === 0 ? (
-            <EmptyState query={q} label="hackathons" />
-          ) : (
-            hacks.map((h) => (
-              <Link key={h.id} to="/hackathons/$hackathonId" params={{ hackathonId: h.id }}>
-                <Card interactive className="p-4 flex items-start gap-3">
-                  <Trophy size={20} className="text-yellow-500 shrink-0 mt-0.5" />
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center justify-between">
-                      <p className="truncate text-[13px] font-semibold text-foreground">
-                        <HighlightText text={h.name} query={q} />
-                      </p>
-                      <span className="rounded bg-warning/10 px-2 py-0.5 text-[10px] font-semibold text-warning">
-                        {h.prize}
-                      </span>
-                    </div>
-                    <p className="text-[12px] text-muted-foreground mt-1">
-                      <HighlightText text={h.description} query={q} />
-                    </p>
-                  </div>
-                </Card>
-              </Link>
-            ))
+          {tab === "Messages" && (
+            <div className="space-y-3">
+              {msgs.length === 0 ? (
+                <EmptyState query={q} label="messages" />
+              ) : (
+                msgs.map((c) => (
+                  <Link key={c.id} to="/messages/$conversationId" params={{ conversationId: c.id }}>
+                    <Card interactive className="p-4 flex items-center gap-3">
+                      <Avatar src={c.with.avatar} alt={c.with.name} size={40} />
+                      <div className="min-w-0 flex-1">
+                        <p className="text-[13px] font-semibold text-foreground">
+                          <HighlightText text={`Chat with ${c.with.name}`} query={q} />
+                        </p>
+                        <p className="text-[12px] text-muted-foreground truncate mt-0.5">
+                          <HighlightText text={c.preview} query={q} />
+                        </p>
+                      </div>
+                    </Card>
+                  </Link>
+                ))
+              )}
+            </div>
           )}
-        </div>
-      )}
 
-      {tab === "Repositories" && (
-        <div className="grid gap-3 md:grid-cols-2">
-          {repos.length === 0 ? (
-            <EmptyState query={q} label="repositories" />
-          ) : (
-            repos.map((r) => (
-              <Link key={r.id} to="/projects/$projectId" params={{ projectId: r.projectId }}>
-                <Card interactive className="p-4 flex items-start gap-3">
-                  <GitBranch size={18} className="text-rose-500 shrink-0 mt-0.5" />
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center justify-between">
-                      <p className="truncate text-[13px] font-semibold text-foreground">
-                        <HighlightText text={r.name} query={q} />
-                      </p>
-                      <span className="text-[11px] text-muted-foreground">⭐ {r.stars}</span>
-                    </div>
-                    <p className="text-[12px] text-muted-foreground mt-1">
-                      <HighlightText text={r.description} query={q} />
-                    </p>
-                    <span className="mt-2 inline-block rounded bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
-                      {r.language}
-                    </span>
-                  </div>
-                </Card>
-              </Link>
-            ))
+          {tab === "Hackathons" && (
+            <div className="grid gap-3 md:grid-cols-2">
+              {hacks.length === 0 ? (
+                <EmptyState query={q} label="hackathons" />
+              ) : (
+                hacks.map((h) => (
+                  <Link key={h.id} to="/hackathons/$hackathonId" params={{ hackathonId: h.id }}>
+                    <Card interactive className="p-4 flex items-start gap-3">
+                      <Trophy size={20} className="text-yellow-500 shrink-0 mt-0.5" />
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center justify-between">
+                          <p className="truncate text-[13px] font-semibold text-foreground">
+                            <HighlightText text={h.name} query={q} />
+                          </p>
+                          <span className="rounded bg-warning/10 px-2 py-0.5 text-[10px] font-semibold text-warning">
+                            {h.prize}
+                          </span>
+                        </div>
+                        <p className="text-[12px] text-muted-foreground mt-1">
+                          <HighlightText text={h.description} query={q} />
+                        </p>
+                      </div>
+                    </Card>
+                  </Link>
+                ))
+              )}
+            </div>
           )}
-        </div>
+
+          {tab === "Repositories" && (
+            <div className="grid gap-3 md:grid-cols-2">
+              {repos.length === 0 ? (
+                <EmptyState query={q} label="repositories" />
+              ) : (
+                repos.map((r) => (
+                  <Link key={r.id} to="/projects/$projectId" params={{ projectId: r.projectId }}>
+                    <Card interactive className="p-4 flex items-start gap-3">
+                      <GitBranch size={18} className="text-rose-500 shrink-0 mt-0.5" />
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center justify-between">
+                          <p className="truncate text-[13px] font-semibold text-foreground">
+                            <HighlightText text={r.name} query={q} />
+                          </p>
+                          <span className="text-[11px] text-muted-foreground">⭐ {r.stars}</span>
+                        </div>
+                        <p className="text-[12px] text-muted-foreground mt-1">
+                          <HighlightText text={r.description} query={q} />
+                        </p>
+                        <span className="mt-2 inline-block rounded bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+                          {r.language}
+                        </span>
+                      </div>
+                    </Card>
+                  </Link>
+                ))
+              )}
+            </div>
+          )}
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
# Pull Request

## Summary

Refactored the Search Page to consume the shared `useGlobalSearch` hook instead of duplicating search queries, API fetches, debounce logic, and search history locally.

---

## Related Issue

Closes #823

---

## Type of Change

Please check the relevant option(s):

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [ ] UI/UX enhancement
- [ ] Tests
- [ ] Other

---

## Changes Made

- Replaced local search state, local debounce logic, and manual search effects with the `useGlobalSearch` hook.
- Wired up search history using the hook's `recentSearches`, `removeHistoryItem`, and `clearHistory`.
- Integrated real backend search results for Developers and Projects, falling back to mock data only when no backend results are loaded.
- Displayed dynamic loading, empty, and error states based on hook attributes.
- Preserved existing layout structure, tabs, and UI elements.
- Cleaned up unused imports and variables to resolve compilation/linter checks.

---

## Screenshots (if applicable)

N/A

---

## Testing

- [x] Tested locally
- [x] Existing tests pass
- [ ] Added new tests
- [x] UI verified
- [ ] Cross-browser tested (if applicable)

---

## Checklist

- [x] My code follows the project's coding standards.
- [x] I have tested my changes locally.
- [ ] I have updated the documentation where necessary.
- [x] My changes do not introduce new warnings or errors.
- [x] I have reviewed my own code.
- [x] This pull request focuses on a single feature or fix.
- [x] I have linked the related issue.

---

## Additional Notes

Project type-checking runs successfully with zero compiler warnings/errors on the modified files.