### PR TITLE
Screen passwords against known-compromised values

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -54,6 +54,33 @@ class Settings(BaseSettings):
 
     PASSWORD_HASH_SCHEME: str = "bcrypt"
 
+    # ----------------------------------------------------------
+    # Password screening
+    # ----------------------------------------------------------
+
+    # Offline blocklist of common/guessable passwords, plus the check that a
+    # password does not simply repeat the user's own username or email.
+    ENABLE_PASSWORD_BLOCKLIST: bool = True
+
+    # Have I Been Pwned range lookup. Off during tests so the suite never
+    # touches the network; the behaviour itself is covered with a mocked
+    # transport.
+    ENABLE_HIBP_CHECK: bool = Field(
+        default_factory=lambda: not (
+            os.getenv("TESTING") == "true" or "pytest" in sys.modules
+        )
+    )
+    HIBP_API_URL: str = "https://api.pwnedpasswords.com/range"
+    HIBP_TIMEOUT_SECONDS: float = 3.0
+
+    # A password is rejected once it has been seen at least this many times.
+    # A count of 1 is often a corpus artefact rather than a password in active
+    # circulation on stuffing lists.
+    HIBP_MIN_BREACH_COUNT: int = 5
+
+    # Range responses are effectively static, so they cache well.
+    HIBP_CACHE_TTL_SECONDS: int = 60 * 60 * 24
+
     # ==========================================================
     # Database
     # ==========================================================

--- a/backend/app/core/password_blocklist.py
+++ b/backend/app/core/password_blocklist.py
@@ -1,0 +1,243 @@
+"""
+Local screening for obviously-guessable passwords.
+
+Composition rules (upper + lower + digit + symbol) are a weak signal on their
+own: ``Password1!``, ``Welcome123!`` and ``Qwerty123!`` all satisfy them and all
+sit near the top of every credential-stuffing wordlist. NIST SP 800-63B
+recommends screening candidates against known-bad values instead of leaning on
+composition alone.
+
+This module is the offline half of that. The network half -- the Have I Been
+Pwned range API -- lives in ``app/services/password_breach_service.py``.
+"""
+
+import re
+import unicodedata
+from typing import Iterable, Optional, Set
+
+# The most frequently observed passwords across public breach corpora, plus the
+# ones this project's own domain invites ("devlink", "github", ...). Entries are
+# stored already normalised (see ``normalise_password``) so lookup is a single
+# set membership test.
+#
+# Deliberately kept small and in-repo rather than shipping a multi-megabyte
+# wordlist: HIBP covers the long tail, and this list only needs to catch the
+# passwords people actually reach for first, including when HIBP is unreachable.
+_RAW_COMMON_PASSWORDS: tuple[str, ...] = (
+    # Classic top-25
+    "123456",
+    "password",
+    "123456789",
+    "12345678",
+    "12345",
+    "1234567",
+    "1234567890",
+    "qwerty",
+    "abc123",
+    "111111",
+    "123123",
+    "admin",
+    "letmein",
+    "welcome",
+    "monkey",
+    "login",
+    "princess",
+    "dragon",
+    "sunshine",
+    "master",
+    "football",
+    "baseball",
+    "superman",
+    "iloveyou",
+    "trustno1",
+    # Keyboard walks
+    "qwertyuiop",
+    "asdfghjkl",
+    "zxcvbnm",
+    "qazwsx",
+    "1qaz2wsx",
+    "qwerty123",
+    "1q2w3e4r",
+    "1q2w3e4r5t",
+    "poiuytrewq",
+    # Composition-rule survivors: these pass every strength check we had
+    "password1",
+    "password123",
+    "passw0rd",
+    "p@ssword",
+    "p@ssw0rd",
+    "welcome1",
+    "welcome123",
+    "admin123",
+    "administrator",
+    "letmein123",
+    "changeme",
+    "changeme123",
+    "secret",
+    "secret123",
+    "temporary",
+    "temppassword",
+    "newpassword",
+    "myp@ssword",
+    "abcd1234",
+    "test1234",
+    "root1234",
+    "pass1234",
+    # Product- and domain-flavoured guesses
+    "devlink",
+    "devlink123",
+    "developer",
+    "developer123",
+    "github",
+    "github123",
+    "opensource",
+    "hacktoberfest",
+    "localhost",
+    "django",
+    "fastapi",
+    # Dates and sequences people pick when forced to add digits
+    "january1",
+    "summer2024",
+    "summer2025",
+    "winter2024",
+    "winter2025",
+    "spring2025",
+    "autumn2025",
+)
+
+# Character swaps people use to satisfy a symbol requirement without actually
+# picking a different word. Folding them lets "P@ssw0rd!" collapse onto
+# "password".
+_LEET_SUBSTITUTIONS = str.maketrans(
+    {
+        "@": "a",
+        "4": "a",
+        "8": "b",
+        "(": "c",
+        "3": "e",
+        "6": "g",
+        "1": "i",
+        "!": "i",
+        "|": "i",
+        "0": "o",
+        "$": "s",
+        "5": "s",
+        "7": "t",
+        "+": "t",
+        "2": "z",
+    }
+)
+
+# Trailing decoration that adds no entropy: "password" -> "password2024!!"
+_TRAILING_NOISE = re.compile(r"[\d\W_]+$")
+
+_NON_ALNUM = re.compile(r"[^a-z0-9]")
+
+# Below this length a substring match against the username is meaningless --
+# almost every password contains some two-letter run from some identifier.
+MIN_CONTEXT_TOKEN_LENGTH = 4
+
+
+def normalise_password(password: str) -> str:
+    """
+    Fold a password down to its recognisable core.
+
+    Lowercases, applies Unicode NFKD folding, strips trailing digits and
+    punctuation, then undoes common leetspeak. ``P@ssw0rd2024!`` and
+    ``password`` both come out as ``password``.
+
+    Order matters: the trailing noise has to go first. Leetspeak folding maps
+    digits onto letters, so running it first would turn the ``2025`` in
+    ``Password2025!`` into letters and leave nothing for the trailing-noise
+    pattern to strip.
+    """
+    folded = unicodedata.normalize("NFKD", password).lower()
+    folded = _TRAILING_NOISE.sub("", folded)
+    folded = folded.translate(_LEET_SUBSTITUTIONS)
+    return folded
+
+
+def _build_blocklist() -> Set[str]:
+    """Normalise the raw list once at import time."""
+    entries: Set[str] = set()
+    for raw in _RAW_COMMON_PASSWORDS:
+        entries.add(raw.lower())
+        entries.add(normalise_password(raw))
+    # Normalisation can strip an entry down to nothing (a purely numeric
+    # password like "123456"); keeping "" would reject every password whose
+    # core folds away.
+    entries.discard("")
+    return entries
+
+
+COMMON_PASSWORDS: Set[str] = _build_blocklist()
+
+
+def is_common_password(password: str) -> bool:
+    """
+    Whether a password is on the local blocklist.
+
+    Both the literal lowercase form and the normalised form are checked, so
+    ``PASSWORD``, ``password``, ``P@ssw0rd`` and ``Password2025!`` are all
+    caught by the single ``password`` entry.
+    """
+    if not password:
+        return False
+
+    if password.lower() in COMMON_PASSWORDS:
+        return True
+
+    return normalise_password(password) in COMMON_PASSWORDS
+
+
+def _context_tokens(values: Iterable[Optional[str]]) -> Set[str]:
+    """
+    Break identifying values into comparable tokens.
+
+    An email contributes its local-part, and any value is additionally split on
+    non-alphanumeric boundaries so ``alex.rivera`` yields ``alex`` and
+    ``rivera`` as well as ``alexrivera``.
+    """
+    tokens: Set[str] = set()
+
+    for value in values:
+        if not value:
+            continue
+
+        candidate = value.strip().lower()
+        if "@" in candidate:
+            candidate = candidate.split("@", 1)[0]
+
+        for part in re.split(r"[^a-z0-9]+", candidate):
+            if len(part) >= MIN_CONTEXT_TOKEN_LENGTH:
+                tokens.add(part)
+
+        collapsed = _NON_ALNUM.sub("", candidate)
+        if len(collapsed) >= MIN_CONTEXT_TOKEN_LENGTH:
+            tokens.add(collapsed)
+
+    return tokens
+
+
+def contains_personal_information(
+    password: str,
+    username: Optional[str] = None,
+    email: Optional[str] = None,
+) -> bool:
+    """
+    Whether the password is built out of the user's own identifiers.
+
+    ``alexrivera`` / ``alex@devlink.app`` picking ``Alex.Rivera2025!`` is a
+    password an attacker guesses on the first page of a targeted list, so it is
+    rejected even though it satisfies every composition rule.
+    """
+    if not password:
+        return False
+
+    haystack = _NON_ALNUM.sub("", normalise_password(password))
+    if not haystack:
+        return False
+
+    return any(
+        token in haystack for token in _context_tokens([username, email])
+    )

--- a/backend/app/core/password_blocklist.py
+++ b/backend/app/core/password_blocklist.py
@@ -238,6 +238,4 @@ def contains_personal_information(
     if not haystack:
         return False
 
-    return any(
-        token in haystack for token in _context_tokens([username, email])
-    )
+    return any(token in haystack for token in _context_tokens([username, email]))

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -131,7 +131,11 @@ class AuthService:
 
         payload.username = validate_username(payload.username)
 
-        validate_password(payload.password)
+        validate_password(
+            payload.password,
+            username=payload.username,
+            email=payload.email,
+        )
 
         if self.get_user_by_email(payload.email):
             raise HTTPException(
@@ -740,7 +744,11 @@ class AuthService:
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Current password is incorrect.",
             )
-        validate_password(new_password)
+        validate_password(
+            new_password,
+            username=user.username,
+            email=user.email,
+        )
 
         if self._is_password_reused(user, new_password):
             raise HTTPException(
@@ -894,9 +902,15 @@ class AuthService:
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Invalid or expired reset token.",
             )
-        validate_password(new_password)
-
+        # The user is resolved before validating so the candidate password can
+        # be screened against this account's own username and email.
         user = self.get_current_user(user_id)
+
+        validate_password(
+            new_password,
+            username=user.username,
+            email=user.email,
+        )
 
         expected_frag = user.password_hash[-10:] if user.password_hash else "nohash"
         if hash_frag and hash_frag != expected_frag:

--- a/backend/app/services/password_breach_service.py
+++ b/backend/app/services/password_breach_service.py
@@ -1,0 +1,158 @@
+"""
+Have I Been Pwned breach lookup.
+
+Uses the range API, which is a k-anonymity scheme: we SHA-1 the password and
+send only the first five hex characters of the digest. The service answers with
+every suffix it holds under that prefix -- several hundred entries -- and the
+comparison happens locally. The password, and even its full hash, never leave
+this process.
+
+The check is advisory. A network problem must never stop somebody registering,
+so every failure path fails open and is logged.
+"""
+
+import hashlib
+import logging
+from typing import Optional
+
+import httpx
+
+from app.core.cache import cache_manager
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+_CACHE_PREFIX = "hibp:range:"
+
+
+class PasswordBreachService:
+    """
+    Look up how often a password appears in known breach corpora.
+
+    Stateless apart from the shared cache, so it is cheap to instantiate per
+    request; a module-level singleton is provided below for convenience.
+    """
+
+    def __init__(
+        self,
+        api_url: Optional[str] = None,
+        timeout: Optional[float] = None,
+    ) -> None:
+        self.api_url = api_url or settings.HIBP_API_URL
+        self.timeout = timeout if timeout is not None else settings.HIBP_TIMEOUT_SECONDS
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def breach_count(self, password: str) -> int:
+        """
+        Number of times the password appears in the breach corpus.
+
+        Returns ``0`` both when the password is genuinely absent and when the
+        lookup could not be completed -- callers must not treat ``0`` as proof
+        of safety, only as "no reason to reject".
+        """
+        if not settings.ENABLE_HIBP_CHECK or not password:
+            return 0
+
+        prefix, suffix = self._hash_parts(password)
+
+        body = self._fetch_range(prefix)
+        if body is None:
+            return 0
+
+        return self._count_from_range(body, suffix)
+
+    def is_compromised(self, password: str) -> bool:
+        """
+        Whether the password appears often enough to be worth rejecting.
+
+        ``HIBP_MIN_BREACH_COUNT`` exists because a handful of the corpus
+        entries are one-off artefacts rather than passwords in active use on
+        credential-stuffing lists.
+        """
+        return self.breach_count(password) >= settings.HIBP_MIN_BREACH_COUNT
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _hash_parts(password: str) -> tuple[str, str]:
+        """
+        Split the SHA-1 of the password into the prefix we send and the suffix
+        we match locally.
+
+        SHA-1 is not a security choice here -- it is the digest the range API
+        is keyed on. The value being protected is the password, and it is
+        protected by only ever transmitting five characters of the digest.
+        """
+        digest = hashlib.sha1(password.encode("utf-8")).hexdigest().upper()
+        return digest[:5], digest[5:]
+
+    def _fetch_range(self, prefix: str) -> Optional[str]:
+        """
+        Fetch (or reuse) the suffix list for a hash prefix.
+
+        Range responses are effectively static, so caching them cuts the
+        request count substantially: five hex characters means only 1,048,576
+        possible buckets, and real traffic clusters hard.
+        """
+        cache_key = f"{_CACHE_PREFIX}{prefix}"
+
+        cached = cache_manager.get(cache_key)
+        if cached is not None:
+            return cached
+
+        try:
+            response = httpx.get(
+                f"{self.api_url}/{prefix}",
+                timeout=self.timeout,
+                headers={
+                    # Opting in to padded responses means every reply contains
+                    # a similar number of entries, so an observer cannot infer
+                    # anything from the response size.
+                    "Add-Padding": "true",
+                    "User-Agent": "DevLink-Password-Screening",
+                },
+            )
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            # Fail open. An outage at a third party must not become an outage
+            # of our signup form.
+            logger.warning("HIBP range lookup failed for prefix %s: %s", prefix, exc)
+            return None
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Unexpected HIBP lookup error: %s", exc)
+            return None
+
+        body = response.text
+        cache_manager.set(cache_key, body, ttl=settings.HIBP_CACHE_TTL_SECONDS)
+        return body
+
+    @staticmethod
+    def _count_from_range(body: str, suffix: str) -> int:
+        """
+        Find our suffix in a range response.
+
+        Each line is ``<SUFFIX>:<COUNT>``. Padded responses include synthetic
+        entries with a count of zero, which fall out naturally: either they do
+        not match our suffix, or the count they carry is zero anyway.
+        """
+        target = suffix.upper()
+
+        for line in body.splitlines():
+            candidate, _, count = line.partition(":")
+            if candidate.strip().upper() != target:
+                continue
+            try:
+                return int(count.strip())
+            except ValueError:
+                logger.warning("Malformed count in HIBP response: %r", line)
+                return 0
+
+        return 0
+
+
+password_breach_service = PasswordBreachService()

--- a/backend/app/utils/validators.py
+++ b/backend/app/utils/validators.py
@@ -52,9 +52,21 @@ def validate_username(username: str) -> str:
 # ==========================================================
 
 
-def validate_password(password: str) -> str:
+def validate_password(
+    password: str,
+    username: str | None = None,
+    email: str | None = None,
+) -> str:
     """
     Validate password strength.
+
+    Runs the composition rules first, then screens the candidate against the
+    local blocklist of known-guessable passwords and, when enabled, the Have I
+    Been Pwned corpus. ``username`` and ``email`` are optional; passing them
+    additionally rejects passwords built out of the user's own identifiers.
+
+    The screening checks are ordered cheapest-first so the network call only
+    happens for a password that has already passed everything else.
     """
 
     if len(password) < 8:
@@ -93,7 +105,59 @@ def validate_password(password: str) -> str:
             detail="Password must contain a special character.",
         )
 
+    _screen_password(password, username=username, email=email)
+
     return password
+
+
+def _screen_password(
+    password: str,
+    username: str | None = None,
+    email: str | None = None,
+) -> None:
+    """
+    Reject passwords that are structurally fine but known to be guessable.
+
+    Imported lazily so that ``validators`` stays a leaf module -- the breach
+    service pulls in the cache manager and httpx, neither of which every
+    caller of this file needs.
+    """
+    from app.core.config import settings
+    from app.core.password_blocklist import (
+        contains_personal_information,
+        is_common_password,
+    )
+
+    if settings.ENABLE_PASSWORD_BLOCKLIST:
+        if is_common_password(password):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "This password is too common and appears on public "
+                    "password lists. Please choose a different one."
+                ),
+            )
+
+        if contains_personal_information(password, username=username, email=email):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Password must not contain your username or email address."
+                ),
+            )
+
+    if settings.ENABLE_HIBP_CHECK:
+        from app.services.password_breach_service import password_breach_service
+
+        # Fails open on any network trouble, so this cannot lock users out.
+        if password_breach_service.is_compromised(password):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "This password has appeared in a known data breach. "
+                    "Please choose a different one."
+                ),
+            )
 
 
 # ==========================================================

--- a/backend/app/utils/validators.py
+++ b/backend/app/utils/validators.py
@@ -141,9 +141,7 @@ def _screen_password(
         if contains_personal_information(password, username=username, email=email):
             raise HTTPException(
                 status_code=400,
-                detail=(
-                    "Password must not contain your username or email address."
-                ),
+                detail=("Password must not contain your username or email address."),
             )
 
     if settings.ENABLE_HIBP_CHECK:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -113,7 +113,7 @@ def register_and_login(client: TestClient):
     """
 
     def _register_and_login_func(
-        email: str, username: str, password: str = "Passw0rd!"
+        email: str, username: str, password: str = "Vermilion-Kestrel97!"
     ) -> tuple[str, str]:
         # Register
         client.post(

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -9,7 +9,7 @@ def test_register_success(client: TestClient):
             "last_name": "User",
             "email": "testregister@example.com",
             "username": "testregister",
-            "password": "Password123!",
+            "password": "Vermilion-Kestrel97!",
         },
     )
     assert response.status_code == 201
@@ -27,7 +27,7 @@ def test_register_duplicate_email(client: TestClient, register_and_login):
             "last_name": "User",
             "email": "dup@example.com",
             "username": "dupuser2",
-            "password": "Password123!",
+            "password": "Vermilion-Kestrel97!",
         },
     )
     assert response.status_code == 409
@@ -44,12 +44,12 @@ def test_login_success(client: TestClient, register_and_login):
             "last_name": "User",
             "email": "login@example.com",
             "username": "loginuser",
-            "password": "Password123!",
+            "password": "Vermilion-Kestrel97!",
         },
     )
     response = client.post(
         "/api/auth/login",
-        json={"email": "login@example.com", "password": "Password123!"},
+        json={"email": "login@example.com", "password": "Vermilion-Kestrel97!"},
     )
     assert response.status_code == 200
     assert "access_token" in response.json()
@@ -59,7 +59,7 @@ def test_login_success(client: TestClient, register_and_login):
 def test_login_invalid_credentials(client: TestClient):
     response = client.post(
         "/api/auth/login",
-        json={"email": "nonexistent@example.com", "password": "Password123!"},
+        json={"email": "nonexistent@example.com", "password": "Vermilion-Kestrel97!"},
     )
     assert response.status_code == 401
 
@@ -82,12 +82,12 @@ def test_refresh_token(client: TestClient, register_and_login):
             "last_name": "User",
             "email": "refresh@example.com",
             "username": "refreshuser",
-            "password": "Password123!",
+            "password": "Vermilion-Kestrel97!",
         },
     )
     login_resp = client.post(
         "/api/auth/login",
-        json={"email": "refresh@example.com", "password": "Password123!"},
+        json={"email": "refresh@example.com", "password": "Vermilion-Kestrel97!"},
     )
     refresh_token = login_resp.json()["refresh_token"]
 

--- a/backend/tests/test_conversations.py
+++ b/backend/tests/test_conversations.py
@@ -123,7 +123,7 @@ def test_router_prevent_self_messaging_integration(client):
             "last_name": "Test",
             "email": "charlie@example.com",
             "username": "charlie",
-            "password": "Passw0rd!",
+            "password": "Vermilion-Kestrel97!",
         },
     )
 
@@ -131,7 +131,7 @@ def test_router_prevent_self_messaging_integration(client):
         "/api/auth/login",
         json={
             "email": "charlie@example.com",
-            "password": "Passw0rd!",
+            "password": "Vermilion-Kestrel97!",
         },
     )
     token = login_resp.json()["access_token"]

--- a/backend/tests/test_forms_validation.py
+++ b/backend/tests/test_forms_validation.py
@@ -30,10 +30,10 @@ class TestLoginFormValidation:
         assert any(err["loc"][0] == "password" for err in exc_info.value.errors())
 
     def test_login_successful_submission(self):
-        payload = {"email": "user@example.com", "password": "Password123!"}
+        payload = {"email": "user@example.com", "password": "Vermilion-Kestrel97!"}
         req = LoginRequest.model_validate(payload)
         assert req.email == "user@example.com"
-        assert req.password == "Password123!"
+        assert req.password == "Vermilion-Kestrel97!"
 
     def test_login_api_endpoint_validation(self, client: TestClient):
         # Invalid email payload to endpoint returns HTTP 422
@@ -77,7 +77,7 @@ class TestSignupFormValidation:
             "last_name": "Doe",
             "username": "johndoe",
             "email": "johndoe@example.com",
-            "password": "Password123!",
+            "password": "Vermilion-Kestrel97!",
         }
         req = RegisterRequest.model_validate(payload)
         assert req.first_name == "John"

--- a/backend/tests/test_last_seen.py
+++ b/backend/tests/test_last_seen.py
@@ -53,10 +53,10 @@ def _register_and_login(
             "last_name": "User",
             "email": email,
             "username": username,
-            "password": "Passw0rd!",
+            "password": "Vermilion-Kestrel97!",
         },
     )
-    r = client.post("/api/auth/login", json={"email": email, "password": "Passw0rd!"})
+    r = client.post("/api/auth/login", json={"email": email, "password": "Vermilion-Kestrel97!"})
     token = r.json()["access_token"]
     me = client.get("/api/users/me", headers={"Authorization": f"Bearer {token}"})
     return me.json()["id"], token

--- a/backend/tests/test_mfa.py
+++ b/backend/tests/test_mfa.py
@@ -20,7 +20,7 @@ def mfa_user(db):
         last_name="Tester",
         username=f"mfa_{uuid4().hex[:6]}",
         email=f"mfa_{uuid4().hex[:6]}@example.com",
-        password_hash=hash_password("Password123!"),
+        password_hash=hash_password("Vermilion-Kestrel97!"),
         is_active=True,
         mfa_enabled=False,
     )
@@ -90,7 +90,7 @@ def test_mfa_enable_and_login_flow(client, db, mfa_user, mfa_auth_headers):
     # 4. Login with password requires MFA
     login_res = client.post(
         "/api/v1/auth/login",
-        json={"email": mfa_user.email, "password": "Password123!"},
+        json={"email": mfa_user.email, "password": "Vermilion-Kestrel97!"},
     )
     assert login_res.status_code == 200
     login_data = login_res.json()
@@ -121,7 +121,7 @@ def test_mfa_login_with_recovery_code(client, db, mfa_user):
     # Trigger password login
     login_res = client.post(
         "/api/v1/auth/login",
-        json={"email": mfa_user.email, "password": "Password123!"},
+        json={"email": mfa_user.email, "password": "Vermilion-Kestrel97!"},
     )
     mfa_token = login_res.json()["mfa_token"]
 
@@ -136,7 +136,7 @@ def test_mfa_login_with_recovery_code(client, db, mfa_user):
     # Reuse of same recovery code should fail
     login_res2 = client.post(
         "/api/v1/auth/login",
-        json={"email": mfa_user.email, "password": "Password123!"},
+        json={"email": mfa_user.email, "password": "Vermilion-Kestrel97!"},
     )
     mfa_token2 = login_res2.json()["mfa_token"]
 

--- a/backend/tests/test_notification_tasks.py
+++ b/backend/tests/test_notification_tasks.py
@@ -93,7 +93,7 @@ def test_router_enqueue_integration(client):
             "last_name": "User",
             "email": "alice2@x.com",
             "username": "alice2",
-            "password": "Passw0rd!",
+            "password": "Vermilion-Kestrel97!",
         },
     )
 
@@ -101,12 +101,12 @@ def test_router_enqueue_integration(client):
         "/api/auth/login",
         json={
             "email": "alice2@x.com",
-            "password": "Passw0rd!",
+            "password": "Vermilion-Kestrel97!",
         },
     )
 
     r = client.post(
-        "/api/auth/login", json={"email": "alice2@x.com", "password": "Passw0rd!"}
+        "/api/auth/login", json={"email": "alice2@x.com", "password": "Vermilion-Kestrel97!"}
     )
 
     a_tok = r.json()["access_token"]
@@ -128,7 +128,7 @@ def test_router_enqueue_integration(client):
             "last_name": "User",
             "email": "bob2@x.com",
             "username": "bob2",
-            "password": "Passw0rd!",
+            "password": "Vermilion-Kestrel97!",
         },
     )
 
@@ -136,12 +136,12 @@ def test_router_enqueue_integration(client):
         "/api/auth/login",
         json={
             "email": "bob2@x.com",
-            "password": "Passw0rd!",
+            "password": "Vermilion-Kestrel97!",
         },
     )
 
     r = client.post(
-        "/api/auth/login", json={"email": "bob2@x.com", "password": "Passw0rd!"}
+        "/api/auth/login", json={"email": "bob2@x.com", "password": "Vermilion-Kestrel97!"}
     )
 
     b_tok = r.json()["access_token"]

--- a/backend/tests/test_notification_tasks.py
+++ b/backend/tests/test_notification_tasks.py
@@ -106,7 +106,8 @@ def test_router_enqueue_integration(client):
     )
 
     r = client.post(
-        "/api/auth/login", json={"email": "alice2@x.com", "password": "Vermilion-Kestrel97!"}
+        "/api/auth/login",
+        json={"email": "alice2@x.com", "password": "Vermilion-Kestrel97!"},
     )
 
     a_tok = r.json()["access_token"]
@@ -141,7 +142,8 @@ def test_router_enqueue_integration(client):
     )
 
     r = client.post(
-        "/api/auth/login", json={"email": "bob2@x.com", "password": "Vermilion-Kestrel97!"}
+        "/api/auth/login",
+        json={"email": "bob2@x.com", "password": "Vermilion-Kestrel97!"},
     )
 
     b_tok = r.json()["access_token"]

--- a/backend/tests/test_notifications_events.py
+++ b/backend/tests/test_notifications_events.py
@@ -34,7 +34,9 @@ def _register_and_login(
             "password": "Vermilion-Kestrel97!",
         },
     )
-    r = client.post("/api/auth/login", json={"email": email, "password": "Vermilion-Kestrel97!"})
+    r = client.post(
+        "/api/auth/login", json={"email": email, "password": "Vermilion-Kestrel97!"}
+    )
     token = r.json()["access_token"]
     me = client.get("/api/users/me", headers={"Authorization": f"Bearer {token}"})
     return me.json()["id"], token

--- a/backend/tests/test_notifications_events.py
+++ b/backend/tests/test_notifications_events.py
@@ -31,10 +31,10 @@ def _register_and_login(
             "last_name": "User",
             "email": email,
             "username": username,
-            "password": "Passw0rd!",
+            "password": "Vermilion-Kestrel97!",
         },
     )
-    r = client.post("/api/auth/login", json={"email": email, "password": "Passw0rd!"})
+    r = client.post("/api/auth/login", json={"email": email, "password": "Vermilion-Kestrel97!"})
     token = r.json()["access_token"]
     me = client.get("/api/users/me", headers={"Authorization": f"Bearer {token}"})
     return me.json()["id"], token

--- a/backend/tests/test_oauth.py
+++ b/backend/tests/test_oauth.py
@@ -75,7 +75,7 @@ def test_github_login_link_existing_account(
         last_name="User",
         username="existing_user",
         email="existing@example.com",
-        password_hash=hash_password("Password123!"),
+        password_hash=hash_password("Vermilion-Kestrel97!"),
         is_active=True,
     )
     db.add(existing_user)

--- a/backend/tests/test_organizations.py
+++ b/backend/tests/test_organizations.py
@@ -21,10 +21,10 @@ def _register_and_login(
             "last_name": "User",
             "email": email,
             "username": username,
-            "password": "Passw0rd!",
+            "password": "Vermilion-Kestrel97!",
         },
     )
-    r = client.post("/api/auth/login", json={"email": email, "password": "Passw0rd!"})
+    r = client.post("/api/auth/login", json={"email": email, "password": "Vermilion-Kestrel97!"})
     token = r.json()["access_token"]
     me = client.get("/api/users/me", headers={"Authorization": f"Bearer {token}"})
     return me.json()["id"], token

--- a/backend/tests/test_organizations.py
+++ b/backend/tests/test_organizations.py
@@ -24,7 +24,9 @@ def _register_and_login(
             "password": "Vermilion-Kestrel97!",
         },
     )
-    r = client.post("/api/auth/login", json={"email": email, "password": "Vermilion-Kestrel97!"})
+    r = client.post(
+        "/api/auth/login", json={"email": email, "password": "Vermilion-Kestrel97!"}
+    )
     token = r.json()["access_token"]
     me = client.get("/api/users/me", headers={"Authorization": f"Bearer {token}"})
     return me.json()["id"], token

--- a/backend/tests/test_password_screening.py
+++ b/backend/tests/test_password_screening.py
@@ -1,0 +1,380 @@
+"""
+Tests for compromised-password screening.
+
+Covers the offline blocklist, the personal-information check, and the Have I
+Been Pwned range lookup. The HIBP transport is always mocked -- the suite must
+not depend on a third party being reachable.
+"""
+
+import hashlib
+from unittest.mock import patch
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+from app.core.password_blocklist import (
+    COMMON_PASSWORDS,
+    contains_personal_information,
+    is_common_password,
+    normalise_password,
+)
+from app.services.password_breach_service import PasswordBreachService
+from app.utils.validators import validate_password
+
+
+# ----------------------------------------------------------------------
+# Normalisation
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("password", "password"),
+        ("PASSWORD", "password"),
+        ("P@ssw0rd", "password"),
+        ("p@$$w0rd", "password"),
+        ("Password2025!", "password"),
+        ("Welcome123", "welcome"),
+    ],
+)
+def test_normalise_password_folds_to_the_core_word(raw, expected):
+    assert normalise_password(raw) == expected
+
+
+def test_normalisation_never_yields_an_empty_blocklist_entry():
+    # A purely numeric entry folds away to "". If that leaked into the
+    # blocklist every password whose core folds away would be rejected.
+    assert "" not in COMMON_PASSWORDS
+
+
+# ----------------------------------------------------------------------
+# Blocklist
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "password",
+    [
+        "password",
+        "Password",
+        "PASSWORD",
+        "P@ssw0rd",
+        "Password1!",
+        "Welcome123!",
+        "Qwerty123",
+        "Admin123!",
+        "Letmein123",
+        "Devlink123!",
+        "Summer2025!",
+        "Changeme123",
+    ],
+)
+def test_common_passwords_are_recognised(password):
+    assert is_common_password(password)
+
+
+@pytest.mark.parametrize(
+    "password",
+    [
+        "correct-horse-battery-staple",
+        "Tr0ub4dor&3xkcd",
+        "vermilion-kestrel-97",
+        "QuietLoomBaseline#8",
+    ],
+)
+def test_unusual_passwords_are_not_flagged(password):
+    assert not is_common_password(password)
+
+
+def test_empty_password_is_not_flagged_as_common():
+    assert not is_common_password("")
+
+
+# ----------------------------------------------------------------------
+# Personal information
+# ----------------------------------------------------------------------
+
+
+def test_password_containing_username_is_rejected():
+    assert contains_personal_information(
+        "AlexRivera2025!", username="alexrivera"
+    )
+
+
+def test_password_containing_email_local_part_is_rejected():
+    assert contains_personal_information(
+        "Rivera#2025", email="rivera@devlink.app"
+    )
+
+
+def test_dotted_username_is_split_into_tokens():
+    assert contains_personal_information("Rivera!99", username="alex.rivera")
+
+
+def test_email_domain_alone_does_not_trigger():
+    # Everyone shares the domain, so matching on it would reject far too much.
+    assert not contains_personal_information(
+        "QuietLoom#8421", email="alex@devlink.app"
+    )
+
+
+def test_short_tokens_are_ignored():
+    # A two-letter username would otherwise match almost any password.
+    assert not contains_personal_information("QuietLoom#8421", username="al")
+
+
+def test_unrelated_password_passes_the_context_check():
+    assert not contains_personal_information(
+        "vermilion-kestrel-97",
+        username="alexrivera",
+        email="alex@devlink.app",
+    )
+
+
+# ----------------------------------------------------------------------
+# HIBP range lookup
+# ----------------------------------------------------------------------
+
+
+def _range_body_for(password: str, count: int) -> str:
+    """Build a realistic range response containing the given password."""
+    digest = hashlib.sha1(password.encode("utf-8")).hexdigest().upper()
+    suffix = digest[5:]
+    return "\n".join(
+        [
+            "0000000000000000000000000000000000A:0",
+            f"{suffix}:{count}",
+            "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF:12",
+        ]
+    )
+
+
+def _response(status_code: int, text: str = "") -> httpx.Response:
+    """
+    Build a response with its request attached.
+
+    ``raise_for_status`` needs the originating request, so a bare
+    ``httpx.Response(200, text=...)`` blows up inside the service.
+    """
+    return httpx.Response(
+        status_code,
+        text=text,
+        request=httpx.Request("GET", "https://hibp.test/range/ABCDE"),
+    )
+
+
+@pytest.fixture
+def breach_service():
+    service = PasswordBreachService(api_url="https://hibp.test/range", timeout=1.0)
+    with patch("app.services.password_breach_service.cache_manager") as cache:
+        cache.get.return_value = None
+        yield service
+
+
+def _enable_hibp(monkeypatch):
+    from app.core import config as config_module
+
+    monkeypatch.setattr(config_module.settings, "ENABLE_HIBP_CHECK", True)
+
+
+def test_only_the_hash_prefix_is_sent(monkeypatch, breach_service):
+    _enable_hibp(monkeypatch)
+    password = "vermilion-kestrel-97"
+    digest = hashlib.sha1(password.encode("utf-8")).hexdigest().upper()
+
+    with patch("httpx.get") as mock_get:
+        mock_get.return_value = _response(200, _range_body_for(password, 42))
+        breach_service.breach_count(password)
+
+    requested_url = mock_get.call_args[0][0]
+
+    assert requested_url.endswith(f"/{digest[:5]}")
+    # Neither the password nor the rest of its digest may appear anywhere in
+    # the outbound request.
+    assert password not in requested_url
+    assert digest[5:] not in requested_url
+
+
+def test_padding_is_requested(monkeypatch, breach_service):
+    _enable_hibp(monkeypatch)
+
+    with patch("httpx.get") as mock_get:
+        mock_get.return_value = _response(200, "ABC:1")
+        breach_service.breach_count("vermilion-kestrel-97")
+
+    assert mock_get.call_args.kwargs["headers"]["Add-Padding"] == "true"
+
+
+def test_breach_count_returns_the_matching_count(monkeypatch, breach_service):
+    _enable_hibp(monkeypatch)
+    password = "vermilion-kestrel-97"
+
+    with patch("httpx.get") as mock_get:
+        mock_get.return_value = _response(200, _range_body_for(password, 4213))
+        assert breach_service.breach_count(password) == 4213
+
+
+def test_absent_suffix_counts_as_zero(monkeypatch, breach_service):
+    _enable_hibp(monkeypatch)
+
+    with patch("httpx.get") as mock_get:
+        mock_get.return_value = _response(
+            200, "0000000000000000000000000000000000A:0"
+        )
+        assert breach_service.breach_count("vermilion-kestrel-97") == 0
+
+
+def test_is_compromised_respects_the_minimum_count(monkeypatch, breach_service):
+    _enable_hibp(monkeypatch)
+
+    from app.core import config as config_module
+
+    monkeypatch.setattr(config_module.settings, "HIBP_MIN_BREACH_COUNT", 5)
+    password = "vermilion-kestrel-97"
+
+    with patch("httpx.get") as mock_get:
+        mock_get.return_value = _response(200, _range_body_for(password, 2))
+        assert not breach_service.is_compromised(password)
+
+    with patch("httpx.get") as mock_get:
+        mock_get.return_value = _response(200, _range_body_for(password, 900))
+        assert breach_service.is_compromised(password)
+
+
+def test_network_failure_fails_open(monkeypatch, breach_service):
+    _enable_hibp(monkeypatch)
+
+    with patch("httpx.get", side_effect=httpx.ConnectTimeout("timed out")):
+        assert breach_service.breach_count("vermilion-kestrel-97") == 0
+        assert not breach_service.is_compromised("vermilion-kestrel-97")
+
+
+def test_server_error_fails_open(monkeypatch, breach_service):
+    _enable_hibp(monkeypatch)
+
+    with patch("httpx.get") as mock_get:
+        mock_get.return_value = _response(503)
+        assert breach_service.breach_count("vermilion-kestrel-97") == 0
+
+
+def test_malformed_count_is_treated_as_zero(monkeypatch, breach_service):
+    _enable_hibp(monkeypatch)
+    digest = hashlib.sha1(b"vermilion-kestrel-97").hexdigest().upper()
+
+    with patch("httpx.get") as mock_get:
+        mock_get.return_value = _response(200, f"{digest[5:]}:not-a-number")
+        assert breach_service.breach_count("vermilion-kestrel-97") == 0
+
+
+def test_disabled_check_skips_the_network_entirely(monkeypatch, breach_service):
+    from app.core import config as config_module
+
+    monkeypatch.setattr(config_module.settings, "ENABLE_HIBP_CHECK", False)
+
+    with patch("httpx.get") as mock_get:
+        assert breach_service.breach_count("password") == 0
+
+    mock_get.assert_not_called()
+
+
+def test_cached_range_is_reused(monkeypatch):
+    _enable_hibp(monkeypatch)
+    password = "vermilion-kestrel-97"
+    service = PasswordBreachService(api_url="https://hibp.test/range")
+
+    with patch("app.services.password_breach_service.cache_manager") as cache:
+        cache.get.return_value = _range_body_for(password, 77)
+
+        with patch("httpx.get") as mock_get:
+            assert service.breach_count(password) == 77
+
+        mock_get.assert_not_called()
+
+
+# ----------------------------------------------------------------------
+# validate_password integration
+# ----------------------------------------------------------------------
+
+
+def test_composition_rules_still_apply():
+    # The screening layer is additive: the original length and character-class
+    # rules must still fire first.
+    with pytest.raises(HTTPException) as exc:
+        validate_password("Ab1!")
+
+    assert exc.value.status_code == 400
+    assert "at least 8 characters" in exc.value.detail
+
+
+def test_strong_unique_password_is_accepted():
+    assert (
+        validate_password(
+            "vermilion-Kestrel-97!",
+            username="alexrivera",
+            email="alex@devlink.app",
+        )
+        == "vermilion-Kestrel-97!"
+    )
+
+
+def test_common_password_is_rejected_by_validate_password():
+    with pytest.raises(HTTPException) as exc:
+        validate_password("Password123!")
+
+    assert exc.value.status_code == 400
+    assert "too common" in exc.value.detail
+
+
+def test_password_containing_username_is_rejected_by_validate_password():
+    with pytest.raises(HTTPException) as exc:
+        validate_password("AlexRivera#2025", username="alexrivera")
+
+    assert exc.value.status_code == 400
+    assert "username or email" in exc.value.detail
+
+
+def test_error_message_does_not_echo_the_password():
+    with pytest.raises(HTTPException) as exc:
+        validate_password("Password123!")
+
+    assert "Password123!" not in exc.value.detail
+
+
+def test_blocklist_can_be_disabled(monkeypatch):
+    from app.core import config as config_module
+
+    monkeypatch.setattr(config_module.settings, "ENABLE_PASSWORD_BLOCKLIST", False)
+    monkeypatch.setattr(config_module.settings, "ENABLE_HIBP_CHECK", False)
+
+    assert validate_password("Password123!") == "Password123!"
+
+
+def test_breached_password_is_rejected_by_validate_password(monkeypatch):
+    from app.core import config as config_module
+
+    monkeypatch.setattr(config_module.settings, "ENABLE_HIBP_CHECK", True)
+    password = "vermilion-Kestrel-97!"
+
+    with patch("app.services.password_breach_service.cache_manager") as cache:
+        cache.get.return_value = _range_body_for(password, 5000)
+
+        with pytest.raises(HTTPException) as exc:
+            validate_password(password)
+
+    assert "known data breach" in exc.value.detail
+
+
+def test_hibp_outage_does_not_block_registration(monkeypatch):
+    from app.core import config as config_module
+
+    monkeypatch.setattr(config_module.settings, "ENABLE_HIBP_CHECK", True)
+
+    with patch("app.services.password_breach_service.cache_manager") as cache:
+        cache.get.return_value = None
+        with patch("httpx.get", side_effect=httpx.ConnectError("no route")):
+            assert (
+                validate_password("vermilion-Kestrel-97!")
+                == "vermilion-Kestrel-97!"
+            )

--- a/backend/tests/test_password_screening.py
+++ b/backend/tests/test_password_screening.py
@@ -22,7 +22,6 @@ from app.core.password_blocklist import (
 from app.services.password_breach_service import PasswordBreachService
 from app.utils.validators import validate_password
 
-
 # ----------------------------------------------------------------------
 # Normalisation
 # ----------------------------------------------------------------------
@@ -98,15 +97,11 @@ def test_empty_password_is_not_flagged_as_common():
 
 
 def test_password_containing_username_is_rejected():
-    assert contains_personal_information(
-        "AlexRivera2025!", username="alexrivera"
-    )
+    assert contains_personal_information("AlexRivera2025!", username="alexrivera")
 
 
 def test_password_containing_email_local_part_is_rejected():
-    assert contains_personal_information(
-        "Rivera#2025", email="rivera@devlink.app"
-    )
+    assert contains_personal_information("Rivera#2025", email="rivera@devlink.app")
 
 
 def test_dotted_username_is_split_into_tokens():
@@ -115,9 +110,7 @@ def test_dotted_username_is_split_into_tokens():
 
 def test_email_domain_alone_does_not_trigger():
     # Everyone shares the domain, so matching on it would reject far too much.
-    assert not contains_personal_information(
-        "QuietLoom#8421", email="alex@devlink.app"
-    )
+    assert not contains_personal_information("QuietLoom#8421", email="alex@devlink.app")
 
 
 def test_short_tokens_are_ignored():
@@ -220,9 +213,7 @@ def test_absent_suffix_counts_as_zero(monkeypatch, breach_service):
     _enable_hibp(monkeypatch)
 
     with patch("httpx.get") as mock_get:
-        mock_get.return_value = _response(
-            200, "0000000000000000000000000000000000A:0"
-        )
+        mock_get.return_value = _response(200, "0000000000000000000000000000000000A:0")
         assert breach_service.breach_count("vermilion-kestrel-97") == 0
 
 
@@ -374,7 +365,4 @@ def test_hibp_outage_does_not_block_registration(monkeypatch):
     with patch("app.services.password_breach_service.cache_manager") as cache:
         cache.get.return_value = None
         with patch("httpx.get", side_effect=httpx.ConnectError("no route")):
-            assert (
-                validate_password("vermilion-Kestrel-97!")
-                == "vermilion-Kestrel-97!"
-            )
+            assert validate_password("vermilion-Kestrel-97!") == "vermilion-Kestrel-97!"

--- a/backend/tests/test_profile_completion.py
+++ b/backend/tests/test_profile_completion.py
@@ -50,10 +50,10 @@ def _register_and_login(
             "last_name": "User",
             "email": email,
             "username": username,
-            "password": "Passw0rd!",
+            "password": "Vermilion-Kestrel97!",
         },
     )
-    r = client.post("/api/auth/login", json={"email": email, "password": "Passw0rd!"})
+    r = client.post("/api/auth/login", json={"email": email, "password": "Vermilion-Kestrel97!"})
     token = r.json()["access_token"]
     me = client.get("/api/users/me", headers={"Authorization": f"Bearer {token}"})
     return me.json()["id"], token

--- a/backend/tests/test_rbac.py
+++ b/backend/tests/test_rbac.py
@@ -377,7 +377,9 @@ class TestUnauthorizedActionsBlocked:
 
     def test_user_cannot_access_admin_endpoint(self, client, register_and_login):
         """A regular USER should get 403 on an admin-only endpoint."""
-        user_id, token = register_and_login("user@test.com", "testuser", "Vermilion-Kestrel97!")
+        user_id, token = register_and_login(
+            "user@test.com", "testuser", "Vermilion-Kestrel97!"
+        )
 
         response = client.get(
             "/api/admin/users",
@@ -387,7 +389,9 @@ class TestUnauthorizedActionsBlocked:
 
     def test_admin_can_access_admin_endpoint(self, client, db, register_and_login):
         """An ADMIN user should be able to access admin endpoints."""
-        user_id, token = register_and_login("admin@test.com", "adminuser", "Vermilion-Kestrel97!")
+        user_id, token = register_and_login(
+            "admin@test.com", "adminuser", "Vermilion-Kestrel97!"
+        )
 
         from app.models.user import User
 

--- a/backend/tests/test_rbac.py
+++ b/backend/tests/test_rbac.py
@@ -377,7 +377,7 @@ class TestUnauthorizedActionsBlocked:
 
     def test_user_cannot_access_admin_endpoint(self, client, register_and_login):
         """A regular USER should get 403 on an admin-only endpoint."""
-        user_id, token = register_and_login("user@test.com", "testuser", "Passw0rd!")
+        user_id, token = register_and_login("user@test.com", "testuser", "Vermilion-Kestrel97!")
 
         response = client.get(
             "/api/admin/users",
@@ -387,7 +387,7 @@ class TestUnauthorizedActionsBlocked:
 
     def test_admin_can_access_admin_endpoint(self, client, db, register_and_login):
         """An ADMIN user should be able to access admin endpoints."""
-        user_id, token = register_and_login("admin@test.com", "adminuser", "Passw0rd!")
+        user_id, token = register_and_login("admin@test.com", "adminuser", "Vermilion-Kestrel97!")
 
         from app.models.user import User
 

--- a/backend/tests/test_refresh_tokens.py
+++ b/backend/tests/test_refresh_tokens.py
@@ -23,7 +23,7 @@ def _register_user(client: TestClient, email: str, username: str):
             "last_name": "User",
             "email": email,
             "username": username,
-            "password": "Password123!",
+            "password": "Vermilion-Kestrel97!",
         },
     )
 
@@ -34,7 +34,7 @@ def test_login_creates_refresh_token_in_db():
 
     res = client.post(
         "/api/auth/login",
-        json={"email": "login_test@example.com", "password": "Password123!"},
+        json={"email": "login_test@example.com", "password": "Vermilion-Kestrel97!"},
         headers={"User-Agent": "Pytest-Client"},
     )
     assert res.status_code == 200
@@ -56,7 +56,7 @@ def test_refresh_token_rotation():
 
     login_res = client.post(
         "/api/auth/login",
-        json={"email": "rotate_test@example.com", "password": "Password123!"},
+        json={"email": "rotate_test@example.com", "password": "Vermilion-Kestrel97!"},
     )
     old_refresh_token = login_res.json()["refresh_token"]
 
@@ -87,7 +87,7 @@ def test_refresh_token_reuse_prevention():
 
     login_res = client.post(
         "/api/auth/login",
-        json={"email": "reuse_test@example.com", "password": "Password123!"},
+        json={"email": "reuse_test@example.com", "password": "Vermilion-Kestrel97!"},
     )
     initial_refresh_token = login_res.json()["refresh_token"]
 
@@ -120,7 +120,7 @@ def test_get_active_sessions():
 
     login_res = client.post(
         "/api/auth/login",
-        json={"email": "sessions_test@example.com", "password": "Password123!"},
+        json={"email": "sessions_test@example.com", "password": "Vermilion-Kestrel97!"},
     )
     access_token = login_res.json()["access_token"]
     headers = {"Authorization": f"Bearer {access_token}"}
@@ -138,7 +138,7 @@ def test_revoke_individual_session():
 
     login_res = client.post(
         "/api/auth/login",
-        json={"email": "revonesess@example.com", "password": "Password123!"},
+        json={"email": "revonesess@example.com", "password": "Vermilion-Kestrel97!"},
     )
     access_token = login_res.json()["access_token"]
     headers = {"Authorization": f"Bearer {access_token}"}
@@ -159,11 +159,11 @@ def test_revoke_all_sessions():
 
     login_res1 = client.post(
         "/api/auth/login",
-        json={"email": "revall@example.com", "password": "Password123!"},
+        json={"email": "revall@example.com", "password": "Vermilion-Kestrel97!"},
     )
     login_res2 = client.post(
         "/api/auth/login",
-        json={"email": "revall@example.com", "password": "Password123!"},
+        json={"email": "revall@example.com", "password": "Vermilion-Kestrel97!"},
     )
     access_token = login_res2.json()["access_token"]
     headers = {"Authorization": f"Bearer {access_token}"}

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -29,7 +29,7 @@ def test_create_user(client: TestClient):
             "last_name": "User",
             "email": "createuser@example.com",
             "username": "createuser",
-            "password": "Password123!",
+            "password": "Vermilion-Kestrel97!",
         },
     )
     assert response.status_code == 201
@@ -45,7 +45,7 @@ def test_create_user_duplicate_email(client: TestClient, register_and_login):
             "last_name": "User",
             "email": "dupem@example.com",
             "username": "dupem2",
-            "password": "Password123!",
+            "password": "Vermilion-Kestrel97!",
         },
     )
     assert response.status_code == 400
@@ -61,7 +61,7 @@ def test_create_user_duplicate_username(client: TestClient, register_and_login):
             "last_name": "User",
             "email": "dupusr2@example.com",
             "username": "dupusr",
-            "password": "Password123!",
+            "password": "Vermilion-Kestrel97!",
         },
     )
     assert response.status_code == 400

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,5 +1,87 @@
 # DevLink Security Documentation
 
+## Password Screening (#855)
+
+Composition rules alone are a weak defence. `Password1!`, `Welcome123!` and
+`Qwerty123!` all satisfy "8 characters, upper, lower, digit, symbol" and all
+appear near the top of every credential-stuffing wordlist. NIST SP 800-63B
+recommends screening candidate passwords against known-bad values rather than
+relying on composition, so `validate_password` now runs three additional checks
+after the structural ones.
+
+### 1. Local blocklist
+
+`app/core/password_blocklist.py` holds an in-repo list of the most commonly
+observed passwords. Candidates are normalised before comparison:
+
+| Input             | Normalised | Rejected |
+| :---------------- | :--------- | :------- |
+| `password`        | `password` | yes      |
+| `P@ssw0rd`        | `password` | yes      |
+| `Password2025!`   | `password` | yes      |
+| `Welcome123!`     | `welcome`  | yes      |
+
+Normalisation lowercases, applies Unicode NFKD folding, strips trailing digits
+and punctuation, then undoes common leetspeak substitutions. That means one
+blocklist entry covers a whole family of decorated variants, so the list stays
+small enough to read.
+
+### 2. Personal information
+
+A password that contains the user's own username or email local-part is
+rejected. `alexrivera` picking `Alex.Rivera2025!` is on the first page of any
+targeted guess list. Tokens shorter than four characters are ignored — a short
+identifier would otherwise match nearly everything — and the email *domain* is
+not considered, since every user shares it.
+
+### 3. Have I Been Pwned
+
+The long tail is covered by the HIBP range API using k-anonymity:
+
+1. SHA-1 the candidate password.
+2. Send **only the first five hex characters** of the digest.
+3. HIBP returns every suffix it holds under that prefix — several hundred.
+4. Match our suffix against that list locally.
+
+The password never leaves the process, and neither does its full hash. Requests
+set `Add-Padding: true` so every response contains a similar number of entries
+and an observer cannot infer anything from the response size. Range responses
+are cached for 24 hours.
+
+**This check fails open.** A timeout, connection error or 5xx from HIBP is
+logged and treated as "no reason to reject". An outage at a third party must
+never become an outage of our signup form.
+
+### Where it applies
+
+Registration, password change, and password reset. Each passes the account's
+username and email so the personal-information check has context.
+
+### Configuration
+
+| Setting                     | Default                              | Purpose                                            |
+| :-------------------------- | :----------------------------------- | :------------------------------------------------- |
+| `ENABLE_PASSWORD_BLOCKLIST` | `true`                               | Local blocklist and personal-information checks     |
+| `ENABLE_HIBP_CHECK`         | `true` (`false` under pytest)        | HIBP range lookup                                   |
+| `HIBP_API_URL`              | `https://api.pwnedpasswords.com/range` | Range API endpoint                                |
+| `HIBP_TIMEOUT_SECONDS`      | `3.0`                                | Per-request timeout                                 |
+| `HIBP_MIN_BREACH_COUNT`     | `5`                                  | Occurrences before a password is rejected           |
+| `HIBP_CACHE_TTL_SECONDS`    | `86400`                              | How long a range response is cached                 |
+
+`HIBP_MIN_BREACH_COUNT` is above 1 deliberately: single-occurrence entries in
+the corpus are often artefacts rather than passwords in active circulation.
+
+`ENABLE_HIBP_CHECK` defaults off under pytest so the suite never depends on a
+third party being reachable; the behaviour itself is covered with a mocked
+transport in `tests/test_password_screening.py`.
+
+### Error messages
+
+Rejection messages state the category ("too common", "appeared in a known data
+breach") and never echo the submitted password back to the client.
+
+---
+
 ## Suspicious Login Detection System (#584)
 
 DevLink evaluates all authentication attempts (both successful and failed) in real time to detect suspicious login patterns and protect user accounts against unauthorized access, credential stuffing, and brute force attacks.


### PR DESCRIPTION
# Pull Request

## Summary

`validate_password` only checked structure — length, upper, lower, digit, symbol. `Password1!`, `Welcome123!` and `Qwerty123!` all pass that, and all three sit near the top of every credential-stuffing wordlist.

NIST SP 800-63B is explicit that composition rules are the weak option and that screening candidates against known-compromised values is what actually helps. This PR adds that screening in three layers.

---

## Related Issue

Closes #855

---

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [ ] UI/UX enhancement
- [x] Tests
- [ ] Other

---

## Changes Made

### 1. Local blocklist — `app/core/password_blocklist.py`

An in-repo list of the most commonly observed passwords. Candidates are normalised before comparison, so one entry covers a family of decorated variants:

| Input           | Normalised | Rejected |
| :-------------- | :--------- | :------- |
| `password`      | `password` | yes      |
| `P@ssw0rd`      | `password` | yes      |
| `Password2025!` | `password` | yes      |
| `Welcome123!`   | `welcome`  | yes      |

Normalisation lowercases, applies NFKD folding, strips trailing digits and punctuation, then undoes leetspeak. **Order matters and I got it wrong on the first pass** — folding leetspeak first turns the `2025` in `Password2025!` into letters, leaving nothing for the trailing-noise pattern to strip, so it never matched. The tests caught it; the ordering constraint is now commented in the function.

Because normalisation collapses variants, the list stays small enough to read and review rather than being a multi-megabyte wordlist vendored into the repo. HIBP covers the long tail.

### 2. Personal information

A password containing the user's own username or email local-part is rejected. Tokens under four characters are ignored (a two-letter username would match almost anything) and the email domain is not considered, since every user shares it.

### 3. Have I Been Pwned — `app/services/password_breach_service.py`

k-anonymity range lookup: SHA-1 the password, send **only the first five hex characters**, match the suffix locally. The password never leaves the process and neither does its full hash. `Add-Padding: true` is set so response size leaks nothing. Range responses cache for 24h.

**Fails open.** Timeout, connection error, 5xx and malformed responses are all logged and treated as "no reason to reject". An outage at a third party must not become an outage of our signup form.

### Wiring

`register`, `change_password` and `reset_password` now pass the account's username and email so the personal-information check has context. `reset_password` resolves the user *before* validating for that reason — the token checks that follow are unchanged.

### Test fixtures

Fourteen test files used `Passw0rd!` or `Password123!` as the fixture password. Both are now rejected, so they are updated to a value that is not on a wordlist. This is the change touching the most files, but it is mechanical.

---

## Testing

- [x] Tested locally
- [x] Existing tests pass
- [x] Added new tests
- [ ] UI verified
- [ ] Cross-browser tested (if applicable)

Additional testing notes:

`tests/test_password_screening.py` — 48 passed. The HIBP transport is mocked throughout; the suite must not depend on a third party being reachable. Coverage includes:

- Normalisation folding, and the guard that an entry never normalises down to `""` (which would reject every password whose core folds away).
- Blocklist hits and misses, including the composition-rule survivors.
- Username/email matching, dotted usernames, the domain-only non-match, and the short-token floor.
- **Privacy**: an explicit assertion that neither the password nor the non-prefix part of its digest appears in the outbound URL.
- Padding is requested.
- Breach counts, the minimum-count threshold, and cache reuse.
- Timeout, connection error, 5xx and malformed-count paths all fail open.
- End-to-end through `validate_password`, including that a HIBP outage does not block registration and that error messages never echo the password.

Regression check on the files whose fixtures changed, compared against a clean `main` worktree:

| File | main | this branch |
| :--- | :--- | :--- |
| `test_auth` | 14 passed | 14 passed |
| `test_users` | 20 passed | 20 passed |
| `test_mfa` | 6 passed | 6 passed |
| `test_refresh_tokens` | 6 passed | 6 passed |
| `test_last_seen` | 3 passed | 3 passed |
| `test_oauth` | 3 passed | 3 passed |
| `test_rbac` | 20 failed, 27 passed | 20 failed, 27 passed |
| `test_organizations` | 9 failed | 9 failed |
| `test_conversations` | 1 failed, 4 passed | 1 failed, 4 passed |
| `test_profile_completion` | 1 failed, 4 passed | 1 failed, 4 passed |
| `test_notifications_events` | 1 failed, 2 passed | 1 failed, 2 passed |
| `test_notification_tasks` | 1 failed, 2 passed | 1 failed, 2 passed |

Identical on both sides — those failures are pre-existing and unrelated (they post to `/organizations/` rather than `/api/organizations/`). No regressions from this change.

---

## Checklist

- [x] My code follows the project's coding standards.
- [x] I have tested my changes locally.
- [x] I have updated the documentation where necessary.
- [x] My changes do not introduce new warnings or errors.
- [x] I have reviewed my own code.
- [x] This pull request focuses on a single feature or fix.
- [x] I have linked the related issue.

---

## Additional Notes

**Existing users are unaffected.** Screening runs on password *entry*, not on login, so nobody is locked out of an account whose password is now on the list. Prompting existing users to rotate a compromised password is a separate, larger piece of work.

Both layers can be turned off independently (`ENABLE_PASSWORD_BLOCKLIST`, `ENABLE_HIBP_CHECK`) — see the new section in `docs/security.md` for the full settings table.
