### PR TITLE
Add PWA support: manifest, service worker, and offline fallback

### DIFF
--- a/docs/pwa.md
+++ b/docs/pwa.md
@@ -1,0 +1,104 @@
+# Progressive Web App
+
+DevLink ships a small PWA layer: a web app manifest, a service worker, an
+offline fallback page, and an in-app offline indicator.
+
+The goal is modest and deliberately so. This is not an offline-first rewrite.
+It makes the app installable, stops a dropped connection producing the
+browser's default error page, and tells the user when they are offline instead
+of letting mutations fail silently.
+
+## What's included
+
+| File                              | Purpose                                          |
+| :-------------------------------- | :----------------------------------------------- |
+| `public/manifest.webmanifest`     | Name, colours, icons, app shortcuts               |
+| `public/sw.js`                    | The service worker                                |
+| `public/offline.html`             | Fallback page when a navigation fails             |
+| `public/icons/icon.svg`           | App icon                                          |
+| `public/icons/icon-maskable.svg`  | Maskable variant, scaled for the 80% safe zone    |
+| `src/lib/pwa.ts`                  | Registration and update handling                  |
+| `src/hooks/useOnlineStatus.ts`    | Connectivity hook                                 |
+| `src/components/OfflineBanner.tsx`| The banner                                        |
+
+## Caching strategy
+
+The worker only touches same-origin `GET` requests. Everything else goes
+straight to the network.
+
+**Cache-first — `/_build/`, `/assets/`, `/icons/`**
+These URLs are content-hashed, so a cache hit can never be stale. A new deploy
+produces new filenames.
+
+**Network-first — navigations**
+Try the network, fall back to the cached shell, then to `offline.html`. Not
+cache-first: a stale app shell paired with a newer API is a worse failure than
+a slightly slower navigation.
+
+**Never cached — `/api/`, `/uploads/`**
+API responses are user-scoped and change constantly; serving a stale one is
+worse than failing the request. Caching an authenticated response also risks
+handing it to the wrong user on a shared device.
+
+The page cache is capped at 40 entries, evicting oldest-first.
+
+## Updates
+
+When a deploy lands while a tab is open, the new worker installs and waits.
+`src/lib/pwa.ts` detects that and the app shows a toast with a **Reload**
+action, which posts `SKIP_WAITING` to the waiting worker and reloads once it
+takes over.
+
+Users are never force-reloaded mid-task. The `controllerchange` handler is
+guarded by a flag, because Chrome can fire it more than once and a reload loop
+is a spectacularly bad failure mode.
+
+`activate` deletes every cache that is not the current version, so deploys do
+not leak storage. Bumping `CACHE_VERSION` in `sw.js` invalidates everything.
+
+## Registration
+
+Only in **production browser builds**:
+
+```ts
+registerServiceWorker({ onUpdateAvailable: (registration) => { ... } });
+```
+
+Not in dev — a service worker there is a reliable way to spend an afternoon
+debugging a stale bundle — and not under Vitest. Pass `force: true` when
+deliberately testing the worker.
+
+Registration never throws. A failure degrades the app to exactly how it behaved
+before the worker existed.
+
+## Offline indicator
+
+`useOnlineStatus()` wraps `navigator.onLine` and the `online`/`offline` events.
+It is a coarse signal — it reports whether a network interface is up, not
+whether our API is reachable — but it fires immediately when Wi-Fi drops, which
+is enough to explain a failed action.
+
+It defaults to `true` during SSR and when `navigator.onLine` is `undefined`, so
+the banner never flashes on a healthy load.
+
+## Testing it locally
+
+The worker does not run in `vite dev`. Use a production build:
+
+```bash
+npm run build
+npm run preview
+```
+
+Then in DevTools:
+
+- **Application → Manifest** — check installability
+- **Application → Service Workers** — confirm registration and activation
+- **Network → Offline**, then reload — you should get the app shell, or
+  `offline.html` on a route never visited
+
+## Not included
+
+Background sync and push notifications are deliberately out of scope. Both need
+a server-side story (a VAPID key pair, a subscription store, a delivery
+pipeline) and belong with the notification work, not here.

--- a/frontend/public/icons/icon-maskable.svg
+++ b/frontend/public/icons/icon-maskable.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512" role="img" aria-label="DevLink">
+  <!-- Maskable icons are cropped to a safe zone of the middle 80%, so the
+       artwork is scaled down and the background bleeds to the full canvas. -->
+  <rect width="512" height="512" fill="#0d1117"/>
+  <g transform="translate(256 256) scale(0.66) translate(-256 -256)">
+    <g stroke="#05b7d7" stroke-width="26" stroke-linecap="round" fill="none">
+      <path d="M196 256h120"/>
+    </g>
+    <circle cx="168" cy="256" r="46" fill="#05b7d7"/>
+    <circle cx="344" cy="256" r="46" fill="#05b7d7"/>
+    <g stroke="#05b7d7" stroke-width="22" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.55">
+      <path d="M168 210v-46l52-44"/>
+      <path d="M344 302v46l-52 44"/>
+    </g>
+  </g>
+</svg>

--- a/frontend/public/icons/icon.svg
+++ b/frontend/public/icons/icon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512" role="img" aria-label="DevLink">
+  <rect width="512" height="512" rx="112" fill="#0d1117"/>
+  <!-- Two nodes joined by a link: the "dev link". -->
+  <g stroke="#05b7d7" stroke-width="26" stroke-linecap="round" fill="none">
+    <path d="M196 256h120"/>
+  </g>
+  <circle cx="168" cy="256" r="46" fill="#05b7d7"/>
+  <circle cx="344" cy="256" r="46" fill="#05b7d7"/>
+  <g stroke="#05b7d7" stroke-width="22" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.55">
+    <path d="M168 210v-46l52-44"/>
+    <path d="M344 302v46l-52 44"/>
+  </g>
+</svg>

--- a/frontend/public/manifest.webmanifest
+++ b/frontend/public/manifest.webmanifest
@@ -1,0 +1,44 @@
+{
+  "name": "DevLink — Where builders connect, collaborate and ship",
+  "short_name": "DevLink",
+  "description": "Find teammates with AI matching, run projects, chat in real time, and enter hackathons together.",
+  "id": "/",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "orientation": "any",
+  "background_color": "#0d1117",
+  "theme_color": "#05b7d7",
+  "categories": ["productivity", "developer", "social"],
+  "icons": [
+    {
+      "src": "/icons/icon.svg",
+      "type": "image/svg+xml",
+      "sizes": "any",
+      "purpose": "any"
+    },
+    {
+      "src": "/icons/icon-maskable.svg",
+      "type": "image/svg+xml",
+      "sizes": "any",
+      "purpose": "maskable"
+    }
+  ],
+  "shortcuts": [
+    {
+      "name": "Dashboard",
+      "url": "/dashboard",
+      "description": "Your projects and activity at a glance"
+    },
+    {
+      "name": "Messages",
+      "url": "/messages",
+      "description": "Open your conversations"
+    },
+    {
+      "name": "Projects",
+      "url": "/projects",
+      "description": "Browse and manage projects"
+    }
+  ]
+}

--- a/frontend/public/offline.html
+++ b/frontend/public/offline.html
@@ -1,0 +1,162 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#05b7d7" />
+    <title>You're offline — DevLink</title>
+    <!--
+      Fully self-contained on purpose. This page is served by the service
+      worker when the network is unavailable, so it cannot rely on a
+      stylesheet, a font or a script that would itself need fetching.
+    -->
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: #f6f8fa;
+        --surface: #ffffff;
+        --fg: #1f2328;
+        --muted: #59636e;
+        --border: #d1d9e0;
+        --primary: #05b7d7;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d1117;
+          --surface: #161b22;
+          --fg: #f0f6fc;
+          --muted: #9198a1;
+          --border: #30363d;
+        }
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 1.5rem;
+        background: var(--bg);
+        color: var(--fg);
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        line-height: 1.5;
+      }
+
+      main {
+        width: 100%;
+        max-width: 28rem;
+        text-align: center;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 0.75rem;
+        padding: 2.5rem 1.75rem;
+      }
+
+      .icon {
+        width: 4rem;
+        height: 4rem;
+        margin: 0 auto 1.5rem;
+        color: var(--muted);
+      }
+
+      h1 {
+        margin: 0 0 0.75rem;
+        font-size: 1.5rem;
+        font-weight: 700;
+      }
+
+      p {
+        margin: 0 0 2rem;
+        color: var(--muted);
+        font-size: 0.9375rem;
+      }
+
+      button {
+        font: inherit;
+        font-weight: 600;
+        font-size: 0.875rem;
+        color: #ffffff;
+        background: var(--primary);
+        border: 0;
+        border-radius: 0.375rem;
+        padding: 0.625rem 1.5rem;
+        cursor: pointer;
+      }
+
+      button:hover {
+        opacity: 0.9;
+      }
+
+      button:active {
+        transform: scale(0.97);
+      }
+
+      button:focus-visible {
+        outline: 2px solid var(--primary);
+        outline-offset: 2px;
+      }
+
+      .status {
+        margin: 1.25rem 0 0;
+        font-size: 0.8125rem;
+        min-height: 1.25rem;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <svg
+        class="icon"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M2 2l20 20" />
+        <path d="M8.5 16.5a5 5 0 0 1 7 0" />
+        <path d="M2 8.82a15 15 0 0 1 4.17-2.65" />
+        <path d="M10.66 5c4.01-.36 8.14.9 11.34 3.76" />
+        <path d="M16.85 11.25a10 10 0 0 1 2.22 1.68" />
+        <path d="M5 12.86a10 10 0 0 1 5.17-2.7" />
+        <line x1="12" y1="20" x2="12.01" y2="20" />
+      </svg>
+
+      <h1>You're offline</h1>
+      <p>
+        DevLink can't reach the network right now. Your work is safe — check your connection and try
+        again.
+      </p>
+
+      <button type="button" id="retry">Try again</button>
+      <p class="status" id="status" role="status" aria-live="polite"></p>
+    </main>
+
+    <script>
+      var status = document.getElementById("status");
+
+      document.getElementById("retry").addEventListener("click", function () {
+        if (navigator.onLine) {
+          window.location.reload();
+        } else {
+          status.textContent = "Still offline. Check your connection.";
+        }
+      });
+
+      // Reload the moment connectivity comes back, so the user does not have
+      // to notice and act themselves.
+      window.addEventListener("online", function () {
+        window.location.reload();
+      });
+    </script>
+  </body>
+</html>

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,165 @@
+/* eslint-disable no-undef */
+/**
+ * DevLink service worker.
+ *
+ * Hand-rolled rather than generated, because what we need is small and the
+ * generated variety tends to bring a build plugin, a config file and a set of
+ * defaults nobody on the team can explain.
+ *
+ * Two strategies:
+ *
+ *   - Build assets (`/_build/`, `/assets/`, `/icons/`) are content-hashed and
+ *     therefore immutable, so they are served cache-first.
+ *   - Navigations are network-first with a cache fallback, so a dropped
+ *     connection lands on the last-seen shell (or the offline page) instead of
+ *     the browser's dinosaur.
+ *
+ * Everything else -- crucially every API call -- is left alone and goes
+ * straight to the network.
+ *
+ * Bump CACHE_VERSION to invalidate every cache on the next deploy.
+ */
+
+const CACHE_VERSION = "v1";
+const ASSET_CACHE = `devlink-assets-${CACHE_VERSION}`;
+const PAGE_CACHE = `devlink-pages-${CACHE_VERSION}`;
+const OFFLINE_URL = "/offline.html";
+
+/** Prefixes whose contents are immutable and safe to serve cache-first. */
+const IMMUTABLE_PREFIXES = ["/_build/", "/assets/", "/icons/"];
+
+/**
+ * Never cached. API responses are user-scoped and frequently mutated; serving
+ * a stale one is worse than failing the request. Auth is excluded outright.
+ */
+const NEVER_CACHE_PREFIXES = ["/api/", "/uploads/"];
+
+/** How many navigation responses to retain before evicting the oldest. */
+const MAX_PAGE_ENTRIES = 40;
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches
+      .open(PAGE_CACHE)
+      .then((cache) => cache.addAll([OFFLINE_URL]))
+      // Take over as soon as the new worker is ready rather than waiting for
+      // every old tab to close.
+      .then(() => self.skipWaiting()),
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => key !== ASSET_CACHE && key !== PAGE_CACHE)
+            .map((key) => caches.delete(key)),
+        ),
+      )
+      // Without this, the freshly activated worker would not control the page
+      // that registered it until the next navigation.
+      .then(() => self.clients.claim()),
+  );
+});
+
+self.addEventListener("message", (event) => {
+  // Lets the page tell a waiting worker to activate immediately, which is how
+  // the "reload to update" prompt in src/lib/pwa.ts works.
+  if (event.data === "SKIP_WAITING") {
+    self.skipWaiting();
+  }
+});
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+
+  // Only GET is cacheable, and only same-origin. Cross-origin requests are
+  // opaque, so caching them would fill storage with responses we cannot read.
+  if (request.method !== "GET") return;
+
+  const url = new URL(request.url);
+  if (url.origin !== self.location.origin) return;
+
+  if (NEVER_CACHE_PREFIXES.some((prefix) => url.pathname.startsWith(prefix))) {
+    return;
+  }
+
+  if (request.mode === "navigate") {
+    event.respondWith(networkFirst(request));
+    return;
+  }
+
+  if (IMMUTABLE_PREFIXES.some((prefix) => url.pathname.startsWith(prefix))) {
+    event.respondWith(cacheFirst(request));
+  }
+});
+
+/**
+ * Serve from cache, falling back to the network and storing what comes back.
+ * Only used for content-hashed URLs, so a cache hit can never be stale.
+ */
+async function cacheFirst(request) {
+  const cached = await caches.match(request);
+  if (cached) return cached;
+
+  const response = await fetch(request);
+
+  if (response.ok) {
+    const cache = await caches.open(ASSET_CACHE);
+    cache.put(request, response.clone());
+  }
+
+  return response;
+}
+
+/**
+ * Try the network, fall back to whatever we have, then to the offline page.
+ *
+ * Network-first rather than cache-first because a stale app shell that no
+ * longer matches the deployed API is a worse experience than a slightly slower
+ * navigation.
+ */
+async function networkFirst(request) {
+  try {
+    const response = await fetch(request);
+
+    if (response.ok) {
+      const cache = await caches.open(PAGE_CACHE);
+      cache.put(request, response.clone());
+      trimCache(PAGE_CACHE, MAX_PAGE_ENTRIES);
+    }
+
+    return response;
+  } catch (error) {
+    const cached = await caches.match(request);
+    if (cached) return cached;
+
+    const offline = await caches.match(OFFLINE_URL);
+    if (offline) return offline;
+
+    // Nothing cached at all -- first visit while offline.
+    return new Response("You are offline.", {
+      status: 503,
+      statusText: "Offline",
+      headers: { "Content-Type": "text/plain; charset=utf-8" },
+    });
+  }
+}
+
+/**
+ * Evict oldest entries once a cache grows past `maxEntries`.
+ *
+ * `cache.keys()` returns insertion order, so the front of the list is the
+ * least recently added.
+ */
+async function trimCache(cacheName, maxEntries) {
+  const cache = await caches.open(cacheName);
+  const keys = await cache.keys();
+
+  if (keys.length <= maxEntries) return;
+
+  await Promise.all(keys.slice(0, keys.length - maxEntries).map((key) => cache.delete(key)));
+}

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 /**
  * DevLink service worker.
  *

--- a/frontend/src/components/OfflineBanner.tsx
+++ b/frontend/src/components/OfflineBanner.tsx
@@ -1,0 +1,30 @@
+import { WifiOff } from "lucide-react";
+
+import { useOnlineStatus } from "@/hooks/useOnlineStatus";
+
+/**
+ * A thin bar shown while the browser reports no connectivity.
+ *
+ * Without it, a dropped connection surfaces as mutations failing for no
+ * visible reason, which reads as the app being broken rather than the network
+ * being down.
+ */
+export function OfflineBanner() {
+  const isOnline = useOnlineStatus();
+
+  if (isOnline) return null;
+
+  return (
+    <div
+      // `alert` rather than `status`: losing connectivity is worth interrupting
+      // a screen reader for, since it invalidates whatever the user is about to
+      // do.
+      role="alert"
+      aria-live="assertive"
+      className="fixed inset-x-0 top-0 z-[100] flex items-center justify-center gap-2 bg-amber-500 px-4 py-2 text-sm font-medium text-amber-950 shadow-sm"
+    >
+      <WifiOff className="h-4 w-4 shrink-0" aria-hidden="true" />
+      <span>You're offline. Changes won't be saved until you reconnect.</span>
+    </div>
+  );
+}

--- a/frontend/src/hooks/__tests__/useOnlineStatus.test.ts
+++ b/frontend/src/hooks/__tests__/useOnlineStatus.test.ts
@@ -1,0 +1,95 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useOnlineStatus } from "@/hooks/useOnlineStatus";
+
+/** jsdom leaves navigator.onLine writable only via defineProperty. */
+function setOnLine(value: boolean | undefined) {
+  Object.defineProperty(window.navigator, "onLine", {
+    configurable: true,
+    value,
+  });
+}
+
+afterEach(() => {
+  setOnLine(true);
+  vi.restoreAllMocks();
+});
+
+describe("useOnlineStatus", () => {
+  it("reports online when the browser is connected", () => {
+    setOnLine(true);
+
+    const { result } = renderHook(() => useOnlineStatus());
+
+    expect(result.current).toBe(true);
+  });
+
+  it("reports offline when the browser is disconnected", () => {
+    setOnLine(false);
+
+    const { result } = renderHook(() => useOnlineStatus());
+
+    expect(result.current).toBe(false);
+  });
+
+  it("treats an undefined navigator.onLine as online", () => {
+    // Some environments never set the property. Defaulting to offline there
+    // would show the banner permanently.
+    setOnLine(undefined);
+
+    const { result } = renderHook(() => useOnlineStatus());
+
+    expect(result.current).toBe(true);
+  });
+
+  it("flips to offline when the offline event fires", () => {
+    setOnLine(true);
+    const { result } = renderHook(() => useOnlineStatus());
+
+    act(() => {
+      setOnLine(false);
+      window.dispatchEvent(new Event("offline"));
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("flips back to online when the online event fires", () => {
+    setOnLine(false);
+    const { result } = renderHook(() => useOnlineStatus());
+
+    act(() => {
+      setOnLine(true);
+      window.dispatchEvent(new Event("online"));
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("removes its listeners on unmount", () => {
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+
+    const { unmount } = renderHook(() => useOnlineStatus());
+    unmount();
+
+    const removed = removeSpy.mock.calls.map(([event]) => event);
+    expect(removed).toContain("online");
+    expect(removed).toContain("offline");
+  });
+
+  it("does not update after unmount", () => {
+    setOnLine(true);
+    const { result, unmount } = renderHook(() => useOnlineStatus());
+
+    unmount();
+
+    act(() => {
+      setOnLine(false);
+      window.dispatchEvent(new Event("offline"));
+    });
+
+    // The last rendered value stands; no state update on an unmounted hook.
+    expect(result.current).toBe(true);
+  });
+});

--- a/frontend/src/hooks/useOnlineStatus.ts
+++ b/frontend/src/hooks/useOnlineStatus.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Track browser connectivity.
+ *
+ * `navigator.onLine` is a coarse signal — it reports whether the machine has a
+ * network interface up, not whether our API is reachable — but it is the only
+ * thing that fires synchronously when a laptop's Wi-Fi drops, and it is enough
+ * to explain to the user why their last action failed.
+ *
+ * Defaults to `true` during SSR and before the first effect, so the offline
+ * banner never flashes on a perfectly healthy page load.
+ */
+export function useOnlineStatus(): boolean {
+  const [isOnline, setIsOnline] = useState<boolean>(() => {
+    if (typeof navigator === "undefined") return true;
+    // Some environments (jsdom included) leave onLine undefined rather than
+    // false; treating that as "offline" would be wrong.
+    return navigator.onLine !== false;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+
+    // Connectivity can change between the initial render and this effect
+    // running, so re-read rather than trusting the initial state.
+    setIsOnline(navigator.onLine !== false);
+
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
+
+  return isOnline;
+}

--- a/frontend/src/lib/__tests__/pwa.test.ts
+++ b/frontend/src/lib/__tests__/pwa.test.ts
@@ -1,0 +1,285 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  applyServiceWorkerUpdate,
+  registerServiceWorker,
+  shouldRegisterServiceWorker,
+  unregisterServiceWorkers,
+  watchForUpdates,
+} from "@/lib/pwa";
+
+/**
+ * Minimal stand-in for a ServiceWorker that records its listeners so a test
+ * can drive `statechange` by hand.
+ */
+function createFakeWorker(state = "installing") {
+  const listeners: Record<string, Array<() => void>> = {};
+
+  return {
+    state,
+    postMessage: vi.fn(),
+    addEventListener: vi.fn((event: string, handler: () => void) => {
+      (listeners[event] ??= []).push(handler);
+    }),
+    emit(event: string) {
+      (listeners[event] ?? []).forEach((handler) => handler());
+    },
+    setState(next: string) {
+      this.state = next;
+    },
+  };
+}
+
+function createFakeRegistration(overrides: Partial<Record<string, unknown>> = {}) {
+  const listeners: Record<string, Array<() => void>> = {};
+
+  return {
+    waiting: null,
+    installing: null,
+    unregister: vi.fn().mockResolvedValue(true),
+    addEventListener: vi.fn((event: string, handler: () => void) => {
+      (listeners[event] ??= []).push(handler);
+    }),
+    emit(event: string) {
+      (listeners[event] ?? []).forEach((handler) => handler());
+    },
+    ...overrides,
+  };
+}
+
+function installServiceWorkerMock(controller: unknown = {}) {
+  const register = vi.fn().mockResolvedValue(createFakeRegistration());
+
+  Object.defineProperty(window.navigator, "serviceWorker", {
+    configurable: true,
+    value: {
+      register,
+      controller,
+      getRegistrations: vi.fn().mockResolvedValue([]),
+      addEventListener: vi.fn(),
+    },
+  });
+
+  return register;
+}
+
+function removeServiceWorkerSupport() {
+  // `delete` does not work on a defineProperty'd value, so shadow it instead.
+  Object.defineProperty(window.navigator, "serviceWorker", {
+    configurable: true,
+    value: undefined,
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  removeServiceWorkerSupport();
+});
+
+describe("shouldRegisterServiceWorker", () => {
+  it("is false under test, where import.meta.env.PROD is false", () => {
+    installServiceWorkerMock();
+
+    expect(shouldRegisterServiceWorker()).toBe(false);
+  });
+
+  it("is true in a production build", () => {
+    installServiceWorkerMock();
+    vi.stubEnv("PROD", true);
+
+    expect(shouldRegisterServiceWorker()).toBe(true);
+  });
+
+  it("is false when the browser has no service worker support", () => {
+    removeServiceWorkerSupport();
+    vi.stubEnv("PROD", true);
+
+    expect(shouldRegisterServiceWorker()).toBe(false);
+  });
+
+  it("can be forced regardless of environment", () => {
+    expect(shouldRegisterServiceWorker(true)).toBe(true);
+  });
+});
+
+describe("registerServiceWorker", () => {
+  it("does not register outside a production build", async () => {
+    const register = installServiceWorkerMock();
+
+    const result = await registerServiceWorker();
+
+    expect(result).toBeNull();
+    expect(register).not.toHaveBeenCalled();
+  });
+
+  it("registers at the root scope when forced", async () => {
+    const register = installServiceWorkerMock();
+
+    await registerServiceWorker({ force: true });
+
+    expect(register).toHaveBeenCalledWith("/sw.js", { scope: "/" });
+  });
+
+  it("returns null instead of throwing when registration fails", async () => {
+    const register = installServiceWorkerMock();
+    register.mockRejectedValue(new Error("insecure origin"));
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(registerServiceWorker({ force: true })).resolves.toBeNull();
+  });
+
+  it("returns null when the browser has no support, even if forced", async () => {
+    removeServiceWorkerSupport();
+
+    await expect(registerServiceWorker({ force: true })).resolves.toBeNull();
+  });
+});
+
+describe("watchForUpdates", () => {
+  it("fires immediately when a worker is already waiting", () => {
+    const registration = createFakeRegistration({ waiting: createFakeWorker() });
+    const onUpdate = vi.fn();
+
+    watchForUpdates(registration as never, onUpdate);
+
+    expect(onUpdate).toHaveBeenCalledWith(registration);
+  });
+
+  it("fires when an update installs while the tab is open", () => {
+    installServiceWorkerMock({ scriptURL: "/sw.js" });
+
+    const installing = createFakeWorker();
+    const registration = createFakeRegistration({ installing });
+    const onUpdate = vi.fn();
+
+    watchForUpdates(registration as never, onUpdate);
+    registration.emit("updatefound");
+
+    installing.setState("installed");
+    installing.emit("statechange");
+
+    expect(onUpdate).toHaveBeenCalledWith(registration);
+  });
+
+  it("does not fire on a first install", () => {
+    // controller is null before any worker has ever controlled the page.
+    // Announcing an "update" to a first-time visitor would be nonsense.
+    installServiceWorkerMock(null);
+
+    const installing = createFakeWorker();
+    const registration = createFakeRegistration({ installing });
+    const onUpdate = vi.fn();
+
+    watchForUpdates(registration as never, onUpdate);
+    registration.emit("updatefound");
+
+    installing.setState("installed");
+    installing.emit("statechange");
+
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it("does not fire while the worker is still installing", () => {
+    installServiceWorkerMock({ scriptURL: "/sw.js" });
+
+    const installing = createFakeWorker("installing");
+    const registration = createFakeRegistration({ installing });
+    const onUpdate = vi.fn();
+
+    watchForUpdates(registration as never, onUpdate);
+    registration.emit("updatefound");
+    installing.emit("statechange");
+
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it("ignores an updatefound with no installing worker", () => {
+    const registration = createFakeRegistration({ installing: null });
+    const onUpdate = vi.fn();
+
+    watchForUpdates(registration as never, onUpdate);
+
+    expect(() => registration.emit("updatefound")).not.toThrow();
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe("applyServiceWorkerUpdate", () => {
+  beforeEach(() => {
+    installServiceWorkerMock();
+  });
+
+  it("tells the waiting worker to activate", () => {
+    const waiting = createFakeWorker("installed");
+    const registration = createFakeRegistration({ waiting });
+
+    applyServiceWorkerUpdate(registration as never);
+
+    expect(waiting.postMessage).toHaveBeenCalledWith("SKIP_WAITING");
+  });
+
+  it("does nothing when no worker is waiting", () => {
+    const registration = createFakeRegistration({ waiting: null });
+
+    expect(() => applyServiceWorkerUpdate(registration as never)).not.toThrow();
+    expect(window.navigator.serviceWorker.addEventListener).not.toHaveBeenCalled();
+  });
+
+  it("reloads only once, even if controllerchange fires repeatedly", () => {
+    const waiting = createFakeWorker("installed");
+    const registration = createFakeRegistration({ waiting });
+
+    const handlers: Array<() => void> = [];
+    (
+      window.navigator.serviceWorker.addEventListener as ReturnType<typeof vi.fn>
+    ).mockImplementation((event: string, handler: () => void) => {
+      if (event === "controllerchange") handlers.push(handler);
+    });
+
+    const reload = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, reload },
+    });
+
+    applyServiceWorkerUpdate(registration as never);
+
+    handlers.forEach((handler) => handler());
+    handlers.forEach((handler) => handler());
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("unregisterServiceWorkers", () => {
+  it("is a no-op without service worker support", async () => {
+    removeServiceWorkerSupport();
+
+    await expect(unregisterServiceWorkers()).resolves.toBeUndefined();
+  });
+
+  it("unregisters every registration", async () => {
+    const first = createFakeRegistration();
+    const second = createFakeRegistration();
+
+    installServiceWorkerMock();
+    (window.navigator.serviceWorker.getRegistrations as ReturnType<typeof vi.fn>).mockResolvedValue(
+      [first, second],
+    );
+
+    Object.defineProperty(window, "caches", {
+      configurable: true,
+      value: {
+        keys: vi.fn().mockResolvedValue(["devlink-assets-v1"]),
+        delete: vi.fn().mockResolvedValue(true),
+      },
+    });
+
+    await unregisterServiceWorkers();
+
+    expect(first.unregister).toHaveBeenCalled();
+    expect(second.unregister).toHaveBeenCalled();
+    expect(window.caches.delete).toHaveBeenCalledWith("devlink-assets-v1");
+  });
+});

--- a/frontend/src/lib/pwa.ts
+++ b/frontend/src/lib/pwa.ts
@@ -1,0 +1,154 @@
+/**
+ * Service worker registration.
+ *
+ * Registration is deliberately narrow: production builds only, in a browser
+ * that supports it, once per page load. A service worker in development is a
+ * reliable way to spend an afternoon debugging a stale bundle, and in tests it
+ * is simply noise.
+ */
+
+const SERVICE_WORKER_URL = "/sw.js";
+
+export type ServiceWorkerUpdateHandler = (registration: ServiceWorkerRegistration) => void;
+
+export interface RegisterServiceWorkerOptions {
+  /**
+   * Called when a new worker has installed and is waiting to take over,
+   * i.e. a new version has been deployed while this tab was open.
+   */
+  onUpdateAvailable?: ServiceWorkerUpdateHandler;
+
+  /**
+   * Register even outside a production build. Only useful when deliberately
+   * testing the worker itself.
+   */
+  force?: boolean;
+}
+
+/**
+ * The browser's service worker container, or `null` where there isn't one.
+ *
+ * Checked by truthiness rather than `"serviceWorker" in navigator`: the key
+ * can exist while holding `undefined` (jsdom, some embedded webviews, and
+ * anything that has shimmed it), and an `in` check happily passes there before
+ * blowing up on first use.
+ */
+function getServiceWorkerContainer(): ServiceWorkerContainer | null {
+  if (typeof navigator === "undefined") return null;
+  return navigator.serviceWorker ?? null;
+}
+
+/** Whether this environment should run a service worker at all. */
+export function shouldRegisterServiceWorker(force = false): boolean {
+  if (force) return true;
+  if (typeof window === "undefined") return false;
+  if (!getServiceWorkerContainer()) return false;
+
+  // import.meta.env.PROD is false in dev and under Vitest.
+  return import.meta.env.PROD === true;
+}
+
+/**
+ * Register the service worker, resolving to the registration or `null` when
+ * this environment should not have one.
+ *
+ * Never throws. A failed registration should degrade the app to "works exactly
+ * as it did before", not break boot.
+ */
+export async function registerServiceWorker(
+  options: RegisterServiceWorkerOptions = {},
+): Promise<ServiceWorkerRegistration | null> {
+  const { onUpdateAvailable, force = false } = options;
+
+  if (!shouldRegisterServiceWorker(force)) return null;
+
+  const container = getServiceWorkerContainer();
+  if (!container) return null;
+
+  try {
+    const registration = await container.register(SERVICE_WORKER_URL, {
+      scope: "/",
+    });
+
+    if (onUpdateAvailable) {
+      watchForUpdates(registration, onUpdateAvailable);
+    }
+
+    return registration;
+  } catch (error) {
+    console.warn("[pwa] Service worker registration failed:", error);
+    return null;
+  }
+}
+
+/**
+ * Watch a registration for a newly installed worker waiting to activate.
+ *
+ * Two cases have to be handled: a worker that is *already* waiting when we
+ * attach (the update finished before this code ran), and one that arrives
+ * later via `updatefound`.
+ */
+export function watchForUpdates(
+  registration: ServiceWorkerRegistration,
+  onUpdateAvailable: ServiceWorkerUpdateHandler,
+): void {
+  if (registration.waiting) {
+    onUpdateAvailable(registration);
+    return;
+  }
+
+  registration.addEventListener("updatefound", () => {
+    const installing = registration.installing;
+    if (!installing) return;
+
+    installing.addEventListener("statechange", () => {
+      // `controller` is null on the very first install. Without this check
+      // every first-time visitor would be told an update is available.
+      if (installing.state === "installed" && getServiceWorkerContainer()?.controller) {
+        onUpdateAvailable(registration);
+      }
+    });
+  });
+}
+
+/**
+ * Tell a waiting worker to activate, then reload so the page is controlled by
+ * the new version.
+ */
+export function applyServiceWorkerUpdate(registration: ServiceWorkerRegistration): void {
+  if (!registration.waiting) return;
+
+  const container = getServiceWorkerContainer();
+  if (!container) return;
+
+  registration.waiting.postMessage("SKIP_WAITING");
+
+  // `controllerchange` fires once the new worker takes over. Guarding with a
+  // flag because Chrome can fire it more than once, and a reload loop is a
+  // spectacularly bad failure mode.
+  let reloading = false;
+  container.addEventListener("controllerchange", () => {
+    if (reloading) return;
+    reloading = true;
+    window.location.reload();
+  });
+}
+
+/**
+ * Unregister every service worker and drop the caches.
+ *
+ * Not called by the app; kept as the escape hatch for when a bad worker gets
+ * shipped and a user needs to be talked out of it from the console.
+ */
+export async function unregisterServiceWorkers(): Promise<void> {
+  const container = getServiceWorkerContainer();
+  if (!container) return;
+
+  const registrations = await container.getRegistrations();
+  await Promise.all(registrations.map((registration) => registration.unregister()));
+
+  if (typeof caches !== "undefined") {
+    const keys = await caches.keys();
+    await Promise.all(keys.map((key) => caches.delete(key)));
+  }
+}

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -10,8 +10,10 @@ import {
 } from "@tanstack/react-router";
 import { AnimatePresence } from "framer-motion";
 import { useEffect, useRef, type ReactNode } from "react";
-import { Toaster } from "sonner";
+import { Toaster, toast } from "sonner";
 import { ThemeProvider } from "@/context/ThemeContext";
+import { OfflineBanner } from "@/components/OfflineBanner";
+import { applyServiceWorkerUpdate, registerServiceWorker } from "@/lib/pwa";
 
 import appCss from "../styles.css?url";
 import { reportLovableError } from "../lib/lovable-error-reporting";
@@ -159,8 +161,22 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
       },
       { property: "og:type", content: "website" },
       { name: "twitter:card", content: "summary_large_image" },
+      // Colours the browser/OS chrome when installed, and matches the
+      // manifest's theme_color.
+      { name: "theme-color", content: "#05b7d7" },
+      { name: "apple-mobile-web-app-capable", content: "yes" },
+      { name: "apple-mobile-web-app-title", content: "DevLink" },
+      {
+        name: "apple-mobile-web-app-status-bar-style",
+        content: "black-translucent",
+      },
     ],
-    links: [{ rel: "stylesheet", href: appCss }],
+    links: [
+      { rel: "stylesheet", href: appCss },
+      { rel: "manifest", href: "/manifest.webmanifest" },
+      { rel: "icon", type: "image/svg+xml", href: "/icons/icon.svg" },
+      { rel: "apple-touch-icon", href: "/icons/icon.svg" },
+    ],
   }),
   shellComponent: RootShell,
   component: RootComponent,
@@ -186,9 +202,25 @@ function RootComponent() {
   const { queryClient } = Route.useRouteContext();
   const location = useRouterState({ select: (s) => s.location });
 
+  useEffect(() => {
+    // No-ops outside a production browser build; see src/lib/pwa.ts.
+    void registerServiceWorker({
+      onUpdateAvailable: (registration) => {
+        toast("A new version of DevLink is available.", {
+          duration: Infinity,
+          action: {
+            label: "Reload",
+            onClick: () => applyServiceWorkerUpdate(registration),
+          },
+        });
+      },
+    });
+  }, []);
+
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider defaultTheme="system">
+        <OfflineBanner />
         <Outlet />
         <Toaster position="top-right" richColors />
       </ThemeProvider>


### PR DESCRIPTION
# Pull Request

## Summary

`frontend/public/` was empty — no web app manifest, no service worker, no offline story at all. That meant:

- The app could not be installed to a home screen or dock.
- A dropped connection produced the browser's default "no internet" page.
- Failed mutations looked like random errors, with nothing telling the user their network was down.

This adds a small PWA layer that fixes those three things. It is **not** an offline-first rewrite, and deliberately so.

---

## Related Issue

Closes #857

---

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [x] Performance improvement
- [ ] Refactoring
- [x] UI/UX enhancement
- [x] Tests
- [ ] Other

---

## Changes Made

| File | Purpose |
| :--- | :--- |
| `public/manifest.webmanifest` | Name, theme colours matching the existing tokens, icons, shortcuts |
| `public/sw.js` | The service worker |
| `public/offline.html` | Fallback when a navigation fails |
| `public/icons/*.svg` | App icon + maskable variant |
| `src/lib/pwa.ts` | Registration and update lifecycle |
| `src/hooks/useOnlineStatus.ts` | Connectivity hook |
| `src/components/OfflineBanner.tsx` | The banner |
| `src/routes/__root.tsx` | Manifest link, theme-color, registration, banner |
| `docs/pwa.md` | How it works and how to test it |

### Why hand-rolled

No new runtime dependency. What we need is ~160 lines; the generator plugins bring a build plugin, a config file, and a set of defaults nobody on the team can explain when something caches wrong at 2am.

### Caching

Same-origin `GET` only. Everything else goes straight to the network.

- **Cache-first** for `/_build/`, `/assets/`, `/icons/` — content-hashed, so a hit can never be stale.
- **Network-first** for navigations, falling back to the cached shell then `offline.html`. Not cache-first: a stale shell paired with a newer API is a worse failure than a slightly slower navigation.
- **Never** for `/api/` and `/uploads/` — user-scoped and constantly changing, and caching an authenticated response risks handing it to the wrong user on a shared device.

Page cache capped at 40 entries, oldest evicted first. `activate` deletes every non-current cache so deploys don't leak storage.

### Two guards worth flagging in review

1. `watchForUpdates` checks `navigator.serviceWorker.controller` before announcing an update. `controller` is null on a first install, so without this **every first-time visitor gets told to reload**.
2. `applyServiceWorkerUpdate` guards its `controllerchange` handler with a flag. Chrome can fire it more than once, and an unguarded reload there is an infinite reload loop.

### A bug the tests caught

I originally used `"serviceWorker" in navigator` for feature detection. That passes when the key *exists holding `undefined`* — jsdom, some embedded webviews, anything that has shimmed it — and then throws on first property access. Switched to a truthiness check via a `getServiceWorkerContainer()` helper. The test asserting a no-support environment is what surfaced it.

---

## Testing

- [x] Tested locally
- [x] Existing tests pass
- [x] Added new tests
- [x] UI verified
- [ ] Cross-browser tested (if applicable)

Additional testing notes:

**New tests — 25 passed** (`src/lib/__tests__/pwa.test.ts`, `src/hooks/__tests__/useOnlineStatus.test.ts`):

- Registration is skipped outside production, forced when asked, scoped to `/`, and returns `null` rather than throwing on failure.
- Update detection: already-waiting worker, worker installing while the tab is open, **no notification on first install**, no notification while still installing, and an `updatefound` with no installing worker.
- `applyServiceWorkerUpdate` posts `SKIP_WAITING`, no-ops with nothing waiting, and **reloads exactly once across repeated `controllerchange` events**.
- `unregisterServiceWorkers` handles no support and clears registrations plus caches.
- `useOnlineStatus`: both states, `undefined` treated as online, both event transitions, listener cleanup, and no update after unmount.

**Full suite:** 296 → 321 passed. The delta is exactly the 25 new tests; nothing else moved. (Four test *files* fail on both sides — Playwright e2e specs that vitest picks up. Pre-existing and unrelated.)

**Typecheck:** 37 errors before, 37 after — all pre-existing, none in the files this PR touches.

**Lint:** clean (`eslint` + `prettier`) on every new and modified file.

**Manual, against `npm run build && npm run preview`:** manifest reports installable, worker registers and activates, DevTools offline reload serves the cached shell, and an unvisited route serves `offline.html`.

---

## Checklist

- [x] My code follows the project's coding standards.
- [x] I have tested my changes locally.
- [x] I have updated the documentation where necessary.
- [x] My changes do not introduce new warnings or errors.
- [x] I have reviewed my own code.
- [x] This pull request focuses on a single feature or fix.
- [x] I have linked the related issue.

---

## Additional Notes

**Out of scope on purpose:** background sync and push notifications. Both need a server-side story — VAPID keys, a subscription store, a delivery pipeline — and belong with the notification work rather than bolted on here.

Icons are SVG. Chrome accepts `sizes: "any"` SVG icons for installability, and a vector avoids checking a pile of PNG raster sizes into the repo. If we later want the widest possible install-prompt support, generating 192/512 PNGs from these SVGs is a small follow-up.

`CACHE_VERSION` in `sw.js` is the kill switch — bumping it invalidates every cache on the next deploy.
