### PR TITLE
Add an internationalization (i18n) foundation to the frontend

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,0 +1,159 @@
+# Internationalization
+
+Every user-facing string in the frontend used to be a hard-coded English
+literal. There was no i18n library, no locale files, and dates and numbers were
+formatted with US conventions regardless of the user's browser settings.
+
+This document covers the foundation added in #858.
+
+## Why not `react-i18next`
+
+What the app needs today is key lookup, `{placeholder}` interpolation, plural
+selection and `Intl` formatting. That is a few hundred lines. `react-i18next`
+is a sizeable dependency with its own plugin system, backend adapters and
+initialisation dance, most of which we would not use.
+
+If requirements grow past this — ICU message syntax, lazy-loaded namespaces,
+integration with a translation-management platform — swapping a library in
+behind the same `useTranslation()` surface is a contained change. Starting with
+the library would have been the harder thing to reverse.
+
+## Layout
+
+| Path                          | Purpose                                    |
+| :---------------------------- | :----------------------------------------- |
+| `src/i18n/types.ts`           | `Catalogue`, `PluralForms`, option types    |
+| `src/i18n/translate.ts`       | Resolution, interpolation, pluralisation    |
+| `src/i18n/format.ts`          | `Intl` wrappers for dates and numbers       |
+| `src/i18n/locales/en.ts`      | English — the source of truth               |
+| `src/i18n/locales/es.ts`      | Spanish — worked reference                  |
+| `src/i18n/locales/index.ts`   | Locale registry and tag resolution          |
+| `src/context/I18nContext.tsx` | `I18nProvider`, `useTranslation()`          |
+| `src/components/LanguageSwitcher.tsx` | The picker                          |
+
+## Using it
+
+```tsx
+import { useTranslation } from "@/context/I18nContext";
+
+function ProjectHeader({ memberCount, createdAt }) {
+  const { t, formatRelativeTime } = useTranslation();
+
+  return (
+    <header>
+      <p>{t("members.count", { count: memberCount })}</p>
+      <time>{formatRelativeTime(createdAt)}</time>
+    </header>
+  );
+}
+```
+
+`t()` is typed against `keyof typeof en`, so an unknown key is a compile error
+and your editor autocompletes the real ones.
+
+## Adding a string
+
+Add it to `src/i18n/locales/en.ts`. That's the whole step — other locales are
+allowed to lag behind and fall back to English.
+
+```ts
+"projects.emptyState.title": "No projects yet",
+"projects.count": { one: "{count} project", other: "{count} projects" },
+```
+
+Keys are **flat and dot-separated**, not nested. Nesting reads nicely in the
+file but turns the key type into a recursive conditional that is slow to check
+and unreadable in an editor tooltip. `keyof` on a flat object is exact and
+instant.
+
+The `as const` on the catalogue is what produces the key type. It must stay.
+
+## Pluralisation
+
+Provide a variant per CLDR category. Only `other` is required:
+
+```ts
+"notifications.unread": {
+  zero: "No unread notifications",
+  one: "{count} unread notification",
+  other: "{count} unread notifications",
+},
+```
+
+`count` selects the form *and* is available as `{count}`, so you don't pass it
+twice.
+
+**One deliberate deviation from CLDR.** English has no `zero` plural category —
+`Intl.PluralRules("en").select(0)` returns `other`. Strictly following that
+would mean a translator who wrote `zero: "No unread notifications"` never saw
+it and got "0 unread notifications" instead. Writing a `zero` form is an
+unambiguous statement of intent, so it wins at `count === 0` in every locale.
+Everything else follows `Intl.PluralRules` exactly.
+
+## Fallback chain
+
+1. Active catalogue
+2. English
+3. A humanised form of the key — `projects.emptyState.title` renders as "Title"
+
+Step 3 is not a translation, but it beats showing a raw dotted key. Missing
+keys warn once each in development and are silent in production. `t()` never
+throws and never returns an empty string: a translation problem should degrade
+the copy, not blank the UI.
+
+Unknown `{placeholders}` are left visible rather than replaced with
+"undefined" — a stray `{userName}` is an obvious bug report, "undefined" is a
+confusing one.
+
+## Locale detection
+
+Stored preference (`localStorage`, key `devlink-locale`) → the browser's
+`navigator.languages` list → `en`.
+
+Region subtags resolve to the base language, so `es-MX` and `es-419` both get
+`es`. Changing locale updates `<html lang>`, which screen readers use to pick a
+voice.
+
+## Formatting
+
+The helpers on `useTranslation()` are pre-bound to the active locale:
+
+| Helper                 | `en-US`   | `de-DE`   |
+| :--------------------- | :-------- | :-------- |
+| `formatNumber(1234.5)` | `1,234.5` | `1.234,5` |
+| `formatPercent(0.42)`  | `42%`     | `42 %`    |
+| `formatCompactNumber(1200)` | `1.2K` | `1200`   |
+
+`formatRelativeTime` uses `numeric: "auto"`, which is what gives "yesterday"
+rather than "1 day ago" in locales that have a word for it.
+
+`formatPercent` takes a **0–1 ratio**, not an already-multiplied number, so
+callers cannot disagree about whether `50` means 50% or 5000%.
+
+Every helper degrades to `en` on a malformed locale tag and returns `""` for an
+unparseable date or non-finite number. Rendering "Invalid Date" at a user is
+never the right answer.
+
+## Adding a language
+
+1. Copy `src/i18n/locales/es.ts` and translate.
+2. Import it in `src/i18n/locales/index.ts` and add a `LOCALES` entry.
+
+Nothing else changes. Partial catalogues are fine — `es.ts` deliberately omits
+`notifications.unread` so the English fallback is exercised by a test rather
+than assumed.
+
+## Migration status
+
+The error pages (`src/components/errors/`) are migrated end-to-end as a worked
+example. The rest of the app still has hard-coded literals; migrating a screen
+means adding its strings to `en.ts` and swapping the literals for `t()` calls,
+and can happen incrementally.
+
+## A gotcha worth knowing
+
+The root route's `errorComponent` and `notFoundComponent` **replace**
+`RootComponent` rather than rendering inside it, so they sit outside the
+providers. The error pages call `useTranslation()`, so `__root.tsx` wraps them
+in their own `I18nProvider` via `OutsideRootProviders`. Without it, an API 401
+would surface as a provider error instead of the sign-in page.

--- a/docs/pwa.md
+++ b/docs/pwa.md
@@ -1,0 +1,104 @@
+# Progressive Web App
+
+DevLink ships a small PWA layer: a web app manifest, a service worker, an
+offline fallback page, and an in-app offline indicator.
+
+The goal is modest and deliberately so. This is not an offline-first rewrite.
+It makes the app installable, stops a dropped connection producing the
+browser's default error page, and tells the user when they are offline instead
+of letting mutations fail silently.
+
+## What's included
+
+| File                              | Purpose                                          |
+| :-------------------------------- | :----------------------------------------------- |
+| `public/manifest.webmanifest`     | Name, colours, icons, app shortcuts               |
+| `public/sw.js`                    | The service worker                                |
+| `public/offline.html`             | Fallback page when a navigation fails             |
+| `public/icons/icon.svg`           | App icon                                          |
+| `public/icons/icon-maskable.svg`  | Maskable variant, scaled for the 80% safe zone    |
+| `src/lib/pwa.ts`                  | Registration and update handling                  |
+| `src/hooks/useOnlineStatus.ts`    | Connectivity hook                                 |
+| `src/components/OfflineBanner.tsx`| The banner                                        |
+
+## Caching strategy
+
+The worker only touches same-origin `GET` requests. Everything else goes
+straight to the network.
+
+**Cache-first — `/_build/`, `/assets/`, `/icons/`**
+These URLs are content-hashed, so a cache hit can never be stale. A new deploy
+produces new filenames.
+
+**Network-first — navigations**
+Try the network, fall back to the cached shell, then to `offline.html`. Not
+cache-first: a stale app shell paired with a newer API is a worse failure than
+a slightly slower navigation.
+
+**Never cached — `/api/`, `/uploads/`**
+API responses are user-scoped and change constantly; serving a stale one is
+worse than failing the request. Caching an authenticated response also risks
+handing it to the wrong user on a shared device.
+
+The page cache is capped at 40 entries, evicting oldest-first.
+
+## Updates
+
+When a deploy lands while a tab is open, the new worker installs and waits.
+`src/lib/pwa.ts` detects that and the app shows a toast with a **Reload**
+action, which posts `SKIP_WAITING` to the waiting worker and reloads once it
+takes over.
+
+Users are never force-reloaded mid-task. The `controllerchange` handler is
+guarded by a flag, because Chrome can fire it more than once and a reload loop
+is a spectacularly bad failure mode.
+
+`activate` deletes every cache that is not the current version, so deploys do
+not leak storage. Bumping `CACHE_VERSION` in `sw.js` invalidates everything.
+
+## Registration
+
+Only in **production browser builds**:
+
+```ts
+registerServiceWorker({ onUpdateAvailable: (registration) => { ... } });
+```
+
+Not in dev — a service worker there is a reliable way to spend an afternoon
+debugging a stale bundle — and not under Vitest. Pass `force: true` when
+deliberately testing the worker.
+
+Registration never throws. A failure degrades the app to exactly how it behaved
+before the worker existed.
+
+## Offline indicator
+
+`useOnlineStatus()` wraps `navigator.onLine` and the `online`/`offline` events.
+It is a coarse signal — it reports whether a network interface is up, not
+whether our API is reachable — but it fires immediately when Wi-Fi drops, which
+is enough to explain a failed action.
+
+It defaults to `true` during SSR and when `navigator.onLine` is `undefined`, so
+the banner never flashes on a healthy load.
+
+## Testing it locally
+
+The worker does not run in `vite dev`. Use a production build:
+
+```bash
+npm run build
+npm run preview
+```
+
+Then in DevTools:
+
+- **Application → Manifest** — check installability
+- **Application → Service Workers** — confirm registration and activation
+- **Network → Offline**, then reload — you should get the app shell, or
+  `offline.html` on a route never visited
+
+## Not included
+
+Background sync and push notifications are deliberately out of scope. Both need
+a server-side story (a VAPID key pair, a subscription store, a delivery
+pipeline) and belong with the notification work, not here.

--- a/frontend/public/icons/icon-maskable.svg
+++ b/frontend/public/icons/icon-maskable.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512" role="img" aria-label="DevLink">
+  <!-- Maskable icons are cropped to a safe zone of the middle 80%, so the
+       artwork is scaled down and the background bleeds to the full canvas. -->
+  <rect width="512" height="512" fill="#0d1117"/>
+  <g transform="translate(256 256) scale(0.66) translate(-256 -256)">
+    <g stroke="#05b7d7" stroke-width="26" stroke-linecap="round" fill="none">
+      <path d="M196 256h120"/>
+    </g>
+    <circle cx="168" cy="256" r="46" fill="#05b7d7"/>
+    <circle cx="344" cy="256" r="46" fill="#05b7d7"/>
+    <g stroke="#05b7d7" stroke-width="22" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.55">
+      <path d="M168 210v-46l52-44"/>
+      <path d="M344 302v46l-52 44"/>
+    </g>
+  </g>
+</svg>

--- a/frontend/public/icons/icon.svg
+++ b/frontend/public/icons/icon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512" role="img" aria-label="DevLink">
+  <rect width="512" height="512" rx="112" fill="#0d1117"/>
+  <!-- Two nodes joined by a link: the "dev link". -->
+  <g stroke="#05b7d7" stroke-width="26" stroke-linecap="round" fill="none">
+    <path d="M196 256h120"/>
+  </g>
+  <circle cx="168" cy="256" r="46" fill="#05b7d7"/>
+  <circle cx="344" cy="256" r="46" fill="#05b7d7"/>
+  <g stroke="#05b7d7" stroke-width="22" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.55">
+    <path d="M168 210v-46l52-44"/>
+    <path d="M344 302v46l-52 44"/>
+  </g>
+</svg>

--- a/frontend/public/manifest.webmanifest
+++ b/frontend/public/manifest.webmanifest
@@ -1,0 +1,44 @@
+{
+  "name": "DevLink — Where builders connect, collaborate and ship",
+  "short_name": "DevLink",
+  "description": "Find teammates with AI matching, run projects, chat in real time, and enter hackathons together.",
+  "id": "/",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "orientation": "any",
+  "background_color": "#0d1117",
+  "theme_color": "#05b7d7",
+  "categories": ["productivity", "developer", "social"],
+  "icons": [
+    {
+      "src": "/icons/icon.svg",
+      "type": "image/svg+xml",
+      "sizes": "any",
+      "purpose": "any"
+    },
+    {
+      "src": "/icons/icon-maskable.svg",
+      "type": "image/svg+xml",
+      "sizes": "any",
+      "purpose": "maskable"
+    }
+  ],
+  "shortcuts": [
+    {
+      "name": "Dashboard",
+      "url": "/dashboard",
+      "description": "Your projects and activity at a glance"
+    },
+    {
+      "name": "Messages",
+      "url": "/messages",
+      "description": "Open your conversations"
+    },
+    {
+      "name": "Projects",
+      "url": "/projects",
+      "description": "Browse and manage projects"
+    }
+  ]
+}

--- a/frontend/public/offline.html
+++ b/frontend/public/offline.html
@@ -1,0 +1,162 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#05b7d7" />
+    <title>You're offline — DevLink</title>
+    <!--
+      Fully self-contained on purpose. This page is served by the service
+      worker when the network is unavailable, so it cannot rely on a
+      stylesheet, a font or a script that would itself need fetching.
+    -->
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: #f6f8fa;
+        --surface: #ffffff;
+        --fg: #1f2328;
+        --muted: #59636e;
+        --border: #d1d9e0;
+        --primary: #05b7d7;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d1117;
+          --surface: #161b22;
+          --fg: #f0f6fc;
+          --muted: #9198a1;
+          --border: #30363d;
+        }
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 1.5rem;
+        background: var(--bg);
+        color: var(--fg);
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        line-height: 1.5;
+      }
+
+      main {
+        width: 100%;
+        max-width: 28rem;
+        text-align: center;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 0.75rem;
+        padding: 2.5rem 1.75rem;
+      }
+
+      .icon {
+        width: 4rem;
+        height: 4rem;
+        margin: 0 auto 1.5rem;
+        color: var(--muted);
+      }
+
+      h1 {
+        margin: 0 0 0.75rem;
+        font-size: 1.5rem;
+        font-weight: 700;
+      }
+
+      p {
+        margin: 0 0 2rem;
+        color: var(--muted);
+        font-size: 0.9375rem;
+      }
+
+      button {
+        font: inherit;
+        font-weight: 600;
+        font-size: 0.875rem;
+        color: #ffffff;
+        background: var(--primary);
+        border: 0;
+        border-radius: 0.375rem;
+        padding: 0.625rem 1.5rem;
+        cursor: pointer;
+      }
+
+      button:hover {
+        opacity: 0.9;
+      }
+
+      button:active {
+        transform: scale(0.97);
+      }
+
+      button:focus-visible {
+        outline: 2px solid var(--primary);
+        outline-offset: 2px;
+      }
+
+      .status {
+        margin: 1.25rem 0 0;
+        font-size: 0.8125rem;
+        min-height: 1.25rem;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <svg
+        class="icon"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M2 2l20 20" />
+        <path d="M8.5 16.5a5 5 0 0 1 7 0" />
+        <path d="M2 8.82a15 15 0 0 1 4.17-2.65" />
+        <path d="M10.66 5c4.01-.36 8.14.9 11.34 3.76" />
+        <path d="M16.85 11.25a10 10 0 0 1 2.22 1.68" />
+        <path d="M5 12.86a10 10 0 0 1 5.17-2.7" />
+        <line x1="12" y1="20" x2="12.01" y2="20" />
+      </svg>
+
+      <h1>You're offline</h1>
+      <p>
+        DevLink can't reach the network right now. Your work is safe — check your connection and try
+        again.
+      </p>
+
+      <button type="button" id="retry">Try again</button>
+      <p class="status" id="status" role="status" aria-live="polite"></p>
+    </main>
+
+    <script>
+      var status = document.getElementById("status");
+
+      document.getElementById("retry").addEventListener("click", function () {
+        if (navigator.onLine) {
+          window.location.reload();
+        } else {
+          status.textContent = "Still offline. Check your connection.";
+        }
+      });
+
+      // Reload the moment connectivity comes back, so the user does not have
+      // to notice and act themselves.
+      window.addEventListener("online", function () {
+        window.location.reload();
+      });
+    </script>
+  </body>
+</html>

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,165 @@
+/* eslint-disable no-undef */
+/**
+ * DevLink service worker.
+ *
+ * Hand-rolled rather than generated, because what we need is small and the
+ * generated variety tends to bring a build plugin, a config file and a set of
+ * defaults nobody on the team can explain.
+ *
+ * Two strategies:
+ *
+ *   - Build assets (`/_build/`, `/assets/`, `/icons/`) are content-hashed and
+ *     therefore immutable, so they are served cache-first.
+ *   - Navigations are network-first with a cache fallback, so a dropped
+ *     connection lands on the last-seen shell (or the offline page) instead of
+ *     the browser's dinosaur.
+ *
+ * Everything else -- crucially every API call -- is left alone and goes
+ * straight to the network.
+ *
+ * Bump CACHE_VERSION to invalidate every cache on the next deploy.
+ */
+
+const CACHE_VERSION = "v1";
+const ASSET_CACHE = `devlink-assets-${CACHE_VERSION}`;
+const PAGE_CACHE = `devlink-pages-${CACHE_VERSION}`;
+const OFFLINE_URL = "/offline.html";
+
+/** Prefixes whose contents are immutable and safe to serve cache-first. */
+const IMMUTABLE_PREFIXES = ["/_build/", "/assets/", "/icons/"];
+
+/**
+ * Never cached. API responses are user-scoped and frequently mutated; serving
+ * a stale one is worse than failing the request. Auth is excluded outright.
+ */
+const NEVER_CACHE_PREFIXES = ["/api/", "/uploads/"];
+
+/** How many navigation responses to retain before evicting the oldest. */
+const MAX_PAGE_ENTRIES = 40;
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches
+      .open(PAGE_CACHE)
+      .then((cache) => cache.addAll([OFFLINE_URL]))
+      // Take over as soon as the new worker is ready rather than waiting for
+      // every old tab to close.
+      .then(() => self.skipWaiting()),
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => key !== ASSET_CACHE && key !== PAGE_CACHE)
+            .map((key) => caches.delete(key)),
+        ),
+      )
+      // Without this, the freshly activated worker would not control the page
+      // that registered it until the next navigation.
+      .then(() => self.clients.claim()),
+  );
+});
+
+self.addEventListener("message", (event) => {
+  // Lets the page tell a waiting worker to activate immediately, which is how
+  // the "reload to update" prompt in src/lib/pwa.ts works.
+  if (event.data === "SKIP_WAITING") {
+    self.skipWaiting();
+  }
+});
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+
+  // Only GET is cacheable, and only same-origin. Cross-origin requests are
+  // opaque, so caching them would fill storage with responses we cannot read.
+  if (request.method !== "GET") return;
+
+  const url = new URL(request.url);
+  if (url.origin !== self.location.origin) return;
+
+  if (NEVER_CACHE_PREFIXES.some((prefix) => url.pathname.startsWith(prefix))) {
+    return;
+  }
+
+  if (request.mode === "navigate") {
+    event.respondWith(networkFirst(request));
+    return;
+  }
+
+  if (IMMUTABLE_PREFIXES.some((prefix) => url.pathname.startsWith(prefix))) {
+    event.respondWith(cacheFirst(request));
+  }
+});
+
+/**
+ * Serve from cache, falling back to the network and storing what comes back.
+ * Only used for content-hashed URLs, so a cache hit can never be stale.
+ */
+async function cacheFirst(request) {
+  const cached = await caches.match(request);
+  if (cached) return cached;
+
+  const response = await fetch(request);
+
+  if (response.ok) {
+    const cache = await caches.open(ASSET_CACHE);
+    cache.put(request, response.clone());
+  }
+
+  return response;
+}
+
+/**
+ * Try the network, fall back to whatever we have, then to the offline page.
+ *
+ * Network-first rather than cache-first because a stale app shell that no
+ * longer matches the deployed API is a worse experience than a slightly slower
+ * navigation.
+ */
+async function networkFirst(request) {
+  try {
+    const response = await fetch(request);
+
+    if (response.ok) {
+      const cache = await caches.open(PAGE_CACHE);
+      cache.put(request, response.clone());
+      trimCache(PAGE_CACHE, MAX_PAGE_ENTRIES);
+    }
+
+    return response;
+  } catch (error) {
+    const cached = await caches.match(request);
+    if (cached) return cached;
+
+    const offline = await caches.match(OFFLINE_URL);
+    if (offline) return offline;
+
+    // Nothing cached at all -- first visit while offline.
+    return new Response("You are offline.", {
+      status: 503,
+      statusText: "Offline",
+      headers: { "Content-Type": "text/plain; charset=utf-8" },
+    });
+  }
+}
+
+/**
+ * Evict oldest entries once a cache grows past `maxEntries`.
+ *
+ * `cache.keys()` returns insertion order, so the front of the list is the
+ * least recently added.
+ */
+async function trimCache(cacheName, maxEntries) {
+  const cache = await caches.open(cacheName);
+  const keys = await cache.keys();
+
+  if (keys.length <= maxEntries) return;
+
+  await Promise.all(keys.slice(0, keys.length - maxEntries).map((key) => cache.delete(key)));
+}

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 /**
  * DevLink service worker.
  *

--- a/frontend/src/components/LanguageSwitcher.tsx
+++ b/frontend/src/components/LanguageSwitcher.tsx
@@ -1,0 +1,51 @@
+import { Languages } from "lucide-react";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useTranslation } from "@/context/I18nContext";
+
+interface LanguageSwitcherProps {
+  /** Hide the leading icon where space is tight. */
+  showIcon?: boolean;
+  className?: string;
+}
+
+/**
+ * Locale picker.
+ *
+ * Options are labelled in their own language ("Español", not "Spanish") —
+ * somebody looking for their language will not necessarily recognise the
+ * English name for it. The English name goes in the `aria-label` so the
+ * accessible name is still useful.
+ */
+export function LanguageSwitcher({ showIcon = true, className }: LanguageSwitcherProps) {
+  const { locale, setLocale, availableLocales, t } = useTranslation();
+
+  return (
+    <div className={className}>
+      <Select value={locale} onValueChange={setLocale}>
+        <SelectTrigger aria-label={t("language.change")} className="w-auto gap-2">
+          {showIcon ? <Languages className="h-4 w-4 shrink-0" aria-hidden="true" /> : null}
+          <SelectValue placeholder={t("language.label")} />
+        </SelectTrigger>
+
+        <SelectContent>
+          {availableLocales.map((definition) => (
+            <SelectItem
+              key={definition.code}
+              value={definition.code}
+              aria-label={definition.englishName}
+            >
+              {definition.nativeName}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/frontend/src/components/OfflineBanner.tsx
+++ b/frontend/src/components/OfflineBanner.tsx
@@ -1,0 +1,30 @@
+import { WifiOff } from "lucide-react";
+
+import { useOnlineStatus } from "@/hooks/useOnlineStatus";
+
+/**
+ * A thin bar shown while the browser reports no connectivity.
+ *
+ * Without it, a dropped connection surfaces as mutations failing for no
+ * visible reason, which reads as the app being broken rather than the network
+ * being down.
+ */
+export function OfflineBanner() {
+  const isOnline = useOnlineStatus();
+
+  if (isOnline) return null;
+
+  return (
+    <div
+      // `alert` rather than `status`: losing connectivity is worth interrupting
+      // a screen reader for, since it invalidates whatever the user is about to
+      // do.
+      role="alert"
+      aria-live="assertive"
+      className="fixed inset-x-0 top-0 z-[100] flex items-center justify-center gap-2 bg-amber-500 px-4 py-2 text-sm font-medium text-amber-950 shadow-sm"
+    >
+      <WifiOff className="h-4 w-4 shrink-0" aria-hidden="true" />
+      <span>You're offline. Changes won't be saved until you reconnect.</span>
+    </div>
+  );
+}

--- a/frontend/src/components/errors/ErrorLayout.tsx
+++ b/frontend/src/components/errors/ErrorLayout.tsx
@@ -1,6 +1,8 @@
 import { Link } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 
+import { useTranslation } from "@/context/I18nContext";
+
 interface ErrorLayoutProps {
   icon: ReactNode;
   title: string;
@@ -15,11 +17,18 @@ export function ErrorLayout({
   icon,
   title,
   description,
-  primaryLabel = "Go Home",
+  primaryLabel,
   primaryTo = "/",
-  secondaryLabel = "Go Back",
+  secondaryLabel,
   onSecondaryClick,
 }: ErrorLayoutProps) {
+  // Defaults are resolved here rather than in the parameter list so they
+  // follow the active locale; a default argument would freeze the English
+  // string at module scope.
+  const { t } = useTranslation();
+  const primary = primaryLabel ?? t("common.goHome");
+  const secondary = secondaryLabel ?? t("common.goBack");
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-background px-4">
       <div className="w-full max-w-md text-center">
@@ -34,7 +43,7 @@ export function ErrorLayout({
             to={primaryTo}
             className="inline-flex items-center justify-center rounded-md bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground transition-transform hover:opacity-90 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           >
-            {primaryLabel}
+            {primary}
           </Link>
 
           <button
@@ -42,7 +51,7 @@ export function ErrorLayout({
             onClick={onSecondaryClick ?? (() => window.history.back())}
             className="inline-flex items-center justify-center rounded-md border border-border bg-surface px-5 py-2.5 text-sm font-medium text-foreground transition-transform hover:bg-muted active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           >
-            {secondaryLabel}
+            {secondary}
           </button>
         </div>
       </div>

--- a/frontend/src/components/errors/ForbiddenPage.tsx
+++ b/frontend/src/components/errors/ForbiddenPage.tsx
@@ -1,13 +1,17 @@
 import { ShieldAlert } from "lucide-react";
 
+import { useTranslation } from "@/context/I18nContext";
+
 import { ErrorLayout } from "./ErrorLayout";
 
 export function ForbiddenPage() {
+  const { t } = useTranslation();
+
   return (
     <ErrorLayout
       icon={<ShieldAlert className="h-16 w-16 text-destructive" />}
-      title="403 • Forbidden"
-      description="You don't have permission to access this resource."
+      title={t("errors.forbidden.title")}
+      description={t("errors.forbidden.description")}
     />
   );
 }

--- a/frontend/src/components/errors/NetworkErrorPage.tsx
+++ b/frontend/src/components/errors/NetworkErrorPage.tsx
@@ -1,14 +1,18 @@
 import { GlobeX } from "lucide-react";
 
+import { useTranslation } from "@/context/I18nContext";
+
 import { ErrorLayout } from "./ErrorLayout";
 
 export function NetworkErrorPage() {
+  const { t } = useTranslation();
+
   return (
     <ErrorLayout
       icon={<GlobeX className="h-16 w-16 text-warning" />}
-      title="Network Error"
-      description="We couldn't reach the server. Please try again."
-      primaryLabel="Retry"
+      title={t("errors.network.title")}
+      description={t("errors.network.description")}
+      primaryLabel={t("common.retry")}
       primaryTo="/"
     />
   );

--- a/frontend/src/components/errors/OfflinePage.tsx
+++ b/frontend/src/components/errors/OfflinePage.tsx
@@ -1,14 +1,18 @@
 import { WifiOff } from "lucide-react";
 
+import { useTranslation } from "@/context/I18nContext";
+
 import { ErrorLayout } from "./ErrorLayout";
 
 export function OfflinePage() {
+  const { t } = useTranslation();
+
   return (
     <ErrorLayout
       icon={<WifiOff className="h-16 w-16 text-muted-foreground" />}
-      title="You're Offline"
-      description="Please check your internet connection and try again."
-      primaryLabel="Retry"
+      title={t("errors.offline.title")}
+      description={t("errors.offline.description")}
+      primaryLabel={t("common.retry")}
       primaryTo="/"
     />
   );

--- a/frontend/src/components/errors/ServerErrorPage.tsx
+++ b/frontend/src/components/errors/ServerErrorPage.tsx
@@ -1,13 +1,17 @@
 import { TriangleAlert } from "lucide-react";
 
+import { useTranslation } from "@/context/I18nContext";
+
 import { ErrorLayout } from "./ErrorLayout";
 
 export function ServerErrorPage() {
+  const { t } = useTranslation();
+
   return (
     <ErrorLayout
       icon={<TriangleAlert className="h-16 w-16 text-warning" />}
-      title="500 • Server Error"
-      description="Something went wrong on our end. Please try again in a few moments."
+      title={t("errors.serverError.title")}
+      description={t("errors.serverError.description")}
     />
   );
 }

--- a/frontend/src/components/errors/UnauthorizedPage.tsx
+++ b/frontend/src/components/errors/UnauthorizedPage.tsx
@@ -1,14 +1,18 @@
 import { Lock } from "lucide-react";
 
+import { useTranslation } from "@/context/I18nContext";
+
 import { ErrorLayout } from "./ErrorLayout";
 
 export function UnauthorizedPage() {
+  const { t } = useTranslation();
+
   return (
     <ErrorLayout
       icon={<Lock className="h-16 w-16 text-warning" />}
-      title="401 • Unauthorized"
-      description="You need to sign in to access this page."
-      primaryLabel="Go to Login"
+      title={t("errors.unauthorized.title")}
+      description={t("errors.unauthorized.description")}
+      primaryLabel={t("common.goToLogin")}
       primaryTo="/auth"
     />
   );

--- a/frontend/src/context/I18nContext.tsx
+++ b/frontend/src/context/I18nContext.tsx
@@ -1,0 +1,183 @@
+/**
+ * DevLink internationalisation.
+ *
+ * Deliberately dependency-free rather than pulling in `react-i18next`. What
+ * the app needs today is key lookup, `{placeholder}` interpolation, plural
+ * selection and `Intl` formatting; that is a few hundred lines, against a
+ * sizeable dependency with its own plugin system and initialisation dance.
+ * If requirements grow past this — ICU message syntax, lazy-loaded namespaces,
+ * translation-management tooling — swapping in a library behind the same
+ * `useTranslation()` surface is a contained change.
+ *
+ * Locale is resolved as: stored preference → `navigator.language` → `en`.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+import {
+  formatCompactNumber,
+  formatDate,
+  formatDateTime,
+  formatNumber,
+  formatPercent,
+  formatRelativeTime,
+} from "@/i18n/format";
+import {
+  DEFAULT_LOCALE,
+  FALLBACK_CATALOGUE,
+  LOCALES,
+  getCatalogue,
+  isSupportedLocale,
+  resolveLocale,
+  type LocaleDefinition,
+} from "@/i18n/locales";
+import type { TranslationKey } from "@/i18n/locales/en";
+import { translate } from "@/i18n/translate";
+import type { TranslateOptions } from "@/i18n/types";
+
+const STORAGE_KEY = "devlink-locale";
+
+export type TranslateFn = (key: TranslationKey, options?: TranslateOptions) => string;
+
+interface I18nContextValue {
+  locale: string;
+  setLocale: (locale: string) => void;
+  availableLocales: LocaleDefinition[];
+  t: TranslateFn;
+  formatDate: (value: Date | string | number, options?: Intl.DateTimeFormatOptions) => string;
+  formatDateTime: (value: Date | string | number, options?: Intl.DateTimeFormatOptions) => string;
+  formatRelativeTime: (value: Date | string | number, now?: Date) => string;
+  formatNumber: (value: number, options?: Intl.NumberFormatOptions) => string;
+  formatPercent: (ratio: number, maximumFractionDigits?: number) => string;
+  formatCompactNumber: (value: number) => string;
+}
+
+const I18nContext = createContext<I18nContextValue | undefined>(undefined);
+
+/** Keys already warned about, so a missing string does not spam the console. */
+const warnedKeys = new Set<string>();
+
+function warnOnce(key: string, locale: string) {
+  if (!import.meta.env.DEV) return;
+
+  const cacheKey = `${locale}:${key}`;
+  if (warnedKeys.has(cacheKey)) return;
+
+  warnedKeys.add(cacheKey);
+  console.warn(`[i18n] Missing translation for "${key}" in locale "${locale}"`);
+}
+
+function getStoredLocale(): string | null {
+  if (typeof window === "undefined") return null;
+
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    return saved && isSupportedLocale(saved) ? saved : null;
+  } catch (error) {
+    // Safari in private mode throws on localStorage access.
+    console.warn("Failed to read stored locale preference", error);
+    return null;
+  }
+}
+
+function detectInitialLocale(defaultLocale: string): string {
+  if (typeof window === "undefined") return defaultLocale;
+
+  const stored = getStoredLocale();
+  if (stored) return stored;
+
+  // `languages` is the user's ordered preference list; `language` is just the
+  // first entry, so prefer the list when it is available.
+  const candidates = navigator.languages?.length ? navigator.languages : [navigator.language];
+
+  for (const candidate of candidates) {
+    const resolved = resolveLocale(candidate);
+    if (resolved) return resolved;
+  }
+
+  return defaultLocale;
+}
+
+interface I18nProviderProps {
+  children: ReactNode;
+  defaultLocale?: string;
+}
+
+export function I18nProvider({ children, defaultLocale = DEFAULT_LOCALE }: I18nProviderProps) {
+  const [locale, setLocaleState] = useState<string>(() => detectInitialLocale(defaultLocale));
+
+  // Keep <html lang> in step. Screen readers use it to pick a voice, and
+  // browsers use it for hyphenation and translation prompts.
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    document.documentElement.lang = locale;
+  }, [locale]);
+
+  const setLocale = useCallback((next: string) => {
+    if (!isSupportedLocale(next)) {
+      console.warn(`[i18n] Ignoring unsupported locale "${next}"`);
+      return;
+    }
+
+    setLocaleState(next);
+
+    try {
+      localStorage.setItem(STORAGE_KEY, next);
+    } catch (error) {
+      // Preference is lost on reload but the app keeps working.
+      console.warn("Failed to persist locale preference", error);
+    }
+  }, []);
+
+  const value = useMemo<I18nContextValue>(() => {
+    const catalogue = getCatalogue(locale);
+
+    const t: TranslateFn = (key, options) =>
+      translate(key, options, {
+        locale,
+        catalogue,
+        fallbackCatalogue: FALLBACK_CATALOGUE,
+        onMissingKey: warnOnce,
+      });
+
+    return {
+      locale,
+      setLocale,
+      availableLocales: Object.values(LOCALES),
+      t,
+      formatDate: (v, options) => formatDate(v, locale, options),
+      formatDateTime: (v, options) => formatDateTime(v, locale, options),
+      formatRelativeTime: (v, now) => formatRelativeTime(v, locale, now),
+      formatNumber: (v, options) => formatNumber(v, locale, options),
+      formatPercent: (ratio, digits) => formatPercent(ratio, locale, digits),
+      formatCompactNumber: (v) => formatCompactNumber(v, locale),
+    };
+  }, [locale, setLocale]);
+
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+}
+
+/**
+ * Access the active locale, `t()`, and the formatting helpers.
+ *
+ * Throws outside a provider rather than silently falling back to English —
+ * a component rendered outside the tree is a wiring bug, and quietly working
+ * in English would hide it until a non-English user reported it.
+ */
+export function useTranslation(): I18nContextValue {
+  const context = useContext(I18nContext);
+
+  if (!context) {
+    throw new Error("useTranslation must be used within an I18nProvider");
+  }
+
+  return context;
+}

--- a/frontend/src/hooks/__tests__/useOnlineStatus.test.ts
+++ b/frontend/src/hooks/__tests__/useOnlineStatus.test.ts
@@ -1,0 +1,95 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useOnlineStatus } from "@/hooks/useOnlineStatus";
+
+/** jsdom leaves navigator.onLine writable only via defineProperty. */
+function setOnLine(value: boolean | undefined) {
+  Object.defineProperty(window.navigator, "onLine", {
+    configurable: true,
+    value,
+  });
+}
+
+afterEach(() => {
+  setOnLine(true);
+  vi.restoreAllMocks();
+});
+
+describe("useOnlineStatus", () => {
+  it("reports online when the browser is connected", () => {
+    setOnLine(true);
+
+    const { result } = renderHook(() => useOnlineStatus());
+
+    expect(result.current).toBe(true);
+  });
+
+  it("reports offline when the browser is disconnected", () => {
+    setOnLine(false);
+
+    const { result } = renderHook(() => useOnlineStatus());
+
+    expect(result.current).toBe(false);
+  });
+
+  it("treats an undefined navigator.onLine as online", () => {
+    // Some environments never set the property. Defaulting to offline there
+    // would show the banner permanently.
+    setOnLine(undefined);
+
+    const { result } = renderHook(() => useOnlineStatus());
+
+    expect(result.current).toBe(true);
+  });
+
+  it("flips to offline when the offline event fires", () => {
+    setOnLine(true);
+    const { result } = renderHook(() => useOnlineStatus());
+
+    act(() => {
+      setOnLine(false);
+      window.dispatchEvent(new Event("offline"));
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("flips back to online when the online event fires", () => {
+    setOnLine(false);
+    const { result } = renderHook(() => useOnlineStatus());
+
+    act(() => {
+      setOnLine(true);
+      window.dispatchEvent(new Event("online"));
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("removes its listeners on unmount", () => {
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+
+    const { unmount } = renderHook(() => useOnlineStatus());
+    unmount();
+
+    const removed = removeSpy.mock.calls.map(([event]) => event);
+    expect(removed).toContain("online");
+    expect(removed).toContain("offline");
+  });
+
+  it("does not update after unmount", () => {
+    setOnLine(true);
+    const { result, unmount } = renderHook(() => useOnlineStatus());
+
+    unmount();
+
+    act(() => {
+      setOnLine(false);
+      window.dispatchEvent(new Event("offline"));
+    });
+
+    // The last rendered value stands; no state update on an unmounted hook.
+    expect(result.current).toBe(true);
+  });
+});

--- a/frontend/src/hooks/useOnlineStatus.ts
+++ b/frontend/src/hooks/useOnlineStatus.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Track browser connectivity.
+ *
+ * `navigator.onLine` is a coarse signal — it reports whether the machine has a
+ * network interface up, not whether our API is reachable — but it is the only
+ * thing that fires synchronously when a laptop's Wi-Fi drops, and it is enough
+ * to explain to the user why their last action failed.
+ *
+ * Defaults to `true` during SSR and before the first effect, so the offline
+ * banner never flashes on a perfectly healthy page load.
+ */
+export function useOnlineStatus(): boolean {
+  const [isOnline, setIsOnline] = useState<boolean>(() => {
+    if (typeof navigator === "undefined") return true;
+    // Some environments (jsdom included) leave onLine undefined rather than
+    // false; treating that as "offline" would be wrong.
+    return navigator.onLine !== false;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+
+    // Connectivity can change between the initial render and this effect
+    // running, so re-read rather than trusting the initial state.
+    setIsOnline(navigator.onLine !== false);
+
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
+
+  return isOnline;
+}

--- a/frontend/src/i18n/__tests__/I18nContext.test.tsx
+++ b/frontend/src/i18n/__tests__/I18nContext.test.tsx
@@ -1,0 +1,232 @@
+import { act, render, renderHook, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { I18nProvider, useTranslation } from "@/context/I18nContext";
+
+const STORAGE_KEY = "devlink-locale";
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <I18nProvider>{children}</I18nProvider>;
+}
+
+function setLanguages(languages: string[]) {
+  Object.defineProperty(window.navigator, "languages", {
+    configurable: true,
+    value: languages,
+  });
+  Object.defineProperty(window.navigator, "language", {
+    configurable: true,
+    value: languages[0],
+  });
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  setLanguages(["en-US"]);
+  document.documentElement.lang = "";
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("locale detection", () => {
+  it("defaults to English", () => {
+    const { result } = renderHook(() => useTranslation(), { wrapper });
+
+    expect(result.current.locale).toBe("en");
+  });
+
+  it("picks up a supported browser language", () => {
+    setLanguages(["es-ES"]);
+
+    const { result } = renderHook(() => useTranslation(), { wrapper });
+
+    expect(result.current.locale).toBe("es");
+  });
+
+  it("walks the browser's preference list", () => {
+    // fr is unsupported, so the next entry should win.
+    setLanguages(["fr-FR", "es-MX"]);
+
+    const { result } = renderHook(() => useTranslation(), { wrapper });
+
+    expect(result.current.locale).toBe("es");
+  });
+
+  it("falls back to English when nothing is supported", () => {
+    setLanguages(["fr-FR", "de-DE"]);
+
+    const { result } = renderHook(() => useTranslation(), { wrapper });
+
+    expect(result.current.locale).toBe("en");
+  });
+
+  it("prefers a stored preference over the browser language", () => {
+    localStorage.setItem(STORAGE_KEY, "es");
+    setLanguages(["en-US"]);
+
+    const { result } = renderHook(() => useTranslation(), { wrapper });
+
+    expect(result.current.locale).toBe("es");
+  });
+
+  it("ignores an unsupported stored value", () => {
+    localStorage.setItem(STORAGE_KEY, "klingon");
+
+    const { result } = renderHook(() => useTranslation(), { wrapper });
+
+    expect(result.current.locale).toBe("en");
+  });
+});
+
+describe("setLocale", () => {
+  it("switches the active locale", () => {
+    const { result } = renderHook(() => useTranslation(), { wrapper });
+
+    act(() => result.current.setLocale("es"));
+
+    expect(result.current.locale).toBe("es");
+  });
+
+  it("persists the choice", () => {
+    const { result } = renderHook(() => useTranslation(), { wrapper });
+
+    act(() => result.current.setLocale("es"));
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("es");
+  });
+
+  it("ignores an unsupported locale", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { result } = renderHook(() => useTranslation(), { wrapper });
+
+    act(() => result.current.setLocale("klingon"));
+
+    expect(result.current.locale).toBe("en");
+  });
+
+  it("keeps working when localStorage throws", () => {
+    // Safari in private mode.
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+
+    const { result } = renderHook(() => useTranslation(), { wrapper });
+
+    act(() => result.current.setLocale("es"));
+
+    expect(result.current.locale).toBe("es");
+  });
+
+  it("updates <html lang>", () => {
+    const { result } = renderHook(() => useTranslation(), { wrapper });
+
+    expect(document.documentElement.lang).toBe("en");
+
+    act(() => result.current.setLocale("es"));
+
+    expect(document.documentElement.lang).toBe("es");
+  });
+});
+
+describe("t()", () => {
+  it("resolves in the active locale", () => {
+    const { result } = renderHook(() => useTranslation(), { wrapper });
+
+    expect(result.current.t("common.retry")).toBe("Retry");
+
+    act(() => result.current.setLocale("es"));
+
+    expect(result.current.t("common.retry")).toBe("Reintentar");
+  });
+
+  it("falls back to English for a key the locale lacks", () => {
+    const { result } = renderHook(() => useTranslation(), { wrapper });
+
+    act(() => result.current.setLocale("es"));
+
+    // notifications.unread is deliberately absent from the Spanish catalogue.
+    expect(result.current.t("notifications.unread", { count: 3 })).toBe("3 unread notifications");
+  });
+
+  it("pluralises in the active locale", () => {
+    const { result } = renderHook(() => useTranslation(), { wrapper });
+
+    act(() => result.current.setLocale("es"));
+
+    expect(result.current.t("projects.count", { count: 1 })).toBe("1 proyecto");
+    expect(result.current.t("projects.count", { count: 4 })).toBe("4 proyectos");
+  });
+});
+
+describe("formatting helpers", () => {
+  it("follow the active locale", () => {
+    const { result } = renderHook(() => useTranslation(), { wrapper });
+
+    const inEnglish = result.current.formatRelativeTime(
+      new Date("2026-08-03T10:00:00Z"),
+      new Date("2026-08-03T12:00:00Z"),
+    );
+    expect(inEnglish).toBe("2 hours ago");
+
+    act(() => result.current.setLocale("es"));
+
+    const inSpanish = result.current.formatRelativeTime(
+      new Date("2026-08-03T10:00:00Z"),
+      new Date("2026-08-03T12:00:00Z"),
+    );
+    expect(inSpanish).toBe("hace 2 horas");
+  });
+});
+
+describe("useTranslation outside a provider", () => {
+  it("throws rather than silently defaulting to English", () => {
+    // Quietly working in English would hide the wiring bug until a
+    // non-English user reported it.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    function Bare() {
+      useTranslation();
+      return null;
+    }
+
+    expect(() => render(<Bare />)).toThrow(/must be used within an I18nProvider/);
+  });
+});
+
+describe("translated components", () => {
+  // The error pages themselves render a TanStack <Link>, which needs a router
+  // in context; exercising them here would be a router test wearing an i18n
+  // costume. LanguageSwitcher has no router dependency and covers the same
+  // ground: a real component reading from the provider.
+  it("labels the switcher in the active locale", async () => {
+    const { LanguageSwitcher } = await import("@/components/LanguageSwitcher");
+
+    localStorage.setItem(STORAGE_KEY, "es");
+
+    render(
+      <I18nProvider>
+        <LanguageSwitcher />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByLabelText("Cambiar idioma")).toBeInTheDocument();
+  });
+
+  it("shows each language in its own name", async () => {
+    const { LanguageSwitcher } = await import("@/components/LanguageSwitcher");
+
+    render(
+      <I18nProvider>
+        <LanguageSwitcher />
+      </I18nProvider>,
+    );
+
+    // The trigger reflects the selected value; "English" is the native name
+    // for `en`, which is what a user scanning the list would look for.
+    expect(screen.getByLabelText("Change language")).toHaveTextContent("English");
+  });
+});

--- a/frontend/src/i18n/__tests__/format.test.ts
+++ b/frontend/src/i18n/__tests__/format.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatCompactNumber,
+  formatDate,
+  formatDateTime,
+  formatNumber,
+  formatPercent,
+  formatRelativeTime,
+} from "@/i18n/format";
+
+const REFERENCE = new Date("2026-08-03T12:00:00Z");
+
+describe("formatNumber", () => {
+  it("uses the locale's grouping and decimal separators", () => {
+    // The whole point of the exercise: en and es disagree about which
+    // character means what.
+    expect(formatNumber(1234.5, "en-US")).toBe("1,234.5");
+    expect(formatNumber(1234.5, "de-DE")).toBe("1.234,5");
+  });
+
+  it("passes options through", () => {
+    expect(formatNumber(0.5, "en-US", { minimumFractionDigits: 2 })).toBe("0.50");
+  });
+
+  it("returns an empty string for a non-finite value", () => {
+    expect(formatNumber(Number.NaN, "en")).toBe("");
+    expect(formatNumber(Number.POSITIVE_INFINITY, "en")).toBe("");
+  });
+
+  it("falls back to English for a malformed locale tag", () => {
+    // A bad value in localStorage must not blank the page.
+    expect(formatNumber(1234.5, "not a locale")).toBe("1,234.5");
+  });
+});
+
+describe("formatPercent", () => {
+  it("treats the input as a ratio", () => {
+    expect(formatPercent(0.42, "en-US")).toBe("42%");
+  });
+
+  it("respects the fraction-digit cap", () => {
+    expect(formatPercent(0.4267, "en-US", 1)).toBe("42.7%");
+  });
+
+  it("returns an empty string for a non-finite value", () => {
+    expect(formatPercent(Number.NaN, "en")).toBe("");
+  });
+});
+
+describe("formatCompactNumber", () => {
+  it("shortens large values", () => {
+    expect(formatCompactNumber(1200, "en-US")).toBe("1.2K");
+    expect(formatCompactNumber(3_400_000, "en-US")).toBe("3.4M");
+  });
+
+  it("leaves small values alone", () => {
+    expect(formatCompactNumber(42, "en-US")).toBe("42");
+  });
+});
+
+describe("formatDate", () => {
+  it("produces a locale-appropriate date", () => {
+    const enResult = formatDate(REFERENCE, "en-US");
+    const deResult = formatDate(REFERENCE, "de-DE");
+
+    expect(enResult).toBeTruthy();
+    expect(deResult).toBeTruthy();
+    expect(enResult).not.toBe(deResult);
+  });
+
+  it("accepts an ISO string", () => {
+    expect(formatDate("2026-08-03T12:00:00Z", "en-US")).toBeTruthy();
+  });
+
+  it("accepts a timestamp", () => {
+    expect(formatDate(REFERENCE.getTime(), "en-US")).toBeTruthy();
+  });
+
+  it("returns an empty string for an unparseable value", () => {
+    // Rendering "Invalid Date" at a user is never right.
+    expect(formatDate("not a date", "en-US")).toBe("");
+  });
+});
+
+describe("formatDateTime", () => {
+  it("includes a time component", () => {
+    const dateOnly = formatDate(REFERENCE, "en-US");
+    const withTime = formatDateTime(REFERENCE, "en-US");
+
+    expect(withTime.length).toBeGreaterThan(dateOnly.length);
+  });
+});
+
+describe("formatRelativeTime", () => {
+  it("describes the recent past", () => {
+    const twoHoursAgo = new Date(REFERENCE.getTime() - 2 * 60 * 60 * 1000);
+
+    expect(formatRelativeTime(twoHoursAgo, "en", REFERENCE)).toBe("2 hours ago");
+  });
+
+  it("describes the near future", () => {
+    const inThreeDays = new Date(REFERENCE.getTime() + 3 * 24 * 60 * 60 * 1000);
+
+    expect(formatRelativeTime(inThreeDays, "en", REFERENCE)).toBe("in 3 days");
+  });
+
+  it("uses natural wording where the locale has it", () => {
+    // numeric: "auto" is what turns "1 day ago" into "yesterday".
+    const yesterday = new Date(REFERENCE.getTime() - 24 * 60 * 60 * 1000);
+
+    expect(formatRelativeTime(yesterday, "en", REFERENCE)).toBe("yesterday");
+  });
+
+  it("picks the largest sensible unit", () => {
+    const lastYear = new Date(REFERENCE.getTime() - 400 * 24 * 60 * 60 * 1000);
+
+    expect(formatRelativeTime(lastYear, "en", REFERENCE)).toContain("year");
+  });
+
+  it("handles sub-second differences", () => {
+    expect(formatRelativeTime(REFERENCE, "en", REFERENCE)).toBe("now");
+  });
+
+  it("translates with the locale", () => {
+    const twoHoursAgo = new Date(REFERENCE.getTime() - 2 * 60 * 60 * 1000);
+
+    expect(formatRelativeTime(twoHoursAgo, "es", REFERENCE)).toBe("hace 2 horas");
+  });
+
+  it("returns an empty string for an unparseable value", () => {
+    expect(formatRelativeTime("nonsense", "en", REFERENCE)).toBe("");
+  });
+});

--- a/frontend/src/i18n/__tests__/translate.test.ts
+++ b/frontend/src/i18n/__tests__/translate.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { en } from "@/i18n/locales/en";
+import { es } from "@/i18n/locales/es";
+import { resolveLocale } from "@/i18n/locales";
+import { humaniseKey, interpolate, isPluralForms, selectPlural, translate } from "@/i18n/translate";
+import type { Catalogue } from "@/i18n/types";
+
+const catalogue: Catalogue = {
+  "greeting.plain": "Hello",
+  "greeting.named": "Hello, {name}!",
+  "greeting.twice": "{name} and {name}",
+  "greeting.spaced": "Hello, { name }!",
+  "items.count": { one: "{count} item", other: "{count} items" },
+  "inbox.unread": {
+    zero: "Nothing unread",
+    one: "{count} unread",
+    other: "{count} unread",
+  },
+};
+
+function t(
+  key: string,
+  options = {},
+  locale = "en",
+  override: Partial<Parameters<typeof translate>[2]> = {},
+) {
+  return translate(key, options, { locale, catalogue, ...override });
+}
+
+// ----------------------------------------------------------------------
+// interpolate
+// ----------------------------------------------------------------------
+
+describe("interpolate", () => {
+  it("substitutes a named placeholder", () => {
+    expect(interpolate("Hello, {name}!", { name: "Alex" })).toBe("Hello, Alex!");
+  });
+
+  it("substitutes every occurrence", () => {
+    expect(interpolate("{a} and {a}", { a: "x" })).toBe("x and x");
+  });
+
+  it("tolerates whitespace inside the braces", () => {
+    expect(interpolate("Hi { name }", { name: "Alex" })).toBe("Hi Alex");
+  });
+
+  it("coerces numbers", () => {
+    expect(interpolate("{n} left", { n: 3 })).toBe("3 left");
+  });
+
+  it("leaves an unknown placeholder visible", () => {
+    // A visible {missing} is an obvious bug report. "undefined" is a
+    // confusing one.
+    expect(interpolate("Hello, {missing}!")).toBe("Hello, {missing}!");
+  });
+
+  it("leaves a placeholder whose value is undefined", () => {
+    expect(interpolate("Hi {name}", { name: undefined })).toBe("Hi {name}");
+  });
+
+  it("returns a template with no placeholders unchanged", () => {
+    expect(interpolate("Plain text", { unused: "x" })).toBe("Plain text");
+  });
+});
+
+// ----------------------------------------------------------------------
+// Pluralisation
+// ----------------------------------------------------------------------
+
+describe("selectPlural", () => {
+  const forms = { one: "one thing", other: "many things" };
+
+  it("picks the English singular for 1", () => {
+    expect(selectPlural(forms, 1, "en")).toBe("one thing");
+  });
+
+  it("picks the plural for 0 and 2 in English", () => {
+    expect(selectPlural(forms, 0, "en")).toBe("many things");
+    expect(selectPlural(forms, 2, "en")).toBe("many things");
+  });
+
+  it("falls back to `other` when the locale needs a category we lack", () => {
+    // Japanese only has `other`, so a catalogue with just `one` must still
+    // resolve.
+    expect(selectPlural({ other: "もの" }, 1, "ja")).toBe("もの");
+  });
+
+  it("falls back to English rules for a malformed locale tag", () => {
+    expect(selectPlural(forms, 1, "not a locale")).toBe("one thing");
+  });
+});
+
+describe("isPluralForms", () => {
+  it("recognises plural forms", () => {
+    expect(isPluralForms({ other: "x" })).toBe(true);
+  });
+
+  it("rejects a plain string", () => {
+    expect(isPluralForms("x")).toBe(false);
+  });
+});
+
+// ----------------------------------------------------------------------
+// humaniseKey
+// ----------------------------------------------------------------------
+
+describe("humaniseKey", () => {
+  it("uses the last segment", () => {
+    expect(humaniseKey("projects.emptyState.title")).toBe("Title");
+  });
+
+  it("splits camelCase", () => {
+    expect(humaniseKey("common.tryAgain")).toBe("Try again");
+  });
+
+  it("handles dashes and underscores", () => {
+    expect(humaniseKey("a.b.some_long-name")).toBe("Some long name");
+  });
+
+  it("handles a key with no dots", () => {
+    expect(humaniseKey("save")).toBe("Save");
+  });
+});
+
+// ----------------------------------------------------------------------
+// translate
+// ----------------------------------------------------------------------
+
+describe("translate", () => {
+  it("resolves a plain key", () => {
+    expect(t("greeting.plain")).toBe("Hello");
+  });
+
+  it("interpolates while resolving", () => {
+    expect(t("greeting.named", { name: "Alex" })).toBe("Hello, Alex!");
+  });
+
+  it("exposes count for interpolation as well as plural selection", () => {
+    expect(t("items.count", { count: 1 })).toBe("1 item");
+    expect(t("items.count", { count: 5 })).toBe("5 items");
+  });
+
+  it("uses the zero form where one is provided", () => {
+    expect(t("inbox.unread", { count: 0 })).toBe("Nothing unread");
+  });
+
+  it("falls back to the fallback catalogue", () => {
+    const result = translate(
+      "only.in.fallback",
+      {},
+      {
+        locale: "es",
+        catalogue,
+        fallbackCatalogue: { "only.in.fallback": "From English" },
+      },
+    );
+
+    expect(result).toBe("From English");
+  });
+
+  it("falls back to a humanised key when nothing matches", () => {
+    expect(t("totally.unknown.keyName")).toBe("Key name");
+  });
+
+  it("reports a missing key exactly once per call", () => {
+    const onMissingKey = vi.fn();
+    t("totally.unknown", {}, "en", { onMissingKey });
+
+    expect(onMissingKey).toHaveBeenCalledWith("totally.unknown", "en");
+  });
+
+  it("warns but still renders when a plural key is used without a count", () => {
+    const onMissingKey = vi.fn();
+
+    expect(t("items.count", {}, "en", { onMissingKey })).toBe("{count} items");
+    expect(onMissingKey).toHaveBeenCalled();
+  });
+
+  it("never returns an empty string", () => {
+    expect(t("nothing.here").length).toBeGreaterThan(0);
+  });
+});
+
+// ----------------------------------------------------------------------
+// Catalogues
+// ----------------------------------------------------------------------
+
+describe("catalogues", () => {
+  it("every Spanish key exists in English", () => {
+    // English is the source of truth; a key only in another locale is dead
+    // weight nothing can reference.
+    const englishKeys = new Set(Object.keys(en));
+    const orphans = Object.keys(es).filter((key) => !englishKeys.has(key));
+
+    expect(orphans).toEqual([]);
+  });
+
+  it("every plural entry defines `other`", () => {
+    for (const [key, message] of Object.entries({ ...en, ...es })) {
+      if (isPluralForms(message)) {
+        expect(message.other, `${key} is missing an "other" form`).toBeTruthy();
+      }
+    }
+  });
+
+  it("Spanish placeholders match the English ones", () => {
+    const names = (value: string) => (value.match(/\{\s*([a-zA-Z0-9_]+)\s*\}/g) ?? []).sort();
+
+    for (const [key, spanish] of Object.entries(es)) {
+      const english = (en as Record<string, unknown>)[key];
+      if (typeof spanish !== "string" || typeof english !== "string") continue;
+
+      expect(names(spanish), `placeholders differ for ${key}`).toEqual(names(english));
+    }
+  });
+});
+
+// ----------------------------------------------------------------------
+// Locale resolution
+// ----------------------------------------------------------------------
+
+describe("resolveLocale", () => {
+  it("matches an exact tag", () => {
+    expect(resolveLocale("es")).toBe("es");
+  });
+
+  it("falls back to the primary subtag", () => {
+    expect(resolveLocale("es-MX")).toBe("es");
+    expect(resolveLocale("en-GB")).toBe("en");
+  });
+
+  it("is case-insensitive", () => {
+    expect(resolveLocale("ES-mx")).toBe("es");
+  });
+
+  it("returns null for an unsupported language", () => {
+    expect(resolveLocale("fr-FR")).toBeNull();
+  });
+
+  it("returns null for empty input", () => {
+    expect(resolveLocale("")).toBeNull();
+    expect(resolveLocale(undefined)).toBeNull();
+    expect(resolveLocale(null)).toBeNull();
+  });
+});

--- a/frontend/src/i18n/format.ts
+++ b/frontend/src/i18n/format.ts
@@ -1,0 +1,188 @@
+/**
+ * Locale-aware formatting helpers.
+ *
+ * The app currently formats dates with ad-hoc `date-fns` calls and numbers
+ * with template strings, so a user whose browser is set to `de-DE` still sees
+ * US conventions throughout. These wrap `Intl` so output follows the active
+ * locale instead.
+ *
+ * Every helper is defensive about the locale tag: an unknown or malformed one
+ * degrades to `en` rather than throwing, because a bad value in localStorage
+ * should not blank out a page.
+ */
+
+const DEFAULT_FALLBACK_LOCALE = "en";
+
+/** Formatter construction is expensive relative to how often we format. */
+const dateFormatterCache = new Map<string, Intl.DateTimeFormat>();
+const numberFormatterCache = new Map<string, Intl.NumberFormat>();
+const relativeFormatterCache = new Map<string, Intl.RelativeTimeFormat>();
+
+function cacheKey(locale: string, options: object): string {
+  return `${locale}|${JSON.stringify(options)}`;
+}
+
+function getDateFormatter(
+  locale: string,
+  options: Intl.DateTimeFormatOptions,
+): Intl.DateTimeFormat {
+  const key = cacheKey(locale, options);
+  let formatter = dateFormatterCache.get(key);
+
+  if (!formatter) {
+    try {
+      formatter = new Intl.DateTimeFormat(locale, options);
+    } catch {
+      formatter = new Intl.DateTimeFormat(DEFAULT_FALLBACK_LOCALE, options);
+    }
+    dateFormatterCache.set(key, formatter);
+  }
+
+  return formatter;
+}
+
+function getNumberFormatter(locale: string, options: Intl.NumberFormatOptions): Intl.NumberFormat {
+  const key = cacheKey(locale, options);
+  let formatter = numberFormatterCache.get(key);
+
+  if (!formatter) {
+    try {
+      formatter = new Intl.NumberFormat(locale, options);
+    } catch {
+      formatter = new Intl.NumberFormat(DEFAULT_FALLBACK_LOCALE, options);
+    }
+    numberFormatterCache.set(key, formatter);
+  }
+
+  return formatter;
+}
+
+function getRelativeFormatter(locale: string): Intl.RelativeTimeFormat {
+  let formatter = relativeFormatterCache.get(locale);
+
+  if (!formatter) {
+    try {
+      formatter = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
+    } catch {
+      formatter = new Intl.RelativeTimeFormat(DEFAULT_FALLBACK_LOCALE, {
+        numeric: "auto",
+      });
+    }
+    relativeFormatterCache.set(locale, formatter);
+  }
+
+  return formatter;
+}
+
+function toDate(value: Date | string | number): Date | null {
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/**
+ * Format a date, e.g. `3 Aug 2026` in `en-GB`, `3 ago 2026` in `es`.
+ *
+ * Returns an empty string for an unparseable value — rendering "Invalid Date"
+ * at a user is never the right answer.
+ */
+export function formatDate(
+  value: Date | string | number,
+  locale: string,
+  options: Intl.DateTimeFormatOptions = { dateStyle: "medium" },
+): string {
+  const date = toDate(value);
+  if (!date) return "";
+
+  return getDateFormatter(locale, options).format(date);
+}
+
+/** Format a date and time together. */
+export function formatDateTime(
+  value: Date | string | number,
+  locale: string,
+  options: Intl.DateTimeFormatOptions = {
+    dateStyle: "medium",
+    timeStyle: "short",
+  },
+): string {
+  return formatDate(value, locale, options);
+}
+
+/** Thresholds for picking a relative-time unit, largest first. */
+const RELATIVE_UNITS: Array<[Intl.RelativeTimeFormatUnit, number]> = [
+  ["year", 60 * 60 * 24 * 365],
+  ["month", 60 * 60 * 24 * 30],
+  ["week", 60 * 60 * 24 * 7],
+  ["day", 60 * 60 * 24],
+  ["hour", 60 * 60],
+  ["minute", 60],
+  ["second", 1],
+];
+
+/**
+ * Format a timestamp relative to now: "2 hours ago", "hace 2 horas".
+ *
+ * `numeric: "auto"` is what produces "yesterday" rather than "1 day ago" in
+ * locales that have a word for it.
+ */
+export function formatRelativeTime(
+  value: Date | string | number,
+  locale: string,
+  now: Date = new Date(),
+): string {
+  const date = toDate(value);
+  if (!date) return "";
+
+  const deltaSeconds = (date.getTime() - now.getTime()) / 1000;
+  const absolute = Math.abs(deltaSeconds);
+
+  for (const [unit, secondsInUnit] of RELATIVE_UNITS) {
+    if (absolute >= secondsInUnit) {
+      const amount = Math.round(deltaSeconds / secondsInUnit);
+      return getRelativeFormatter(locale).format(amount, unit);
+    }
+  }
+
+  // Under a second in either direction.
+  return getRelativeFormatter(locale).format(0, "second");
+}
+
+/** Format a number: `1,234.5` in `en`, `1.234,5` in `es`. */
+export function formatNumber(
+  value: number,
+  locale: string,
+  options: Intl.NumberFormatOptions = {},
+): string {
+  if (!Number.isFinite(value)) return "";
+
+  return getNumberFormatter(locale, options).format(value);
+}
+
+/**
+ * Format a 0–1 ratio as a percentage.
+ *
+ * Takes a ratio rather than an already-multiplied number so callers cannot
+ * disagree about whether `50` means 50% or 5000%.
+ */
+export function formatPercent(ratio: number, locale: string, maximumFractionDigits = 0): string {
+  if (!Number.isFinite(ratio)) return "";
+
+  return getNumberFormatter(locale, {
+    style: "percent",
+    maximumFractionDigits,
+  }).format(ratio);
+}
+
+/**
+ * Compact notation for large counts: `1.2K`, `3.4M`.
+ *
+ * Used for follower and view counts, where the exact figure is noise.
+ */
+export function formatCompactNumber(value: number, locale: string): string {
+  if (!Number.isFinite(value)) return "";
+
+  return getNumberFormatter(locale, {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(value);
+}

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1,0 +1,80 @@
+/**
+ * English catalogue — the source of truth.
+ *
+ * Every key must exist here. Other locales are allowed to be incomplete; a
+ * missing key falls back to the English string.
+ *
+ * Keys are flat and dot-separated, grouped by area. `as const` is what gives
+ * `TranslationKey` exact autocomplete, so it must stay.
+ */
+
+export const en = {
+  // ------------------------------------------------------------------
+  // Shared vocabulary
+  // ------------------------------------------------------------------
+  "common.appName": "DevLink",
+  "common.cancel": "Cancel",
+  "common.save": "Save",
+  "common.retry": "Retry",
+  "common.goHome": "Go Home",
+  "common.goBack": "Go Back",
+  "common.goToLogin": "Go to Login",
+  "common.loading": "Loading…",
+  "common.search": "Search",
+  "common.close": "Close",
+
+  // ------------------------------------------------------------------
+  // Error pages
+  //
+  // Status numerals stay in the string: they are the same in every locale,
+  // and splitting them out would mean assembling the title in the component.
+  // ------------------------------------------------------------------
+  "errors.unauthorized.title": "401 • Unauthorized",
+  "errors.unauthorized.description": "You need to sign in to access this page.",
+
+  "errors.forbidden.title": "403 • Forbidden",
+  "errors.forbidden.description": "You don't have permission to access this resource.",
+
+  "errors.serverError.title": "500 • Server Error",
+  "errors.serverError.description":
+    "Something went wrong on our end. Please try again in a few moments.",
+
+  "errors.network.title": "Network Error",
+  "errors.network.description": "We couldn't reach the server. Please try again.",
+
+  "errors.offline.title": "You're Offline",
+  "errors.offline.description": "Please check your internet connection and try again.",
+
+  // ------------------------------------------------------------------
+  // Language switcher
+  // ------------------------------------------------------------------
+  "language.label": "Language",
+  "language.change": "Change language",
+
+  // ------------------------------------------------------------------
+  // Pluralised counts
+  // ------------------------------------------------------------------
+  "projects.count": {
+    one: "{count} project",
+    other: "{count} projects",
+  },
+  "members.count": {
+    one: "{count} member",
+    other: "{count} members",
+  },
+  "notifications.unread": {
+    zero: "No unread notifications",
+    one: "{count} unread notification",
+    other: "{count} unread notifications",
+  },
+} as const;
+
+/**
+ * Every valid translation key.
+ *
+ * Passing anything else to `t()` is a compile error, which is the main reason
+ * to keep the catalogue flat and `as const`.
+ */
+export type TranslationKey = keyof typeof en;
+
+export default en;

--- a/frontend/src/i18n/locales/es.ts
+++ b/frontend/src/i18n/locales/es.ts
@@ -1,0 +1,54 @@
+/**
+ * Spanish catalogue.
+ *
+ * Included as a worked reference so the shape of a second locale is concrete
+ * rather than hypothetical. Deliberately *not* exhaustive: the missing keys
+ * demonstrate that an incomplete catalogue falls back to English cleanly
+ * instead of rendering a raw key at the user.
+ */
+
+import type { Catalogue } from "../types";
+
+export const es: Catalogue = {
+  "common.appName": "DevLink",
+  "common.cancel": "Cancelar",
+  "common.save": "Guardar",
+  "common.retry": "Reintentar",
+  "common.goHome": "Ir al inicio",
+  "common.goBack": "Volver",
+  "common.goToLogin": "Iniciar sesión",
+  "common.loading": "Cargando…",
+  "common.search": "Buscar",
+  "common.close": "Cerrar",
+
+  "errors.unauthorized.title": "401 • No autorizado",
+  "errors.unauthorized.description": "Debes iniciar sesión para acceder a esta página.",
+
+  "errors.forbidden.title": "403 • Prohibido",
+  "errors.forbidden.description": "No tienes permiso para acceder a este recurso.",
+
+  "errors.serverError.title": "500 • Error del servidor",
+  "errors.serverError.description":
+    "Algo salió mal por nuestra parte. Inténtalo de nuevo en unos momentos.",
+
+  "errors.network.title": "Error de red",
+  "errors.network.description": "No pudimos conectar con el servidor. Inténtalo de nuevo.",
+
+  "errors.offline.title": "Estás sin conexión",
+  "errors.offline.description": "Comprueba tu conexión a internet e inténtalo de nuevo.",
+
+  "language.label": "Idioma",
+  "language.change": "Cambiar idioma",
+
+  "projects.count": {
+    one: "{count} proyecto",
+    other: "{count} proyectos",
+  },
+  "members.count": {
+    one: "{count} miembro",
+    other: "{count} miembros",
+  },
+  // "notifications.unread" is intentionally absent — it falls back to English.
+};
+
+export default es;

--- a/frontend/src/i18n/locales/index.ts
+++ b/frontend/src/i18n/locales/index.ts
@@ -1,0 +1,69 @@
+/**
+ * Locale registry.
+ *
+ * Adding a language is: write the catalogue file, import it, add one entry
+ * here. Nothing else in the app needs to change.
+ */
+
+import type { Catalogue } from "../types";
+
+import { en } from "./en";
+import { es } from "./es";
+
+export const DEFAULT_LOCALE = "en";
+
+export interface LocaleDefinition {
+  code: string;
+  /** Name in the language itself — "Español", not "Spanish". */
+  nativeName: string;
+  /** English name, for the accessible label. */
+  englishName: string;
+  catalogue: Catalogue;
+}
+
+export const LOCALES: Record<string, LocaleDefinition> = {
+  en: {
+    code: "en",
+    nativeName: "English",
+    englishName: "English",
+    catalogue: en,
+  },
+  es: {
+    code: "es",
+    nativeName: "Español",
+    englishName: "Spanish",
+    catalogue: es,
+  },
+};
+
+export const SUPPORTED_LOCALES = Object.keys(LOCALES);
+
+/** The English catalogue, used as the fallback for every other locale. */
+export const FALLBACK_CATALOGUE: Catalogue = en;
+
+export function isSupportedLocale(locale: string): boolean {
+  return locale in LOCALES;
+}
+
+/**
+ * Map a browser language tag onto a locale we actually have.
+ *
+ * `navigator.language` gives things like `es-419` or `en-GB`. An exact match
+ * wins; otherwise the primary subtag is tried, so `es-MX` resolves to `es`.
+ * Returns `null` when nothing matches, leaving the caller to decide.
+ */
+export function resolveLocale(tag: string | undefined | null): string | null {
+  if (!tag) return null;
+
+  const normalised = tag.toLowerCase();
+  if (isSupportedLocale(normalised)) return normalised;
+
+  const primary = normalised.split("-")[0];
+  if (isSupportedLocale(primary)) return primary;
+
+  return null;
+}
+
+export function getCatalogue(locale: string): Catalogue {
+  return LOCALES[locale]?.catalogue ?? FALLBACK_CATALOGUE;
+}

--- a/frontend/src/i18n/translate.ts
+++ b/frontend/src/i18n/translate.ts
@@ -1,0 +1,152 @@
+/**
+ * Message resolution, interpolation and pluralisation.
+ *
+ * Everything here is pure — no React, no browser globals beyond `Intl` — so
+ * the rules can be tested directly.
+ */
+
+import type {
+  Catalogue,
+  InterpolationValues,
+  Message,
+  PluralForms,
+  TranslateOptions,
+} from "./types";
+
+/** Matches `{name}`, allowing incidental whitespace: `{ name }`. */
+const PLACEHOLDER_PATTERN = /\{\s*([a-zA-Z0-9_]+)\s*\}/g;
+
+/**
+ * `Intl.PluralRules` instances are not cheap to build and we call this on
+ * every render of every pluralised string.
+ */
+const pluralRulesCache = new Map<string, Intl.PluralRules>();
+
+function getPluralRules(locale: string): Intl.PluralRules {
+  let rules = pluralRulesCache.get(locale);
+
+  if (!rules) {
+    try {
+      rules = new Intl.PluralRules(locale);
+    } catch {
+      // An unknown or malformed tag must not take the page down.
+      rules = new Intl.PluralRules("en");
+    }
+    pluralRulesCache.set(locale, rules);
+  }
+
+  return rules;
+}
+
+/** Whether a message carries plural variants rather than being a plain string. */
+export function isPluralForms(message: Message): message is PluralForms {
+  return typeof message === "object" && message !== null && "other" in message;
+}
+
+/**
+ * Substitute `{placeholder}` tokens.
+ *
+ * An unknown placeholder is left verbatim rather than replaced with
+ * `undefined`. A visible `{userName}` in the UI is an obvious bug report; the
+ * string "undefined" is a confusing one.
+ */
+export function interpolate(template: string, values: InterpolationValues = {}): string {
+  return template.replace(PLACEHOLDER_PATTERN, (match, name: string) => {
+    const value = values[name];
+    return value === undefined || value === null ? match : String(value);
+  });
+}
+
+/**
+ * Pick the plural variant for `count` under `locale`.
+ *
+ * One deliberate deviation from CLDR: an explicit `zero` form is honoured at
+ * `count === 0` in every locale. English has no `zero` plural category, so
+ * strictly following `Intl.PluralRules` would mean a translator who wrote
+ * `zero: "No unread notifications"` silently never saw it and got
+ * "0 unread notifications" instead. Writing a `zero` form is an unambiguous
+ * statement of intent, so it wins.
+ *
+ * Otherwise falls back to `other`, which every entry is required to define, so
+ * a locale needing a category the translator did not supply still renders.
+ */
+export function selectPlural(forms: PluralForms, count: number, locale: string): string {
+  if (count === 0 && forms.zero !== undefined) {
+    return forms.zero;
+  }
+
+  const category = getPluralRules(locale).select(count);
+  return forms[category] ?? forms.other;
+}
+
+/**
+ * Turn a key into something readable for the last-resort fallback.
+ *
+ * `projects.emptyState.title` becomes "Title"; `common.tryAgain` becomes
+ * "Try again". Not a translation, but far better than rendering a raw dotted
+ * key at the user.
+ */
+export function humaniseKey(key: string): string {
+  const segment = key.split(".").pop() ?? key;
+
+  const spaced = segment
+    .replace(/[_-]+/g, " ")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .trim()
+    .toLowerCase();
+
+  if (!spaced) return key;
+
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+export interface TranslateContext {
+  locale: string;
+  catalogue: Catalogue;
+  /** English, normally. Used when the active catalogue lacks the key. */
+  fallbackCatalogue?: Catalogue;
+  /** Called once per missing key. Wired to a dev-only console warning. */
+  onMissingKey?: (key: string, locale: string) => void;
+}
+
+/**
+ * Resolve a key to a finished string.
+ *
+ * Lookup order is active catalogue, then the fallback catalogue, then a
+ * humanised form of the key itself. It never throws and never returns an empty
+ * string, because a translation problem should degrade the copy, not blank out
+ * the UI or crash a render.
+ */
+export function translate(
+  key: string,
+  options: TranslateOptions = {},
+  context: TranslateContext,
+): string {
+  const { locale, catalogue, fallbackCatalogue, onMissingKey } = context;
+
+  let message: Message | undefined = catalogue[key];
+
+  if (message === undefined && fallbackCatalogue) {
+    message = fallbackCatalogue[key];
+  }
+
+  if (message === undefined) {
+    onMissingKey?.(key, locale);
+    return humaniseKey(key);
+  }
+
+  const { count, ...rest } = options;
+  const values: InterpolationValues = count === undefined ? rest : { ...rest, count };
+
+  if (isPluralForms(message)) {
+    if (count === undefined) {
+      // Asking for a pluralised message without a count is a caller bug.
+      // `other` is the sane guess; warning makes it findable.
+      onMissingKey?.(`${key} (missing count)`, locale);
+      return interpolate(message.other, values);
+    }
+    return interpolate(selectPlural(message, count, locale), values);
+  }
+
+  return interpolate(message, values);
+}

--- a/frontend/src/i18n/types.ts
+++ b/frontend/src/i18n/types.ts
@@ -1,0 +1,53 @@
+/**
+ * Core i18n types.
+ *
+ * Kept in their own module so the catalogues, the translator and the React
+ * layer can all import them without pulling each other in.
+ */
+
+/**
+ * Values substituted into a `{placeholder}` in a message.
+ *
+ * `undefined` is permitted so callers can pass an optional value straight
+ * through; `interpolate` leaves the placeholder visible rather than printing
+ * "undefined".
+ */
+export type InterpolationValues = Record<string, string | number | undefined>;
+
+/**
+ * A message with per-plural-category variants.
+ *
+ * Categories are the CLDR ones (`zero`, `one`, `two`, `few`, `many`, `other`)
+ * as reported by `Intl.PluralRules`. Only `other` is required — English needs
+ * `one` and `other`, Japanese needs only `other`, Polish needs four.
+ */
+export interface PluralForms {
+  zero?: string;
+  one?: string;
+  two?: string;
+  few?: string;
+  many?: string;
+  other: string;
+}
+
+/** A single catalogue entry: a plain message or a set of plural forms. */
+export type Message = string | PluralForms;
+
+/**
+ * A catalogue: flat dot-separated keys to messages.
+ *
+ * Flat rather than nested on purpose. Nesting reads nicely in the file but
+ * makes the key type a recursive conditional that is slow to check and awful
+ * to read in an editor tooltip; `keyof typeof en` on a flat object gives exact
+ * autocomplete for free.
+ */
+export type Catalogue = Record<string, Message>;
+
+/** Options accepted by `t()`. */
+export interface TranslateOptions extends InterpolationValues {
+  /**
+   * Selects a plural form and is also available as `{count}` for
+   * interpolation, so `"{count} projects"` needs no second argument.
+   */
+  count?: number;
+}

--- a/frontend/src/lib/__tests__/pwa.test.ts
+++ b/frontend/src/lib/__tests__/pwa.test.ts
@@ -1,0 +1,285 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  applyServiceWorkerUpdate,
+  registerServiceWorker,
+  shouldRegisterServiceWorker,
+  unregisterServiceWorkers,
+  watchForUpdates,
+} from "@/lib/pwa";
+
+/**
+ * Minimal stand-in for a ServiceWorker that records its listeners so a test
+ * can drive `statechange` by hand.
+ */
+function createFakeWorker(state = "installing") {
+  const listeners: Record<string, Array<() => void>> = {};
+
+  return {
+    state,
+    postMessage: vi.fn(),
+    addEventListener: vi.fn((event: string, handler: () => void) => {
+      (listeners[event] ??= []).push(handler);
+    }),
+    emit(event: string) {
+      (listeners[event] ?? []).forEach((handler) => handler());
+    },
+    setState(next: string) {
+      this.state = next;
+    },
+  };
+}
+
+function createFakeRegistration(overrides: Partial<Record<string, unknown>> = {}) {
+  const listeners: Record<string, Array<() => void>> = {};
+
+  return {
+    waiting: null,
+    installing: null,
+    unregister: vi.fn().mockResolvedValue(true),
+    addEventListener: vi.fn((event: string, handler: () => void) => {
+      (listeners[event] ??= []).push(handler);
+    }),
+    emit(event: string) {
+      (listeners[event] ?? []).forEach((handler) => handler());
+    },
+    ...overrides,
+  };
+}
+
+function installServiceWorkerMock(controller: unknown = {}) {
+  const register = vi.fn().mockResolvedValue(createFakeRegistration());
+
+  Object.defineProperty(window.navigator, "serviceWorker", {
+    configurable: true,
+    value: {
+      register,
+      controller,
+      getRegistrations: vi.fn().mockResolvedValue([]),
+      addEventListener: vi.fn(),
+    },
+  });
+
+  return register;
+}
+
+function removeServiceWorkerSupport() {
+  // `delete` does not work on a defineProperty'd value, so shadow it instead.
+  Object.defineProperty(window.navigator, "serviceWorker", {
+    configurable: true,
+    value: undefined,
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  removeServiceWorkerSupport();
+});
+
+describe("shouldRegisterServiceWorker", () => {
+  it("is false under test, where import.meta.env.PROD is false", () => {
+    installServiceWorkerMock();
+
+    expect(shouldRegisterServiceWorker()).toBe(false);
+  });
+
+  it("is true in a production build", () => {
+    installServiceWorkerMock();
+    vi.stubEnv("PROD", true);
+
+    expect(shouldRegisterServiceWorker()).toBe(true);
+  });
+
+  it("is false when the browser has no service worker support", () => {
+    removeServiceWorkerSupport();
+    vi.stubEnv("PROD", true);
+
+    expect(shouldRegisterServiceWorker()).toBe(false);
+  });
+
+  it("can be forced regardless of environment", () => {
+    expect(shouldRegisterServiceWorker(true)).toBe(true);
+  });
+});
+
+describe("registerServiceWorker", () => {
+  it("does not register outside a production build", async () => {
+    const register = installServiceWorkerMock();
+
+    const result = await registerServiceWorker();
+
+    expect(result).toBeNull();
+    expect(register).not.toHaveBeenCalled();
+  });
+
+  it("registers at the root scope when forced", async () => {
+    const register = installServiceWorkerMock();
+
+    await registerServiceWorker({ force: true });
+
+    expect(register).toHaveBeenCalledWith("/sw.js", { scope: "/" });
+  });
+
+  it("returns null instead of throwing when registration fails", async () => {
+    const register = installServiceWorkerMock();
+    register.mockRejectedValue(new Error("insecure origin"));
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(registerServiceWorker({ force: true })).resolves.toBeNull();
+  });
+
+  it("returns null when the browser has no support, even if forced", async () => {
+    removeServiceWorkerSupport();
+
+    await expect(registerServiceWorker({ force: true })).resolves.toBeNull();
+  });
+});
+
+describe("watchForUpdates", () => {
+  it("fires immediately when a worker is already waiting", () => {
+    const registration = createFakeRegistration({ waiting: createFakeWorker() });
+    const onUpdate = vi.fn();
+
+    watchForUpdates(registration as never, onUpdate);
+
+    expect(onUpdate).toHaveBeenCalledWith(registration);
+  });
+
+  it("fires when an update installs while the tab is open", () => {
+    installServiceWorkerMock({ scriptURL: "/sw.js" });
+
+    const installing = createFakeWorker();
+    const registration = createFakeRegistration({ installing });
+    const onUpdate = vi.fn();
+
+    watchForUpdates(registration as never, onUpdate);
+    registration.emit("updatefound");
+
+    installing.setState("installed");
+    installing.emit("statechange");
+
+    expect(onUpdate).toHaveBeenCalledWith(registration);
+  });
+
+  it("does not fire on a first install", () => {
+    // controller is null before any worker has ever controlled the page.
+    // Announcing an "update" to a first-time visitor would be nonsense.
+    installServiceWorkerMock(null);
+
+    const installing = createFakeWorker();
+    const registration = createFakeRegistration({ installing });
+    const onUpdate = vi.fn();
+
+    watchForUpdates(registration as never, onUpdate);
+    registration.emit("updatefound");
+
+    installing.setState("installed");
+    installing.emit("statechange");
+
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it("does not fire while the worker is still installing", () => {
+    installServiceWorkerMock({ scriptURL: "/sw.js" });
+
+    const installing = createFakeWorker("installing");
+    const registration = createFakeRegistration({ installing });
+    const onUpdate = vi.fn();
+
+    watchForUpdates(registration as never, onUpdate);
+    registration.emit("updatefound");
+    installing.emit("statechange");
+
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it("ignores an updatefound with no installing worker", () => {
+    const registration = createFakeRegistration({ installing: null });
+    const onUpdate = vi.fn();
+
+    watchForUpdates(registration as never, onUpdate);
+
+    expect(() => registration.emit("updatefound")).not.toThrow();
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe("applyServiceWorkerUpdate", () => {
+  beforeEach(() => {
+    installServiceWorkerMock();
+  });
+
+  it("tells the waiting worker to activate", () => {
+    const waiting = createFakeWorker("installed");
+    const registration = createFakeRegistration({ waiting });
+
+    applyServiceWorkerUpdate(registration as never);
+
+    expect(waiting.postMessage).toHaveBeenCalledWith("SKIP_WAITING");
+  });
+
+  it("does nothing when no worker is waiting", () => {
+    const registration = createFakeRegistration({ waiting: null });
+
+    expect(() => applyServiceWorkerUpdate(registration as never)).not.toThrow();
+    expect(window.navigator.serviceWorker.addEventListener).not.toHaveBeenCalled();
+  });
+
+  it("reloads only once, even if controllerchange fires repeatedly", () => {
+    const waiting = createFakeWorker("installed");
+    const registration = createFakeRegistration({ waiting });
+
+    const handlers: Array<() => void> = [];
+    (
+      window.navigator.serviceWorker.addEventListener as ReturnType<typeof vi.fn>
+    ).mockImplementation((event: string, handler: () => void) => {
+      if (event === "controllerchange") handlers.push(handler);
+    });
+
+    const reload = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, reload },
+    });
+
+    applyServiceWorkerUpdate(registration as never);
+
+    handlers.forEach((handler) => handler());
+    handlers.forEach((handler) => handler());
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("unregisterServiceWorkers", () => {
+  it("is a no-op without service worker support", async () => {
+    removeServiceWorkerSupport();
+
+    await expect(unregisterServiceWorkers()).resolves.toBeUndefined();
+  });
+
+  it("unregisters every registration", async () => {
+    const first = createFakeRegistration();
+    const second = createFakeRegistration();
+
+    installServiceWorkerMock();
+    (window.navigator.serviceWorker.getRegistrations as ReturnType<typeof vi.fn>).mockResolvedValue(
+      [first, second],
+    );
+
+    Object.defineProperty(window, "caches", {
+      configurable: true,
+      value: {
+        keys: vi.fn().mockResolvedValue(["devlink-assets-v1"]),
+        delete: vi.fn().mockResolvedValue(true),
+      },
+    });
+
+    await unregisterServiceWorkers();
+
+    expect(first.unregister).toHaveBeenCalled();
+    expect(second.unregister).toHaveBeenCalled();
+    expect(window.caches.delete).toHaveBeenCalledWith("devlink-assets-v1");
+  });
+});

--- a/frontend/src/lib/pwa.ts
+++ b/frontend/src/lib/pwa.ts
@@ -1,0 +1,154 @@
+/**
+ * Service worker registration.
+ *
+ * Registration is deliberately narrow: production builds only, in a browser
+ * that supports it, once per page load. A service worker in development is a
+ * reliable way to spend an afternoon debugging a stale bundle, and in tests it
+ * is simply noise.
+ */
+
+const SERVICE_WORKER_URL = "/sw.js";
+
+export type ServiceWorkerUpdateHandler = (registration: ServiceWorkerRegistration) => void;
+
+export interface RegisterServiceWorkerOptions {
+  /**
+   * Called when a new worker has installed and is waiting to take over,
+   * i.e. a new version has been deployed while this tab was open.
+   */
+  onUpdateAvailable?: ServiceWorkerUpdateHandler;
+
+  /**
+   * Register even outside a production build. Only useful when deliberately
+   * testing the worker itself.
+   */
+  force?: boolean;
+}
+
+/**
+ * The browser's service worker container, or `null` where there isn't one.
+ *
+ * Checked by truthiness rather than `"serviceWorker" in navigator`: the key
+ * can exist while holding `undefined` (jsdom, some embedded webviews, and
+ * anything that has shimmed it), and an `in` check happily passes there before
+ * blowing up on first use.
+ */
+function getServiceWorkerContainer(): ServiceWorkerContainer | null {
+  if (typeof navigator === "undefined") return null;
+  return navigator.serviceWorker ?? null;
+}
+
+/** Whether this environment should run a service worker at all. */
+export function shouldRegisterServiceWorker(force = false): boolean {
+  if (force) return true;
+  if (typeof window === "undefined") return false;
+  if (!getServiceWorkerContainer()) return false;
+
+  // import.meta.env.PROD is false in dev and under Vitest.
+  return import.meta.env.PROD === true;
+}
+
+/**
+ * Register the service worker, resolving to the registration or `null` when
+ * this environment should not have one.
+ *
+ * Never throws. A failed registration should degrade the app to "works exactly
+ * as it did before", not break boot.
+ */
+export async function registerServiceWorker(
+  options: RegisterServiceWorkerOptions = {},
+): Promise<ServiceWorkerRegistration | null> {
+  const { onUpdateAvailable, force = false } = options;
+
+  if (!shouldRegisterServiceWorker(force)) return null;
+
+  const container = getServiceWorkerContainer();
+  if (!container) return null;
+
+  try {
+    const registration = await container.register(SERVICE_WORKER_URL, {
+      scope: "/",
+    });
+
+    if (onUpdateAvailable) {
+      watchForUpdates(registration, onUpdateAvailable);
+    }
+
+    return registration;
+  } catch (error) {
+    console.warn("[pwa] Service worker registration failed:", error);
+    return null;
+  }
+}
+
+/**
+ * Watch a registration for a newly installed worker waiting to activate.
+ *
+ * Two cases have to be handled: a worker that is *already* waiting when we
+ * attach (the update finished before this code ran), and one that arrives
+ * later via `updatefound`.
+ */
+export function watchForUpdates(
+  registration: ServiceWorkerRegistration,
+  onUpdateAvailable: ServiceWorkerUpdateHandler,
+): void {
+  if (registration.waiting) {
+    onUpdateAvailable(registration);
+    return;
+  }
+
+  registration.addEventListener("updatefound", () => {
+    const installing = registration.installing;
+    if (!installing) return;
+
+    installing.addEventListener("statechange", () => {
+      // `controller` is null on the very first install. Without this check
+      // every first-time visitor would be told an update is available.
+      if (installing.state === "installed" && getServiceWorkerContainer()?.controller) {
+        onUpdateAvailable(registration);
+      }
+    });
+  });
+}
+
+/**
+ * Tell a waiting worker to activate, then reload so the page is controlled by
+ * the new version.
+ */
+export function applyServiceWorkerUpdate(registration: ServiceWorkerRegistration): void {
+  if (!registration.waiting) return;
+
+  const container = getServiceWorkerContainer();
+  if (!container) return;
+
+  registration.waiting.postMessage("SKIP_WAITING");
+
+  // `controllerchange` fires once the new worker takes over. Guarding with a
+  // flag because Chrome can fire it more than once, and a reload loop is a
+  // spectacularly bad failure mode.
+  let reloading = false;
+  container.addEventListener("controllerchange", () => {
+    if (reloading) return;
+    reloading = true;
+    window.location.reload();
+  });
+}
+
+/**
+ * Unregister every service worker and drop the caches.
+ *
+ * Not called by the app; kept as the escape hatch for when a bad worker gets
+ * shipped and a user needs to be talked out of it from the console.
+ */
+export async function unregisterServiceWorkers(): Promise<void> {
+  const container = getServiceWorkerContainer();
+  if (!container) return;
+
+  const registrations = await container.getRegistrations();
+  await Promise.all(registrations.map((registration) => registration.unregister()));
+
+  if (typeof caches !== "undefined") {
+    const keys = await caches.keys();
+    await Promise.all(keys.map((key) => caches.delete(key)));
+  }
+}

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -12,6 +12,7 @@ import { AnimatePresence } from "framer-motion";
 import { useEffect, useRef, type ReactNode } from "react";
 import { Toaster } from "sonner";
 import { ThemeProvider } from "@/context/ThemeContext";
+import { I18nProvider } from "@/context/I18nContext";
 
 import appCss from "../styles.css?url";
 import { reportLovableError } from "../lib/lovable-error-reporting";
@@ -76,6 +77,17 @@ function NotFoundComponent() {
   );
 }
 
+/**
+ * The root route's errorComponent and notFoundComponent replace RootComponent
+ * rather than rendering inside it, so anything they show sits outside the
+ * providers. The error pages call useTranslation(), so they need their own
+ * I18nProvider — without it an API 401 would surface as a provider error
+ * instead of the sign-in page.
+ */
+function OutsideRootProviders({ children }: { children: ReactNode }) {
+  return <I18nProvider>{children}</I18nProvider>;
+}
+
 function ErrorComponent({ error, reset }: { error: Error; reset: () => void }) {
   console.error(error);
   const router = useRouter();
@@ -85,15 +97,27 @@ function ErrorComponent({ error, reset }: { error: Error; reset: () => void }) {
 
   if (error instanceof ApiError) {
     if (error.status === 401) {
-      return <UnauthorizedPage />;
+      return (
+        <OutsideRootProviders>
+          <UnauthorizedPage />
+        </OutsideRootProviders>
+      );
     }
 
     if (error.status === 403) {
-      return <ForbiddenPage />;
+      return (
+        <OutsideRootProviders>
+          <ForbiddenPage />
+        </OutsideRootProviders>
+      );
     }
 
     if (error.status >= 500) {
-      return <ServerErrorPage />;
+      return (
+        <OutsideRootProviders>
+          <ServerErrorPage />
+        </OutsideRootProviders>
+      );
     }
 
     // status 0  -> fetch/network failure (coreFetch's catch block)
@@ -103,7 +127,11 @@ function ErrorComponent({ error, reset }: { error: Error; reset: () => void }) {
       // navigator is undefined during SSR; assume online in that case so we
       // don't render OfflinePage on the server for a purely client-side signal.
       const isOnline = typeof navigator === "undefined" ? true : navigator.onLine;
-      return isOnline ? <NetworkErrorPage /> : <OfflinePage />;
+      return (
+        <OutsideRootProviders>
+          {isOnline ? <NetworkErrorPage /> : <OfflinePage />}
+        </OutsideRootProviders>
+      );
     }
   }
 
@@ -188,14 +216,16 @@ function RootComponent() {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider defaultTheme="system">
-        <Outlet />
+      <I18nProvider>
+        <ThemeProvider defaultTheme="system">
+          <Outlet />
+          <Toaster position="top-right" richColors />
+        </ThemeProvider>
+        <AnimatePresence mode="wait" initial={false}>
+          <Outlet key={location.pathname} />
+        </AnimatePresence>
         <Toaster position="top-right" richColors />
-      </ThemeProvider>
-      <AnimatePresence mode="wait" initial={false}>
-        <Outlet key={location.pathname} />
-      </AnimatePresence>
-      <Toaster position="top-right" richColors />
+      </I18nProvider>
     </QueryClientProvider>
   );
 }

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -10,8 +10,10 @@ import {
 } from "@tanstack/react-router";
 import { AnimatePresence } from "framer-motion";
 import { useEffect, useRef, type ReactNode } from "react";
-import { Toaster } from "sonner";
+import { Toaster, toast } from "sonner";
 import { ThemeProvider } from "@/context/ThemeContext";
+import { OfflineBanner } from "@/components/OfflineBanner";
+import { applyServiceWorkerUpdate, registerServiceWorker } from "@/lib/pwa";
 
 import appCss from "../styles.css?url";
 import { reportLovableError } from "../lib/lovable-error-reporting";
@@ -159,8 +161,22 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
       },
       { property: "og:type", content: "website" },
       { name: "twitter:card", content: "summary_large_image" },
+      // Colours the browser/OS chrome when installed, and matches the
+      // manifest's theme_color.
+      { name: "theme-color", content: "#05b7d7" },
+      { name: "apple-mobile-web-app-capable", content: "yes" },
+      { name: "apple-mobile-web-app-title", content: "DevLink" },
+      {
+        name: "apple-mobile-web-app-status-bar-style",
+        content: "black-translucent",
+      },
     ],
-    links: [{ rel: "stylesheet", href: appCss }],
+    links: [
+      { rel: "stylesheet", href: appCss },
+      { rel: "manifest", href: "/manifest.webmanifest" },
+      { rel: "icon", type: "image/svg+xml", href: "/icons/icon.svg" },
+      { rel: "apple-touch-icon", href: "/icons/icon.svg" },
+    ],
   }),
   shellComponent: RootShell,
   component: RootComponent,
@@ -186,9 +202,25 @@ function RootComponent() {
   const { queryClient } = Route.useRouteContext();
   const location = useRouterState({ select: (s) => s.location });
 
+  useEffect(() => {
+    // No-ops outside a production browser build; see src/lib/pwa.ts.
+    void registerServiceWorker({
+      onUpdateAvailable: (registration) => {
+        toast("A new version of DevLink is available.", {
+          duration: Infinity,
+          action: {
+            label: "Reload",
+            onClick: () => applyServiceWorkerUpdate(registration),
+          },
+        });
+      },
+    });
+  }, []);
+
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider defaultTheme="system">
+        <OfflineBanner />
         <Outlet />
         <Toaster position="top-right" richColors />
       </ThemeProvider>


### PR DESCRIPTION
# Pull Request

## Summary

Every user-facing string in the frontend is a hard-coded English literal. There is no i18n library, no locale files, and dates and numbers are formatted with US conventions regardless of the browser's locale — a user on `de-DE` sees `1,234.5` where they expect `1.234,5`.

This adds the foundation, plus one screen migrated end-to-end to prove the pattern.

Retro-fitting i18n once there are thousands of literals is dramatically more painful than putting the plumbing in now, and a large share of this project's contributors are not native English speakers.

---

## Related Issue

Closes #858

---

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [x] UI/UX enhancement
- [x] Tests
- [ ] Other

---

## Changes Made

| Path | Purpose |
| :--- | :--- |
| `src/i18n/types.ts` | `Catalogue`, `PluralForms`, option types |
| `src/i18n/translate.ts` | Resolution, interpolation, pluralisation (pure) |
| `src/i18n/format.ts` | `Intl` wrappers for dates, relative times, numbers |
| `src/i18n/locales/en.ts` | English — the source of truth |
| `src/i18n/locales/es.ts` | Spanish — worked reference |
| `src/i18n/locales/index.ts` | Registry and BCP-47 tag resolution |
| `src/context/I18nContext.tsx` | `I18nProvider`, `useTranslation()` |
| `src/components/LanguageSwitcher.tsx` | The picker |
| `src/components/errors/*` | Migrated end-to-end |
| `docs/i18n.md` | How to add strings and languages |

### Why not `react-i18next`

What we need today is key lookup, `{placeholder}` interpolation, plural selection and `Intl` formatting — a few hundred lines. `react-i18next` is a sizeable dependency with a plugin system, backend adapters and an initialisation dance we would not use.

If requirements grow past this (ICU syntax, lazy namespaces, a TMS integration), swapping a library in behind the same `useTranslation()` surface is contained. Starting *with* the library is the harder thing to reverse.

### Flat keys, not nested

Nesting reads nicely in the file but makes the key type a recursive conditional — slow to check and unreadable in an editor tooltip. `keyof typeof en` on a flat object is exact and instant, so `t("typo.key")` is a compile error and autocomplete works.

---

## Two things the tests caught

**1. The `zero` plural form silently never fired.**

English has no `zero` CLDR category — `Intl.PluralRules("en").select(0)` returns `other`. Following that strictly meant a translator who wrote `zero: "No unread notifications"` never saw it and got "0 unread notifications" instead.

Writing a `zero` form is an unambiguous statement of intent, so it now wins at `count === 0` in every locale. This is a deliberate, documented deviation from CLDR — everything else follows `Intl.PluralRules` exactly. Flagging it explicitly since it's the one place this diverges from the spec.

**2. The error pages render outside the providers.**

The root route's `errorComponent` and `notFoundComponent` **replace** `RootComponent` rather than rendering inside it. Since the migrated error pages call `useTranslation()`, an API 401 would have surfaced as *"useTranslation must be used within an I18nProvider"* instead of the sign-in page. `__root.tsx` now wraps them via `OutsideRootProviders`.

This is exactly why the PR migrates a real screen rather than only shipping the mechanism — the wiring problem was invisible until something actually consumed it.

---

## Design notes

- **Fallback chain:** active catalogue → English → a humanised key (`projects.emptyState.title` → "Title"). `t()` never throws and never returns `""` — a translation problem should degrade the copy, not blank the UI.
- **Unknown placeholders stay visible.** A stray `{userName}` on screen is an obvious bug report; the string "undefined" is a confusing one.
- **`useTranslation()` throws outside a provider** rather than quietly defaulting to English, which would hide the wiring bug until a non-English user reported it.
- **`formatPercent` takes a 0–1 ratio**, not an already-multiplied number, so callers cannot disagree about whether `50` means 50% or 5000%.
- **Formatters are cached** — `Intl` construction is expensive relative to how often we format — and every one degrades to `en` on a malformed locale tag, so a bad `localStorage` value cannot blank a page.
- `<html lang>` follows the active locale, which screen readers use to pick a voice.

---

## Testing

- [x] Tested locally
- [x] Existing tests pass
- [x] Added new tests
- [x] UI verified
- [ ] Cross-browser tested (if applicable)

Additional testing notes:

**New tests — 73 passed** across three files:

- `translate.test.ts` — interpolation (repeats, whitespace, numbers, unknown and `undefined` values), plural selection including the Japanese `other`-only case and a malformed tag, key humanisation, the full fallback chain, and the plural-without-count warning.
- `format.test.ts` — locale-dependent grouping/decimals, compact notation, relative time in English and Spanish, the `numeric: "auto"` "yesterday" case, unit selection, and the non-finite / unparseable guards.
- `I18nContext.test.tsx` — detection precedence, walking `navigator.languages` past unsupported entries, rejecting an unsupported stored value, persistence, surviving a throwing `localStorage` (Safari private mode), `<html lang>` updates, live locale switching, English fallback for a key Spanish lacks, and the throw-outside-provider case.

Three of these are **catalogue invariants** rather than unit tests, and will keep future locales honest: every non-English key must exist in English, every plural entry must define `other`, and a translated string's `{placeholders}` must match the English original.

**Full suite:** 296 → 369 passed. The delta is exactly the 73 new tests. (Four test *files* fail on both sides — Playwright e2e specs vitest picks up. Pre-existing and unrelated.)

**Typecheck:** 37 errors before, 37 after — all pre-existing, none in files this PR touches.

**Lint:** clean. `I18nContext.tsx` emits the same `react-refresh/only-export-components` warning that the existing `ThemeContext.tsx` does, which is inherent to a context file exporting both a provider and its hook.

---

## Checklist

- [x] My code follows the project's coding standards.
- [x] I have tested my changes locally.
- [x] I have updated the documentation where necessary.
- [x] My changes do not introduce new warnings or errors.
- [x] I have reviewed my own code.
- [x] This pull request focuses on a single feature or fix.
- [x] I have linked the related issue.

---

## Merge order

> **This branch has #862 merged into it.** Both PRs wire themselves into `src/routes/__root.tsx` — the import block and the provider tree — so they collided. Both hunks were purely additive and the resolution keeps everything from each side:
>
> ```tsx
> <I18nProvider>
>   <ThemeProvider defaultTheme="system">
>     <OfflineBanner />
>     ...
> ```
>
> `I18nProvider` sits outside `ThemeProvider` so anything under the theme can translate. `OfflineBanner` does not consume i18n today, but that is where it will need to be once its copy is migrated.
>
> **Please merge #862 first.** Once it lands, this PR's diff collapses to only the i18n changes. Verified in a combined worktree with all five PRs merged: 394 tests pass, typecheck and lint unchanged from baseline.

---

## Additional Notes

**No visible change for English users.** The migrated error pages render exactly the copy they rendered before; the strings just come from a catalogue now.

Spanish deliberately omits `notifications.unread` so the English fallback is covered by a test rather than assumed. Machine-assisted and worth a native review before anyone relies on it.

The rest of the app still has hard-coded literals. Migrating a screen is: add its strings to `en.ts`, swap the literals for `t()`. That can happen incrementally, one screen per PR, and does not need to block this.

`LanguageSwitcher` is not mounted in the settings page yet — that touches a screen this PR otherwise leaves alone, and belongs with the settings work in #574.
