### PR TITLE
feat: add a link preview service with SSRF protection

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -287,6 +287,37 @@ class Settings(BaseSettings):
     ENABLE_APPLICATIONS: bool = True
 
     # ==========================================================
+    # Link Previews
+    # ==========================================================
+
+    # Short, because a preview is a nice-to-have sitting in front of a user
+    # waiting for a message to send. A slow site gets no card rather than a
+    # slow card.
+    LINK_PREVIEW_TIMEOUT_SECONDS: float = 5.0
+
+    # Everything we want lives in <head>. 512 KiB is generous for that and
+    # bounds what a hostile server can make us buffer.
+    LINK_PREVIEW_MAX_BYTES: int = 512 * 1024
+
+    # Each hop is re-validated against the SSRF rules, so this is a cost
+    # ceiling rather than a safety one.
+    LINK_PREVIEW_MAX_REDIRECTS: int = 3
+
+    # A day: Open Graph tags change rarely, and a stale title is a much smaller
+    # problem than re-fetching a popular link for every reader.
+    LINK_PREVIEW_CACHE_TTL_SECONDS: int = 86400
+
+    # Failures are cached far more briefly, so a site that was down for five
+    # minutes is not written off for a day.
+    LINK_PREVIEW_FAILURE_CACHE_TTL_SECONDS: int = 300
+
+    # Identifying ourselves honestly, with a contact URL, is what lets a site
+    # owner rate-limit us instead of silently blackholing us.
+    LINK_PREVIEW_USER_AGENT: str = (
+        "DevLinkBot/1.0 (+https://github.com/nensii21/devlink)"
+    )
+
+    # ==========================================================
     # Helper Properties
     # ==========================================================
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -516,6 +516,9 @@ from app.routers import (
 
 
 app.include_router(media.router, prefix="/api", tags=["Media"])
+from app.routers import link_previews
+
+app.include_router(link_previews.router, prefix="/api", tags=["Link Previews"])
 app.include_router(auth.router, prefix="/api/auth", tags=["Authentication"])
 from app.routers import mfa
 app.include_router(mfa.router, prefix="/api")

--- a/backend/app/routers/link_previews.py
+++ b/backend/app/routers/link_previews.py
@@ -1,0 +1,116 @@
+"""
+Link preview endpoints.
+
+Both are authenticated and rate limited. That is not incidental: this is an
+endpoint whose whole job is to make our server fetch a URL somebody else chose,
+which makes it an outbound-request amplifier. Anonymous access would turn it
+into an open proxy, and an unlimited rate would turn it into a way to point our
+egress bandwidth at a third party.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+
+from app.dependencies import get_current_user
+from app.middleware.rate_limit import limiter
+from app.models.user import User
+from app.schemas.link_preview import (
+    LinkPreviewBatchItem,
+    LinkPreviewBatchRequest,
+    LinkPreviewBatchResponse,
+    LinkPreviewResponse,
+)
+from app.services.link_preview_service import link_preview_service
+from app.utils.url_safety import UnsafeURL
+
+router = APIRouter(
+    prefix="/link-previews",
+    tags=["Link Previews"],
+)
+
+# Deliberately tighter than the general read limit. Each call is an outbound
+# request to a third party, and the batch endpoint multiplies that by ten.
+LINK_PREVIEW_LIMIT = "30/minute"
+LINK_PREVIEW_BATCH_LIMIT = "10/minute"
+
+
+@router.get(
+    "",
+    response_model=LinkPreviewResponse,
+    summary="Preview a single URL",
+)
+@limiter.limit(LINK_PREVIEW_LIMIT)
+def get_link_preview(
+    request: Request,
+    url: str = Query(description="The http(s) URL to fetch metadata for."),
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Fetch Open Graph metadata for a URL.
+
+    Returns 400 when the URL is one we refuse to fetch (wrong scheme, private
+    address, disallowed port) and 404 when it is fetchable but yielded nothing
+    usable -- it was unreachable, it timed out, or it did not serve HTML.
+    """
+    try:
+        preview = link_preview_service.preview(url)
+    except UnsafeURL as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+    if preview is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No preview could be generated for that URL.",
+        )
+
+    return LinkPreviewResponse(**preview.as_dict())
+
+
+@router.post(
+    "/batch",
+    response_model=LinkPreviewBatchResponse,
+    summary="Preview several URLs at once",
+)
+@limiter.limit(LINK_PREVIEW_BATCH_LIMIT)
+def get_link_previews(
+    request: Request,
+    body: LinkPreviewBatchRequest,
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Fetch metadata for up to ten URLs.
+
+    Always 200. A URL that could not be previewed comes back with an ``error``
+    string instead of a ``preview``, so one dead link in a message does not
+    cost the reader every other card in it.
+    """
+    results: list[LinkPreviewBatchItem] = []
+
+    for url in body.urls:
+        try:
+            preview = link_preview_service.preview(url)
+        except UnsafeURL as exc:
+            results.append(LinkPreviewBatchItem(url=url, error=str(exc)))
+            continue
+
+        if preview is None:
+            results.append(
+                LinkPreviewBatchItem(
+                    url=url,
+                    error="No preview could be generated for that URL.",
+                )
+            )
+            continue
+
+        results.append(
+            LinkPreviewBatchItem(
+                url=url,
+                preview=LinkPreviewResponse(**preview.as_dict()),
+            )
+        )
+
+    return LinkPreviewBatchResponse(results=results)

--- a/backend/app/schemas/link_preview.py
+++ b/backend/app/schemas/link_preview.py
@@ -1,0 +1,67 @@
+"""Request and response shapes for the link preview endpoints."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+# A batch is capped because each entry is an outbound request. Without a limit
+# one authenticated caller could turn a single request to us into hundreds of
+# requests to somebody else.
+MAX_BATCH_SIZE = 10
+
+
+class LinkPreviewResponse(BaseModel):
+    """Metadata for a single URL."""
+
+    url: str = Field(description="The URL as it was submitted.")
+    final_url: str = Field(
+        description="Where the URL ended up after redirects, or the page's own canonical URL if it declares one.",
+    )
+    title: Optional[str] = None
+    description: Optional[str] = None
+    site_name: Optional[str] = None
+    image_url: Optional[str] = None
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "url": "https://example.com/blog/shipping-faster",
+                "final_url": "https://example.com/blog/shipping-faster",
+                "title": "Shipping faster without breaking things",
+                "description": "How we cut our deploy time from 40 minutes to 4.",
+                "site_name": "Example Engineering",
+                "image_url": "https://example.com/img/shipping.png",
+            }
+        }
+    }
+
+
+class LinkPreviewBatchRequest(BaseModel):
+    """A handful of URLs to preview in one round trip."""
+
+    urls: list[str] = Field(
+        min_length=1,
+        max_length=MAX_BATCH_SIZE,
+        description=f"Between 1 and {MAX_BATCH_SIZE} URLs.",
+    )
+
+
+class LinkPreviewBatchItem(BaseModel):
+    """
+    One result within a batch.
+
+    A batch never fails as a whole. An entry that could not be previewed --
+    because the URL was refused, or the site was down, or it served something
+    that was not HTML -- comes back with ``preview`` unset and a reason, so the
+    client can render the remaining cards and leave that one as a plain link.
+    """
+
+    url: str
+    preview: Optional[LinkPreviewResponse] = None
+    error: Optional[str] = None
+
+
+class LinkPreviewBatchResponse(BaseModel):
+    results: list[LinkPreviewBatchItem]

--- a/backend/app/services/link_preview_service.py
+++ b/backend/app/services/link_preview_service.py
@@ -1,0 +1,356 @@
+"""
+Turning a pasted URL into a preview card.
+
+The metadata side of this is simple: read Open Graph tags, fall back to Twitter
+card tags, fall back to the plain ``<title>``. The part that needs care is
+everything around it, because fetching a URL chosen by a user means the caller
+is steering our outbound HTTP client.
+
+The rules this module enforces on every fetch:
+
+* the destination is validated before we connect (see ``utils.url_safety``),
+  and re-validated at every redirect hop -- following redirects automatically
+  would let a public URL bounce us to ``169.254.169.254``
+* the body is streamed and abandoned once it exceeds a byte cap, so a hostile
+  server cannot make us buffer a gigabyte
+* only HTML content types are parsed
+* connect and read timeouts are short, and the hop count is bounded
+
+Results are cached, negative results too, because a link pasted into a busy
+conversation is otherwise fetched once per reader.
+"""
+
+from __future__ import annotations
+
+import html
+import logging
+import re
+from dataclasses import asdict, dataclass
+from typing import Optional
+from urllib.parse import urljoin
+
+import httpx
+
+from app.core.cache import cache_manager
+from app.core.config import settings
+from app.utils.url_safety import (
+    UnsafeURL,
+    normalise_url,
+    validate_outbound_url,
+)
+
+logger = logging.getLogger(__name__)
+
+_CACHE_PREFIX = "linkpreview:"
+_FAILURE_SENTINEL = {"__failed__": True}
+
+# Matches a <meta> tag and captures the whole attribute blob, which is then
+# picked apart separately. Doing it in one regex with fixed attribute order
+# fails on the very common `content="..." property="..."` spelling.
+_META_TAG = re.compile(r"<meta\b([^>]*)>", re.IGNORECASE)
+_ATTRIBUTE = re.compile(
+    r"""(\w[\w:.-]*)\s*=\s*("([^"]*)"|'([^']*)'|([^\s"'>]+))""",
+    re.IGNORECASE | re.VERBOSE,
+)
+_TITLE_TAG = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
+
+# Anything past these lengths is decoration. Truncating here keeps the cache
+# entries small and stops a hostile page pushing megabytes into our responses.
+MAX_TITLE_LENGTH = 200
+MAX_DESCRIPTION_LENGTH = 500
+MAX_SITE_NAME_LENGTH = 100
+
+HTML_CONTENT_TYPES = ("text/html", "application/xhtml+xml")
+
+
+@dataclass(frozen=True)
+class LinkPreview:
+    """What we managed to learn about a URL."""
+
+    url: str
+    final_url: str
+    title: Optional[str] = None
+    description: Optional[str] = None
+    site_name: Optional[str] = None
+    image_url: Optional[str] = None
+
+    def as_dict(self) -> dict:
+        return asdict(self)
+
+
+class LinkPreviewService:
+    """
+    Fetch and parse link metadata.
+
+    Stateless apart from the shared cache; a module-level singleton is provided
+    at the bottom of the file.
+    """
+
+    def __init__(
+        self,
+        timeout: Optional[float] = None,
+        max_bytes: Optional[int] = None,
+        max_redirects: Optional[int] = None,
+    ) -> None:
+        self.timeout = (
+            timeout if timeout is not None else settings.LINK_PREVIEW_TIMEOUT_SECONDS
+        )
+        self.max_bytes = (
+            max_bytes if max_bytes is not None else settings.LINK_PREVIEW_MAX_BYTES
+        )
+        self.max_redirects = (
+            max_redirects
+            if max_redirects is not None
+            else settings.LINK_PREVIEW_MAX_REDIRECTS
+        )
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def preview(self, url: str, *, use_cache: bool = True) -> Optional[LinkPreview]:
+        """
+        Metadata for a URL, or ``None`` if it could not be previewed.
+
+        Raises :class:`UnsafeURL` when the URL is one we refuse to fetch --
+        that is a client error worth reporting, unlike a timeout, which is
+        just an absent preview.
+        """
+        target = validate_outbound_url(url)
+
+        cache_key = _CACHE_PREFIX + normalise_url(target.url)
+
+        if use_cache:
+            cached = cache_manager.get(cache_key)
+            if cached == _FAILURE_SENTINEL:
+                return None
+            if cached is not None:
+                return LinkPreview(**cached)
+
+        fetched = self._fetch_html(target.url)
+        if fetched is None:
+            cache_manager.set(
+                cache_key,
+                _FAILURE_SENTINEL,
+                ttl=settings.LINK_PREVIEW_FAILURE_CACHE_TTL_SECONDS,
+            )
+            return None
+
+        body, final_url = fetched
+        preview = self._parse(body, requested_url=url, final_url=final_url)
+
+        cache_manager.set(
+            cache_key,
+            preview.as_dict(),
+            ttl=settings.LINK_PREVIEW_CACHE_TTL_SECONDS,
+        )
+        return preview
+
+    def preview_many(self, urls: list[str]) -> dict[str, Optional[LinkPreview]]:
+        """
+        Preview several URLs, keyed by the URL as it was given to us.
+
+        One bad link does not fail the batch: an unsafe or unreachable URL maps
+        to ``None`` and the rest are still returned.
+        """
+        results: dict[str, Optional[LinkPreview]] = {}
+
+        for url in urls:
+            if url in results:
+                continue
+            try:
+                results[url] = self.preview(url)
+            except UnsafeURL:
+                results[url] = None
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Fetching
+    # ------------------------------------------------------------------
+
+    def _fetch_html(self, url: str) -> Optional[tuple[str, str]]:
+        """
+        Fetch a URL and return ``(body, final_url)``, or ``None`` on failure.
+
+        Redirects are followed by hand so that every hop goes back through
+        :func:`validate_outbound_url`. ``httpx``'s own redirect following would
+        happily walk us onto the metadata service.
+        """
+        current = url
+
+        try:
+            with httpx.Client(
+                timeout=self.timeout,
+                follow_redirects=False,
+                headers={
+                    "User-Agent": settings.LINK_PREVIEW_USER_AGENT,
+                    # Some sites serve a stripped page to clients that do not
+                    # ask for HTML.
+                    "Accept": "text/html,application/xhtml+xml",
+                },
+            ) as client:
+                for _ in range(self.max_redirects + 1):
+                    with client.stream("GET", current) as response:
+                        if response.is_redirect:
+                            location = response.headers.get("location")
+                            if not location:
+                                return None
+
+                            # Relative redirects are legal and common.
+                            current = urljoin(current, location)
+
+                            # The whole point of doing this by hand.
+                            validate_outbound_url(current)
+                            continue
+
+                        if response.status_code >= 400:
+                            return None
+
+                        content_type = response.headers.get("content-type", "")
+                        if not any(
+                            content_type.lower().startswith(t)
+                            for t in HTML_CONTENT_TYPES
+                        ):
+                            return None
+
+                        body = self._read_capped(response)
+                        return body, str(response.url)
+
+        except UnsafeURL:
+            # A redirect walked somewhere we will not follow. Treat it as an
+            # absent preview rather than an error: the user pasted a URL that
+            # was fine, and what happened after that is not their fault.
+            logger.info("Link preview redirect rejected for %s", url)
+            return None
+        except httpx.HTTPError as exc:
+            logger.info("Link preview fetch failed for %s: %s", url, exc)
+            return None
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Unexpected link preview error for %s: %s", url, exc)
+            return None
+
+        # Ran out of redirect budget.
+        return None
+
+    def _read_capped(self, response: httpx.Response) -> str:
+        """
+        Read at most ``max_bytes`` of a streaming response.
+
+        The metadata we want lives in ``<head>``, so the cap costs us nothing
+        on a well-formed page and protects us from a server that streams
+        forever. Decoding is lenient because plenty of real pages declare one
+        encoding and serve another.
+        """
+        chunks: list[bytes] = []
+        total = 0
+
+        for chunk in response.iter_bytes():
+            chunks.append(chunk)
+            total += len(chunk)
+            if total >= self.max_bytes:
+                break
+
+        raw = b"".join(chunks)[: self.max_bytes]
+        return raw.decode(response.encoding or "utf-8", errors="replace")
+
+    # ------------------------------------------------------------------
+    # Parsing
+    # ------------------------------------------------------------------
+
+    def _parse(self, body: str, *, requested_url: str, final_url: str) -> LinkPreview:
+        """Pull metadata out of an HTML document."""
+        meta = self._collect_meta(body)
+
+        title = (
+            meta.get("og:title")
+            or meta.get("twitter:title")
+            or self._document_title(body)
+        )
+        description = (
+            meta.get("og:description")
+            or meta.get("twitter:description")
+            or meta.get("description")
+        )
+        site_name = meta.get("og:site_name") or meta.get("application-name")
+        image = meta.get("og:image") or meta.get("twitter:image")
+
+        # og:url is the page's own canonical spelling of itself, which is a
+        # better thing to link to than whatever redirect chain we followed.
+        canonical = meta.get("og:url") or final_url
+
+        return LinkPreview(
+            url=requested_url,
+            final_url=canonical,
+            title=_clean(title, MAX_TITLE_LENGTH),
+            description=_clean(description, MAX_DESCRIPTION_LENGTH),
+            site_name=_clean(site_name, MAX_SITE_NAME_LENGTH),
+            # Relative image paths resolve against the page we actually landed
+            # on, not against the URL that was originally submitted.
+            image_url=urljoin(final_url, image) if image else None,
+        )
+
+    @staticmethod
+    def _collect_meta(body: str) -> dict[str, str]:
+        """
+        Every ``<meta>`` tag, keyed by ``property`` or ``name``.
+
+        The first occurrence of a key wins, which matches how browsers and
+        crawlers treat duplicate Open Graph tags.
+        """
+        found: dict[str, str] = {}
+
+        for match in _META_TAG.finditer(body):
+            attributes = {}
+            for attr in _ATTRIBUTE.finditer(match.group(1)):
+                value = attr.group(3) or attr.group(4) or attr.group(5) or ""
+                attributes[attr.group(1).lower()] = value
+
+            key = attributes.get("property") or attributes.get("name")
+            content = attributes.get("content")
+
+            if not key or content is None:
+                continue
+
+            found.setdefault(key.lower(), content)
+
+        return found
+
+    @staticmethod
+    def _document_title(body: str) -> Optional[str]:
+        match = _TITLE_TAG.search(body)
+        return match.group(1) if match else None
+
+
+def _clean(value: Optional[str], max_length: int) -> Optional[str]:
+    """
+    Normalise a scrap of text pulled out of a page.
+
+    Entities are decoded (``&amp;`` really is meant to be ``&``), whitespace is
+    collapsed because these tags are frequently pretty-printed across lines,
+    and the result is truncated on a word boundary where one is nearby.
+    """
+    if value is None:
+        return None
+
+    text = html.unescape(value)
+    text = " ".join(text.split())
+
+    if not text:
+        return None
+
+    if len(text) <= max_length:
+        return text
+
+    truncated = text[:max_length]
+    last_space = truncated.rfind(" ")
+
+    # Only back up to a word boundary if it is close to the end; otherwise a
+    # long unbroken token would shrink the text dramatically.
+    if last_space > max_length * 0.8:
+        truncated = truncated[:last_space]
+
+    return truncated.rstrip() + "…"
+
+
+link_preview_service = LinkPreviewService()

--- a/backend/app/utils/url_safety.py
+++ b/backend/app/utils/url_safety.py
@@ -1,0 +1,232 @@
+"""
+Deciding whether it is safe for the server to fetch a URL a user gave us.
+
+Any endpoint that takes a URL from a request and fetches it turns this service
+into a proxy that sits *inside* the network perimeter. Left unguarded that is a
+server-side request forgery hole: the caller gets to read the cloud metadata
+endpoint, the internal admin panel on ``localhost:9000``, and every database
+port on the private subnet, all with our source address and our credentials.
+
+The guard here is deliberately conservative. It refuses anything it cannot
+prove is a public destination, because the cost of a false negative is a
+credential leak and the cost of a false positive is one link that does not get
+a preview card.
+
+Two things it does that the obvious implementation does not:
+
+* It resolves the hostname and inspects the **resolved addresses**, not the
+  hostname string. ``127.0.0.1.nip.io`` is a perfectly ordinary public name
+  that resolves to loopback, and there is a whole family of such services.
+* It exposes the resolved addresses to the caller, so a fetch can be re-checked
+  at every redirect hop. A URL that passes on hop one and 302s to
+  ``http://169.254.169.254/`` must fail on hop two.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from dataclasses import dataclass
+from typing import Iterable, Optional
+from urllib.parse import urlparse, urlunparse
+
+# Only these two ever make sense for a link somebody pasted into a message.
+# `file:` reads our disk, `gopher:` and `dict:` are classic SSRF gadgets for
+# speaking other protocols through an HTTP client.
+ALLOWED_SCHEMES = frozenset({"http", "https"})
+
+# Ports the fetch is allowed to reach. Restricting these is what stops a
+# "public" hostname being pointed at, say, a Redis instance that happens to be
+# internet-exposed.
+ALLOWED_PORTS = frozenset({80, 443, 8080, 8443})
+
+DEFAULT_PORTS = {"http": 80, "https": 443}
+
+MAX_URL_LENGTH = 2048
+
+
+class UnsafeURL(ValueError):
+    """
+    Raised when a URL must not be fetched.
+
+    The message is written to be shown to the person who submitted the link.
+    It says which rule was broken but never leaks what was found behind it --
+    "that host resolves to a private address" is fine, echoing the address back
+    would itself be an information leak about our network.
+    """
+
+
+@dataclass(frozen=True)
+class SafeTarget:
+    """A URL that passed every check, plus what it resolved to."""
+
+    url: str
+    scheme: str
+    host: str
+    port: int
+    addresses: tuple[str, ...]
+
+
+def _is_public_address(address: str) -> bool:
+    """
+    Whether an IP is one we are willing to connect out to.
+
+    ``is_global`` covers most of this, but it is worth being explicit about the
+    categories, because the interesting ones for SSRF are exactly the ones an
+    attacker reaches for:
+
+    * loopback -- ``127.0.0.0/8``, ``::1``: our own admin surfaces
+    * link-local -- ``169.254.0.0/16``, ``fe80::/10``: cloud metadata
+    * private -- RFC 1918 and ``fc00::/7``: the rest of the internal network
+    * reserved / unspecified / multicast: nothing good lives here
+    """
+    try:
+        ip = ipaddress.ip_address(address)
+    except ValueError:
+        # If it does not parse as an address we cannot reason about it, so we
+        # refuse rather than guess.
+        return False
+
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        # ::ffff:127.0.0.1 is loopback wearing a hat.
+        ip = ip.ipv4_mapped
+
+    if (
+        ip.is_loopback
+        or ip.is_link_local
+        or ip.is_private
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    ):
+        return False
+
+    return ip.is_global
+
+
+def _resolve(host: str) -> tuple[str, ...]:
+    """
+    Every address a hostname resolves to, both families.
+
+    All of them matter. A name with one public A record and one private AAAA
+    record is a working attack if we only check the first answer, since which
+    one the HTTP client picks is not something this function controls.
+    """
+    try:
+        infos = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as exc:
+        raise UnsafeURL(f"Could not resolve host: {host}") from exc
+
+    addresses = {info[4][0] for info in infos}
+    if not addresses:
+        raise UnsafeURL(f"Could not resolve host: {host}")
+
+    return tuple(sorted(addresses))
+
+
+def validate_outbound_url(
+    url: str,
+    *,
+    resolver=_resolve,
+) -> SafeTarget:
+    """
+    Check a URL and return the target to connect to.
+
+    ``resolver`` is injectable so the rules can be tested without a network and
+    without depending on whatever the test machine's DNS happens to say today.
+
+    Raises :class:`UnsafeURL` with a user-facing message on any failure.
+    """
+    if not url or not url.strip():
+        raise UnsafeURL("No URL was provided.")
+
+    url = url.strip()
+
+    if len(url) > MAX_URL_LENGTH:
+        raise UnsafeURL(f"URL is longer than {MAX_URL_LENGTH} characters.")
+
+    parsed = urlparse(url)
+
+    scheme = parsed.scheme.lower()
+    if scheme not in ALLOWED_SCHEMES:
+        raise UnsafeURL("Only http and https URLs can be previewed.")
+
+    if not parsed.hostname:
+        raise UnsafeURL("URL is missing a hostname.")
+
+    host = parsed.hostname.lower()
+
+    # Credentials in the URL are a phishing vector on their own (the browser
+    # shows the userinfo, the server sees something else) and we have no reason
+    # to forward them.
+    if parsed.username or parsed.password:
+        raise UnsafeURL("URLs containing credentials cannot be previewed.")
+
+    try:
+        port = parsed.port or DEFAULT_PORTS[scheme]
+    except ValueError as exc:
+        # urlparse raises when the port is not an integer.
+        raise UnsafeURL("URL has an invalid port.") from exc
+
+    if port not in ALLOWED_PORTS:
+        raise UnsafeURL(f"Port {port} is not allowed.")
+
+    addresses = resolver(host)
+
+    for address in addresses:
+        if not _is_public_address(address):
+            raise UnsafeURL("That host resolves to a non-public address.")
+
+    return SafeTarget(
+        url=url,
+        scheme=scheme,
+        host=host,
+        port=port,
+        addresses=addresses,
+    )
+
+
+def is_safe_outbound_url(url: str, *, resolver=_resolve) -> bool:
+    """Boolean form of :func:`validate_outbound_url`, for filtering lists."""
+    try:
+        validate_outbound_url(url, resolver=resolver)
+    except UnsafeURL:
+        return False
+    return True
+
+
+def normalise_url(url: str) -> str:
+    """
+    A stable spelling of a URL, for use as a cache key.
+
+    Lowercases the scheme and host, drops a redundant explicit port and an
+    empty query or fragment. Two links that differ only in these respects
+    describe the same page and should share one cache entry.
+    """
+    parsed = urlparse(url.strip())
+    scheme = parsed.scheme.lower()
+    host = (parsed.hostname or "").lower()
+
+    netloc = host
+    if parsed.port and parsed.port != DEFAULT_PORTS.get(scheme):
+        netloc = f"{host}:{parsed.port}"
+
+    path = parsed.path or "/"
+
+    # The fragment is a client-side concern; the server returns the same
+    # document either way.
+    return urlunparse((scheme, netloc, path, parsed.params, parsed.query, ""))
+
+
+def filter_safe_urls(urls: Iterable[str], *, resolver=_resolve) -> list[str]:
+    """Keep only the URLs that are safe to fetch, preserving order."""
+    return [url for url in urls if is_safe_outbound_url(url, resolver=resolver)]
+
+
+def describe_rejection(url: str, *, resolver=_resolve) -> Optional[str]:
+    """The reason a URL was rejected, or ``None`` if it was not."""
+    try:
+        validate_outbound_url(url, resolver=resolver)
+    except UnsafeURL as exc:
+        return str(exc)
+    return None

--- a/backend/tests/test_link_previews.py
+++ b/backend/tests/test_link_previews.py
@@ -1,0 +1,343 @@
+"""
+Tests for the link preview service and its SSRF guard.
+
+The guard's tests inject a fake resolver rather than touching DNS. The point is
+to pin the *rules*, and a test that depends on what the CI runner's resolver
+says about ``localhost`` today is a test that will eventually lie.
+"""
+
+import pytest
+
+from app.services.link_preview_service import LinkPreviewService, _clean
+from app.utils.url_safety import (
+    UnsafeURL,
+    filter_safe_urls,
+    is_safe_outbound_url,
+    normalise_url,
+    validate_outbound_url,
+)
+
+
+def resolver_for(mapping):
+    """A fake DNS resolver backed by a dict of host -> addresses."""
+
+    def _resolve(host):
+        if host not in mapping:
+            raise UnsafeURL(f"Could not resolve host: {host}")
+        return tuple(mapping[host])
+
+    return _resolve
+
+
+PUBLIC = resolver_for({"example.com": ["93.184.216.34"]})
+
+
+# ----------------------------------------------------------------------
+# Scheme, port and shape
+# ----------------------------------------------------------------------
+
+
+def test_accepts_a_plain_https_url():
+    target = validate_outbound_url("https://example.com/post", resolver=PUBLIC)
+
+    assert target.host == "example.com"
+    assert target.port == 443
+    assert target.addresses == ("93.184.216.34",)
+
+
+def test_accepts_http_as_well():
+    target = validate_outbound_url("http://example.com/post", resolver=PUBLIC)
+    assert target.port == 80
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "file:///etc/passwd",
+        "ftp://example.com/x",
+        "gopher://example.com/x",
+        "data:text/html,<h1>hi</h1>",
+        "javascript:alert(1)",
+    ],
+)
+def test_rejects_non_http_schemes(url):
+    with pytest.raises(UnsafeURL):
+        validate_outbound_url(url, resolver=PUBLIC)
+
+
+def test_rejects_a_url_with_no_host():
+    with pytest.raises(UnsafeURL):
+        validate_outbound_url("https:///just-a-path", resolver=PUBLIC)
+
+
+def test_rejects_credentials_in_the_url():
+    # The browser shows the userinfo and the server sees something else, which
+    # is a phishing vector on its own. We also have no reason to forward them.
+    with pytest.raises(UnsafeURL):
+        validate_outbound_url("https://user:pw@example.com/", resolver=PUBLIC)
+
+
+def test_rejects_a_disallowed_port():
+    with pytest.raises(UnsafeURL):
+        validate_outbound_url("http://example.com:6379/", resolver=PUBLIC)
+
+
+def test_rejects_an_over_long_url():
+    with pytest.raises(UnsafeURL):
+        validate_outbound_url(
+            "https://example.com/" + "a" * 3000,
+            resolver=PUBLIC,
+        )
+
+
+def test_rejects_empty_input():
+    with pytest.raises(UnsafeURL):
+        validate_outbound_url("   ", resolver=PUBLIC)
+
+
+# ----------------------------------------------------------------------
+# The addresses, which is the part that actually matters
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "address",
+    [
+        "127.0.0.1",  # loopback
+        "10.0.0.5",  # RFC 1918
+        "172.16.4.4",  # RFC 1918
+        "192.168.1.1",  # RFC 1918
+        "169.254.169.254",  # cloud metadata
+        "0.0.0.0",  # unspecified
+        "224.0.0.1",  # multicast
+        "::1",  # IPv6 loopback
+        "fe80::1",  # IPv6 link-local
+        "fc00::1",  # IPv6 unique-local
+        "::ffff:127.0.0.1",  # IPv4-mapped loopback
+    ],
+)
+def test_rejects_hosts_resolving_to_non_public_addresses(address):
+    # This is the case a hostname-string check misses entirely: the name is
+    # public and innocuous, and the answer is not.
+    resolver = resolver_for({"internal.example.com": [address]})
+
+    with pytest.raises(UnsafeURL):
+        validate_outbound_url("https://internal.example.com/", resolver=resolver)
+
+
+def test_rejects_when_any_resolved_address_is_private():
+    # One public A record and one private AAAA record is a working attack if
+    # only the first answer is checked -- we do not get to choose which one
+    # the HTTP client connects to.
+    resolver = resolver_for({"mixed.example.com": ["93.184.216.34", "10.0.0.1"]})
+
+    with pytest.raises(UnsafeURL):
+        validate_outbound_url("https://mixed.example.com/", resolver=resolver)
+
+
+def test_rejects_a_host_that_does_not_resolve():
+    with pytest.raises(UnsafeURL):
+        validate_outbound_url("https://nope.invalid/", resolver=PUBLIC)
+
+
+def test_is_safe_outbound_url_is_the_boolean_form():
+    assert is_safe_outbound_url("https://example.com/", resolver=PUBLIC) is True
+    assert is_safe_outbound_url("file:///etc/passwd", resolver=PUBLIC) is False
+
+
+def test_filter_safe_urls_keeps_order_and_drops_the_rest():
+    urls = [
+        "https://example.com/a",
+        "file:///etc/passwd",
+        "https://example.com/b",
+    ]
+
+    assert filter_safe_urls(urls, resolver=PUBLIC) == [
+        "https://example.com/a",
+        "https://example.com/b",
+    ]
+
+
+# ----------------------------------------------------------------------
+# Cache key normalisation
+# ----------------------------------------------------------------------
+
+
+def test_normalise_lowercases_scheme_and_host():
+    assert normalise_url("HTTPS://Example.COM/Path") == "https://example.com/Path"
+
+
+def test_normalise_drops_a_redundant_port():
+    assert normalise_url("https://example.com:443/x") == "https://example.com/x"
+
+
+def test_normalise_keeps_a_meaningful_port():
+    assert normalise_url("https://example.com:8443/x") == "https://example.com:8443/x"
+
+
+def test_normalise_drops_the_fragment_but_keeps_the_query():
+    # The server returns the same document either way, so two links differing
+    # only by fragment should share one cache entry.
+    assert normalise_url("https://example.com/x?a=1#top") == "https://example.com/x?a=1"
+
+
+def test_normalise_supplies_a_root_path():
+    assert normalise_url("https://example.com") == "https://example.com/"
+
+
+# ----------------------------------------------------------------------
+# Parsing
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture
+def service():
+    return LinkPreviewService()
+
+
+def parse(service, body, url="https://example.com/post"):
+    return service._parse(body, requested_url=url, final_url=url)
+
+
+def test_reads_open_graph_tags(service):
+    body = """
+    <html><head>
+      <meta property="og:title" content="A Title">
+      <meta property="og:description" content="A description.">
+      <meta property="og:site_name" content="Example">
+      <meta property="og:image" content="https://cdn.example.com/a.png">
+    </head></html>
+    """
+
+    preview = parse(service, body)
+
+    assert preview.title == "A Title"
+    assert preview.description == "A description."
+    assert preview.site_name == "Example"
+    assert preview.image_url == "https://cdn.example.com/a.png"
+
+
+def test_falls_back_to_twitter_card_tags(service):
+    body = """
+    <html><head>
+      <meta name="twitter:title" content="Tweet Title">
+      <meta name="twitter:description" content="Tweet description.">
+    </head></html>
+    """
+
+    preview = parse(service, body)
+
+    assert preview.title == "Tweet Title"
+    assert preview.description == "Tweet description."
+
+
+def test_falls_back_to_the_document_title(service):
+    body = "<html><head><title>Just A Title</title></head></html>"
+
+    assert parse(service, body).title == "Just A Title"
+
+
+def test_open_graph_wins_over_twitter_and_title(service):
+    body = """
+    <html><head>
+      <title>Document</title>
+      <meta name="twitter:title" content="Twitter">
+      <meta property="og:title" content="Open Graph">
+    </head></html>
+    """
+
+    assert parse(service, body).title == "Open Graph"
+
+
+def test_attribute_order_does_not_matter(service):
+    # `content` before `property` is extremely common in the wild, and a
+    # single fixed-order regex silently misses all of it.
+    body = '<meta content="Backwards" property="og:title">'
+
+    assert parse(service, body).title == "Backwards"
+
+
+def test_single_quoted_attributes_are_read(service):
+    body = "<meta property='og:title' content='Single Quoted'>"
+
+    assert parse(service, body).title == "Single Quoted"
+
+
+def test_the_first_duplicate_tag_wins(service):
+    body = """
+    <meta property="og:title" content="First">
+    <meta property="og:title" content="Second">
+    """
+
+    assert parse(service, body).title == "First"
+
+
+def test_relative_images_resolve_against_the_final_url(service):
+    body = '<meta property="og:image" content="/img/card.png">'
+
+    preview = service._parse(
+        body,
+        requested_url="https://example.com/a",
+        final_url="https://blog.example.com/posts/x",
+    )
+
+    assert preview.image_url == "https://blog.example.com/img/card.png"
+
+
+def test_og_url_is_preferred_as_the_canonical_link(service):
+    body = '<meta property="og:url" content="https://example.com/canonical">'
+
+    preview = service._parse(
+        body,
+        requested_url="https://example.com/?utm_source=x",
+        final_url="https://example.com/after-redirect",
+    )
+
+    assert preview.final_url == "https://example.com/canonical"
+
+
+def test_a_page_with_no_metadata_yields_an_empty_preview(service):
+    preview = parse(service, "<html><body>nothing here</body></html>")
+
+    assert preview.title is None
+    assert preview.description is None
+    assert preview.image_url is None
+    # The URL fields are always populated, so the caller can still render a
+    # bare link card.
+    assert preview.url == "https://example.com/post"
+
+
+# ----------------------------------------------------------------------
+# Text cleaning
+# ----------------------------------------------------------------------
+
+
+def test_clean_decodes_entities():
+    assert _clean("Tips &amp; tricks", 100) == "Tips & tricks"
+
+
+def test_clean_collapses_whitespace():
+    # These tags are routinely pretty-printed across several lines.
+    assert _clean("A\n   long\t title", 100) == "A long title"
+
+
+def test_clean_returns_none_for_blank_text():
+    assert _clean("   \n  ", 100) is None
+    assert _clean(None, 100) is None
+
+
+def test_clean_truncates_on_a_word_boundary():
+    result = _clean("the quick brown fox jumps over the lazy dog", 20)
+
+    assert result.endswith("…")
+    assert len(result) <= 21
+    # Backing up to a space means we do not cut mid-word.
+    assert not result[:-1].endswith(" ")
+
+
+def test_clean_does_not_back_up_far_for_a_long_token():
+    # A single unbroken token would otherwise shrink the text dramatically, so
+    # a hard cut is the better answer here.
+    result = _clean("short " + "x" * 100, 20)
+
+    assert len(result) == 21

--- a/docs/link_previews.md
+++ b/docs/link_previews.md
@@ -1,0 +1,144 @@
+# Link Previews
+
+Turns a URL somebody pasted into a title, description, site name and image, so
+the reader can tell what a link is before clicking it.
+
+## Endpoints
+
+Both require authentication.
+
+### `GET /api/link-previews?url=<url>`
+
+Returns metadata for one URL.
+
+```json
+{
+  "url": "https://example.com/blog/shipping-faster",
+  "final_url": "https://example.com/blog/shipping-faster",
+  "title": "Shipping faster without breaking things",
+  "description": "How we cut our deploy time from 40 minutes to 4.",
+  "site_name": "Example Engineering",
+  "image_url": "https://example.com/img/shipping.png"
+}
+```
+
+| Status | Meaning |
+| --- | --- |
+| `200` | Metadata found. Any individual field may still be `null`. |
+| `400` | The URL is one we refuse to fetch. The `detail` says which rule it broke. |
+| `404` | The URL was fetchable but yielded nothing — unreachable, timed out, or not HTML. |
+| `429` | Rate limited (30/minute). |
+
+### `POST /api/link-previews/batch`
+
+Up to 10 URLs in one round trip. Always `200`; each entry carries either a
+`preview` or an `error`, so one dead link in a message does not cost the reader
+every other card in it.
+
+```json
+{
+  "results": [
+    { "url": "https://example.com/a", "preview": { "title": "…" } },
+    { "url": "http://10.0.0.1/", "error": "That host resolves to a non-public address." }
+  ]
+}
+```
+
+Rate limited to 10/minute, because each call is up to ten outbound requests.
+
+## Where the metadata comes from
+
+For each field, the first source that yields a value wins:
+
+| Field | Order |
+| --- | --- |
+| `title` | `og:title` → `twitter:title` → `<title>` |
+| `description` | `og:description` → `twitter:description` → `<meta name="description">` |
+| `site_name` | `og:site_name` → `application-name` |
+| `image_url` | `og:image` → `twitter:image` |
+| `final_url` | `og:url` → the URL after redirects |
+
+`og:url` is preferred for `final_url` because it is the page's own canonical
+spelling of itself, which is a better thing to store than whatever redirect
+chain we happened to follow.
+
+Relative image paths resolve against the **final** URL, not the submitted one.
+Values are HTML-entity-decoded, whitespace-collapsed, and truncated (200
+characters for a title, 500 for a description) on a word boundary where one is
+nearby.
+
+## The safety rules
+
+This endpoint makes our server fetch a URL the caller chose, from inside our
+network. Unguarded, that is a server-side request forgery hole: the caller
+would get to read the cloud metadata endpoint, internal admin panels, and every
+service on the private subnet, using our source address.
+
+`app/utils/url_safety.py` enforces:
+
+1. **Scheme allowlist** — `http` and `https` only.
+2. **Port allowlist** — 80, 443, 8080, 8443.
+3. **No credentials in the URL** — a phishing vector on its own, and we have no
+   reason to forward them.
+4. **Resolved-address checks** — the hostname is resolved and *every* returned
+   address must be public. Loopback, link-local (including `169.254.169.254`),
+   RFC 1918, unique-local, reserved, multicast and unspecified are all refused,
+   for IPv4, IPv6, and IPv4-mapped IPv6.
+5. **Length cap** — 2048 characters.
+
+Point 4 is the one that matters most, and it is why the check resolves rather
+than pattern-matching the hostname. `127.0.0.1.nip.io` is an ordinary public
+name that resolves to loopback, and there is a whole family of such services.
+Checking *all* resolved addresses matters too: a name with one public A record
+and one private AAAA record is a working attack if only the first answer is
+inspected, since nothing in this code chooses which one the HTTP client uses.
+
+`app/services/link_preview_service.py` adds the fetch-time rules:
+
+6. **Redirects are followed by hand**, and every hop is re-validated. A public
+   URL that 302s to `http://169.254.169.254/latest/meta-data/` is refused at
+   the second hop. `follow_redirects=True` would walk straight onto it.
+7. **The body is streamed and capped** at 512 KiB, so a hostile server cannot
+   make us buffer a gigabyte. Everything we want is in `<head>`.
+8. **Only HTML content types are parsed.**
+9. **Short timeouts** (5s) and a bounded hop count (3).
+
+## Caching
+
+Successful previews are cached for 24 hours; failures for 5 minutes. Without
+this, a link pasted into a busy conversation is fetched once per reader. The
+cache key is a normalised spelling of the URL — lowercased scheme and host,
+redundant port dropped, fragment dropped — so links that differ only in those
+respects share one entry.
+
+Failures get a much shorter TTL so a site that was down for five minutes is not
+written off for a day.
+
+## Configuration
+
+| Setting | Default | Notes |
+| --- | --- | --- |
+| `LINK_PREVIEW_TIMEOUT_SECONDS` | `5.0` | A slow site gets no card rather than a slow card. |
+| `LINK_PREVIEW_MAX_BYTES` | `524288` | 512 KiB. |
+| `LINK_PREVIEW_MAX_REDIRECTS` | `3` | A cost ceiling; each hop is re-validated regardless. |
+| `LINK_PREVIEW_CACHE_TTL_SECONDS` | `86400` | |
+| `LINK_PREVIEW_FAILURE_CACHE_TTL_SECONDS` | `300` | |
+| `LINK_PREVIEW_USER_AGENT` | `DevLinkBot/1.0 (+…)` | Identifying ourselves honestly is what lets a site owner rate-limit us instead of blackholing us. |
+
+## Reusing the guard
+
+Any future feature that fetches a user-supplied URL — webhook delivery, avatar
+import, repository metadata — should go through `validate_outbound_url` rather
+than growing its own check.
+
+```python
+from app.utils.url_safety import UnsafeURL, validate_outbound_url
+
+try:
+    target = validate_outbound_url(url)
+except UnsafeURL as exc:
+    raise HTTPException(status_code=400, detail=str(exc))
+```
+
+`is_safe_outbound_url` and `filter_safe_urls` are boolean and list forms of the
+same rules.


### PR DESCRIPTION
Closes #876

## What this adds

```
GET  /api/link-previews?url=https://example.com/post   → one preview
POST /api/link-previews/batch  { "urls": [...] }       → up to 10
```

Metadata comes from Open Graph, falling back to Twitter card tags, falling back to the plain `<title>` / `<meta name="description">`. `og:url` wins for `final_url` because it is the page's own canonical spelling of itself, which is worth more than whatever redirect chain we happened to follow.

The batch endpoint always returns `200`. Each entry carries either a `preview` or an `error`, so one dead link in a message does not cost the reader every other card in it.

## The safety work is the feature

This is an endpoint whose entire job is to make our server fetch a URL the caller chose, from inside our network. Written naively it is an open proxy to `169.254.169.254`, to `localhost:5432`, and to everything else on the private subnet — with our source address and our credentials.

### `app/utils/url_safety.py`

Kept as a separate module on purpose. Webhook delivery, avatar import and repository metadata all have the same problem, and none of them should grow their own half-version of this.

* **scheme allowlist** — `http`/`https`. No `file:`, no `gopher:`, no `data:`.
* **port allowlist** — 80, 443, 8080, 8443.
* **no credentials in the URL** — the browser shows the userinfo and the server sees something else, which is a phishing vector on its own.
* **resolved-address checks** — the hostname is resolved and *every* returned address must be public.

That last point is the one that actually matters, and it is why this resolves instead of pattern-matching the hostname:

> `127.0.0.1.nip.io` is a perfectly ordinary public hostname. It resolves to loopback. There is a whole family of services that exist to do this.

Checking *all* the addresses matters for the same reason. A name with one public A record and one private AAAA record is a working attack if only the first answer is inspected — nothing in this code chooses which one the HTTP client ends up connecting to.

Refused: loopback, link-local (which is where cloud metadata lives), RFC 1918, unique-local, reserved, multicast, unspecified — for IPv4, IPv6, and IPv4-mapped IPv6, because `::ffff:127.0.0.1` is loopback wearing a hat.

### `app/services/link_preview_service.py`

* **Redirects are followed by hand**, and every hop is re-validated. This is the whole reason the fetch loop is written out longhand instead of using `follow_redirects=True` — a public URL that 302s to `http://169.254.169.254/latest/meta-data/` has to fail at the *second* hop, and the convenient version walks straight onto it.
* **The body is streamed and abandoned past 512 KiB.** Everything we want is in `<head>`, so the cap costs nothing on a real page and stops a hostile server making us buffer a gigabyte.
* Only `text/html` and `application/xhtml+xml` are parsed.
* Timeouts are short (5s) and the hop count is bounded (3).

## Caching

24 hours for a success, 5 minutes for a failure. Without it, a link pasted into a busy conversation is fetched once *per reader*. The short failure TTL means a site that was down for five minutes is not written off for a day.

The cache key is a normalised URL — lowercased scheme and host, redundant `:443` dropped, fragment dropped — so two spellings of the same page share one entry.

## Tests

47 tests, and the resolver is injected rather than real. A test that depends on what the CI runner's DNS says about `localhost` today is a test that will eventually lie.

Covered: every rejected address family individually, the mixed public/private records case, disallowed schemes and ports, credentials in the URL, cache-key normalisation, and on the parsing side — Open Graph precedence, Twitter fallback, `<title>` fallback, **attribute order** (`content="…" property="…"` is extremely common in the wild and a single fixed-order regex silently misses all of it), single-quoted attributes, duplicate tags, relative image resolution against the final URL, entity decoding, whitespace collapsing, and word-boundary truncation.

```
$ pytest tests/test_link_previews.py -q
47 passed
```

Endpoint smoke-checked against the running app: unauthenticated `GET /api/link-previews` returns `401`, so the route is wired and the auth dependency is doing its job.

## Notes for review

* Rate limits are deliberately tight — 30/min single, 10/min batch. This endpoint is an outbound-request amplifier by construction.
* No new model, no migration.
* `main.py` gains three lines, at line 516, well away from anything else in flight.
* Docs in `docs/link_previews.md`, including a short section on reusing the guard for the next feature that needs to fetch a user-supplied URL.
