### PR TITLE
feat: publish hackathons and milestones as a subscribable iCalendar feed

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -258,6 +258,24 @@ class Settings(BaseSettings):
     ETAG_CACHE_CONTROL: str = "private, no-cache"
 
     # ==========================================================
+    # Calendar Feeds
+    # ==========================================================
+
+    # Mixed into the feed-token signing key. Changing it invalidates every
+    # issued feed URL at once, which is the blunt revocation lever available
+    # while tokens are stateless.
+    CALENDAR_FEED_TOKEN_SALT: str = "devlink-calendar-feed"
+
+    # A year. Long enough that a subscription is genuinely set-and-forget,
+    # short enough that a URL abandoned in a browser history stops working.
+    CALENDAR_FEED_TOKEN_MAX_AGE_DAYS: int = 365
+
+    # Advertised to clients via REFRESH-INTERVAL and X-PUBLISHED-TTL. Without
+    # a hint, clients pick their own interval, often an hour for a feed that
+    # changes daily.
+    CALENDAR_FEED_REFRESH_MINUTES: int = 360
+
+    # ==========================================================
     # Celery
     # ==========================================================
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -530,6 +530,8 @@ app.include_router(project_members.router, prefix="/api", tags=["Project Members
 app.include_router(project_dashboards.router, prefix="/api", tags=["Project Dashboards"])
 from app.routers import project_milestones
 app.include_router(project_milestones.router, prefix="/api", tags=["Project Milestones"])
+from app.routers import calendar as calendar_router
+app.include_router(calendar_router.router, prefix="/api", tags=["Calendar"])
 app.include_router(analytics.router, prefix="/api", tags=["Analytics"])
 app.include_router(builder_flares.router, prefix="/api/flare", tags=["Builder's Flare"])
 app.include_router(messages.router, prefix="/api/messages", tags=["Messages"])

--- a/backend/app/routers/calendar.py
+++ b/backend/app/routers/calendar.py
@@ -1,0 +1,189 @@
+"""
+Calendar endpoints: single-event downloads and the subscribable feed.
+
+The feed endpoint is the odd one out. It authenticates with a token in the
+query string rather than a header, because a calendar client will not send one
+-- it does "GET this URL, forever" and nothing more. Everything else here is
+ordinary session-authenticated API.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi.responses import Response
+from sqlalchemy.orm import Session
+
+from app.dependencies import get_current_user, get_database
+from app.middleware.rate_limit import limiter
+from app.models.hackathon import Hackathon
+from app.models.milestone import Milestone
+from app.models.user import User
+from app.schemas.calendar import CalendarFeedTokenResponse
+from app.services.calendar_feed_service import (
+    CalendarFeedService,
+    InvalidFeedToken,
+    generate_feed_token,
+    parse_feed_token,
+)
+
+router = APIRouter(
+    prefix="/calendar",
+    tags=["Calendar"],
+)
+
+CALENDAR_LIMIT = "60/minute"
+
+CALENDAR_MEDIA_TYPE = "text/calendar; charset=utf-8"
+
+
+def _ics_response(body: str, filename: str) -> Response:
+    """
+    An .ics response with the headers clients actually look at.
+
+    ``Content-Disposition: attachment`` is what makes a browser hand the file
+    to the calendar application instead of rendering it as text. The feed
+    endpoint deliberately does not use it -- a subscription is polled, not
+    downloaded, and an attachment header there produces a download prompt every
+    time somebody opens the URL in a browser to check it.
+    """
+    return Response(
+        content=body,
+        media_type=CALENDAR_MEDIA_TYPE,
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@router.get(
+    "/feed-token",
+    response_model=CalendarFeedTokenResponse,
+    summary="Get the URL to subscribe to in a calendar client",
+)
+@limiter.limit(CALENDAR_LIMIT)
+def get_feed_token(
+    request: Request,
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Mint a feed token and return the URL built from it.
+
+    Calling this again issues a new token. The previous one keeps working until
+    it expires -- feed tokens are stateless, so there is nothing to delete. See
+    ``docs/calendar_feeds.md``.
+    """
+    token = generate_feed_token(current_user.id)
+
+    return CalendarFeedTokenResponse(
+        token=token,
+        feed_url=str(request.url_for("get_calendar_feed")) + f"?token={token}",
+    )
+
+
+@router.get(
+    "/events.ics",
+    name="get_calendar_feed",
+    summary="Subscribable calendar feed",
+    response_class=Response,
+)
+@limiter.limit(CALENDAR_LIMIT)
+def get_calendar_feed(
+    request: Request,
+    token: str = Query(description="A feed token from /api/calendar/feed-token."),
+    db: Session = Depends(get_database),
+):
+    """
+    Every dated item for the user the token belongs to.
+
+    A bad token gets 404, not 401. A 401 that distinguishes "wrong token" from
+    "no such feed" is an oracle for guessing tokens, and a calendar client
+    cannot do anything useful with a 401 anyway.
+    """
+    try:
+        user_id = parse_feed_token(token)
+    except InvalidFeedToken:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Calendar feed not found.",
+        )
+
+    service = CalendarFeedService(db)
+    body = service.render_feed(user_id)
+
+    # No Content-Disposition here: this URL is polled by a subscription, and an
+    # attachment header turns every manual visit into a download prompt.
+    return Response(content=body, media_type=CALENDAR_MEDIA_TYPE)
+
+
+@router.get(
+    "/hackathons/{hackathon_id}.ics",
+    summary="Download one hackathon as a calendar event",
+    response_class=Response,
+)
+@limiter.limit(CALENDAR_LIMIT)
+def download_hackathon_event(
+    request: Request,
+    hackathon_id: uuid.UUID,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
+):
+    """The "Add to calendar" button next to a hackathon."""
+    hackathon = db.get(Hackathon, hackathon_id)
+    if hackathon is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Hackathon not found",
+        )
+
+    service = CalendarFeedService(db)
+    if not service.can_read_hackathon(hackathon, current_user.id):
+        # 404 rather than 403: an unpublished hackathon should not confirm its
+        # own existence to somebody who cannot see it.
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Hackathon not found",
+        )
+
+    return _ics_response(
+        service.render_hackathon(hackathon),
+        f"hackathon-{hackathon.id}.ics",
+    )
+
+
+@router.get(
+    "/milestones/{milestone_id}.ics",
+    summary="Download one milestone as a calendar event",
+    response_class=Response,
+)
+@limiter.limit(CALENDAR_LIMIT)
+def download_milestone_event(
+    request: Request,
+    milestone_id: uuid.UUID,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
+):
+    """The "Add to calendar" button next to a milestone."""
+    milestone = db.get(Milestone, milestone_id)
+    if milestone is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Milestone not found",
+        )
+
+    if milestone.due_date is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="That milestone has no due date to add to a calendar.",
+        )
+
+    service = CalendarFeedService(db)
+    if not service.can_read_milestone(milestone, current_user.id):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Milestone not found",
+        )
+
+    return _ics_response(
+        service.render_milestone(milestone),
+        f"milestone-{milestone.id}.ics",
+    )

--- a/backend/app/schemas/calendar.py
+++ b/backend/app/schemas/calendar.py
@@ -1,0 +1,30 @@
+"""Response shapes for the calendar endpoints."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class CalendarFeedTokenResponse(BaseModel):
+    """
+    A feed token and the URL built from it.
+
+    Both are returned because the client needs the URL to show the user, and
+    the token on its own to build a different URL if it ever needs to.
+    """
+
+    token: str = Field(
+        description="Opaque, signed, scoped to the calendar feed and nothing else."
+    )
+    feed_url: str = Field(
+        description="Paste this into a calendar client's 'subscribe to calendar' box."
+    )
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "token": "v1.PVCyXH2GTP6vHTF6vNPVKw.1785312000.9Ku2r0m2Rjk",
+                "feed_url": "https://api.devlink.dev/api/calendar/events.ics?token=v1.PVCyXH2GTP6vHTF6vNPVKw.1785312000.9Ku2r0m2Rjk",
+            }
+        }
+    }

--- a/backend/app/services/calendar_feed_service.py
+++ b/backend/app/services/calendar_feed_service.py
@@ -1,0 +1,391 @@
+"""
+Building the calendar feed and the token that guards it.
+
+Two shapes, because they solve different problems:
+
+* a **single-event download**, which works offline, works when the user is not
+  signed in on their phone, and creates no ongoing relationship with us
+* a **subscribable feed**, which the user pastes into their calendar client
+  once and then forgets about
+
+The feed is the one people actually want, and it is also the awkward one.
+Calendar clients do not do OAuth; they do "GET this URL, forever, with no
+headers I control". So the feed cannot use a session cookie or a bearer token
+-- it needs a secret that lives in the URL.
+
+That secret is generated here. It is:
+
+* **scoped** -- it authenticates nothing except the calendar feed, so a leaked
+  feed URL exposes the user's hackathon and milestone titles and nothing else
+* **stateless** -- an HMAC over the user id and an issue timestamp, so no new
+  table and no migration
+* **expiring** -- a year by default, so an abandoned URL does not work forever
+
+The trade-off in being stateless is that a *specific* leaked token cannot be
+revoked on its own; see :func:`rotate_all_feed_tokens` for what can be done
+instead, and ``docs/calendar_feeds.md`` for the follow-up that would fix it.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Optional, Sequence
+
+from sqlalchemy import or_
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.models.hackathon import Hackathon
+from app.models.hackathon_registration import HackathonRegistration
+from app.models.milestone import Milestone
+from app.models.project_member import ProjectMember
+from app.utils.ics import Alarm, Calendar, Event
+
+logger = logging.getLogger(__name__)
+
+TOKEN_VERSION = "v1"
+
+# A hackathon that ended two years ago is not something anybody wants filling
+# their calendar. Feeds are a rolling window, not an archive.
+FEED_LOOKBACK_DAYS = 90
+FEED_LOOKAHEAD_DAYS = 365
+
+# Remind people the day before a milestone is due and an hour before a
+# hackathon starts. The asymmetry is deliberate: a deadline needs warning, an
+# event needs a nudge.
+MILESTONE_ALARM_MINUTES = 24 * 60
+HACKATHON_ALARM_MINUTES = 60
+
+
+class InvalidFeedToken(ValueError):
+    """Raised when a feed token is missing, malformed, expired or forged."""
+
+
+# ----------------------------------------------------------------------
+# Tokens
+# ----------------------------------------------------------------------
+
+
+def _signing_key() -> bytes:
+    """
+    The key feed tokens are signed with.
+
+    Derived from ``SECRET_KEY`` and a feed-specific salt rather than using
+    ``SECRET_KEY`` directly, so that a feed token can never be confused with a
+    session token even if one of the formats changes later.
+    """
+    return hashlib.sha256(
+        f"{settings.SECRET_KEY}:{settings.CALENDAR_FEED_TOKEN_SALT}".encode("utf-8")
+    ).digest()
+
+
+def _b64(raw: bytes) -> str:
+    """URL-safe base64 with the padding stripped, so it is clean in a URL."""
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _unb64(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(value + padding)
+
+
+def generate_feed_token(user_id: uuid.UUID, *, issued_at: datetime = None) -> str:
+    """
+    Mint a feed token for a user.
+
+    Format: ``v1.<user-id>.<issued-at>.<signature>``. Everything but the
+    signature is readable, which is fine -- the token proves possession, it does
+    not hide anything.
+    """
+    issued_at = issued_at or datetime.now(timezone.utc)
+    payload = f"{TOKEN_VERSION}.{_b64(user_id.bytes)}.{int(issued_at.timestamp())}"
+
+    signature = hmac.new(
+        _signing_key(),
+        payload.encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+
+    return f"{payload}.{_b64(signature)}"
+
+
+def parse_feed_token(token: str) -> uuid.UUID:
+    """
+    Verify a feed token and return the user it belongs to.
+
+    Raises :class:`InvalidFeedToken` for anything that is not a currently valid
+    token. The caller should answer 404 rather than 401 -- an unauthenticated
+    URL that says "wrong token" is an oracle for guessing them, and a calendar
+    client cannot act on a 401 anyway.
+    """
+    if not token:
+        raise InvalidFeedToken("No feed token supplied.")
+
+    parts = token.split(".")
+    if len(parts) != 4:
+        raise InvalidFeedToken("Malformed feed token.")
+
+    version, encoded_id, issued_str, encoded_signature = parts
+
+    if version != TOKEN_VERSION:
+        raise InvalidFeedToken("Unsupported feed token version.")
+
+    payload = f"{version}.{encoded_id}.{issued_str}"
+    expected = hmac.new(
+        _signing_key(),
+        payload.encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+
+    try:
+        provided = _unb64(encoded_signature)
+    except (ValueError, TypeError) as exc:
+        raise InvalidFeedToken("Malformed feed token.") from exc
+
+    # Constant time, so the comparison does not leak how much of a guessed
+    # signature was right.
+    if not hmac.compare_digest(expected, provided):
+        raise InvalidFeedToken("Feed token signature does not match.")
+
+    try:
+        issued_at = datetime.fromtimestamp(int(issued_str), tz=timezone.utc)
+    except (ValueError, OverflowError, OSError) as exc:
+        raise InvalidFeedToken("Malformed feed token.") from exc
+
+    max_age = timedelta(days=settings.CALENDAR_FEED_TOKEN_MAX_AGE_DAYS)
+    if datetime.now(timezone.utc) - issued_at > max_age:
+        raise InvalidFeedToken("Feed token has expired.")
+
+    try:
+        return uuid.UUID(bytes=_unb64(encoded_id))
+    except (ValueError, TypeError) as exc:
+        raise InvalidFeedToken("Malformed feed token.") from exc
+
+
+def rotate_all_feed_tokens() -> None:
+    """
+    Documentation, not code.
+
+    Because tokens are stateless there is nothing to delete. Every issued feed
+    URL is invalidated at once by changing ``CALENDAR_FEED_TOKEN_SALT`` and
+    restarting. That is the blunt instrument; per-user revocation needs a table
+    to revoke against.
+    """
+    raise NotImplementedError(
+        "Feed tokens are stateless. Rotate CALENDAR_FEED_TOKEN_SALT to "
+        "invalidate every issued feed URL."
+    )
+
+
+# ----------------------------------------------------------------------
+# Building the calendar
+# ----------------------------------------------------------------------
+
+
+class CalendarFeedService:
+    """Collects a user's dated items and renders them as iCalendar."""
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    # -- Collection ----------------------------------------------------
+
+    def hackathons_for(self, user_id: uuid.UUID) -> Sequence[Hackathon]:
+        """
+        Hackathons the user has registered for, within the feed window.
+
+        Only registered ones: a feed of every hackathon on the platform is a
+        newsletter, not a calendar.
+        """
+        now = datetime.now(timezone.utc)
+
+        return (
+            self.db.query(Hackathon)
+            .join(
+                HackathonRegistration,
+                HackathonRegistration.hackathon_id == Hackathon.id,
+            )
+            .filter(HackathonRegistration.user_id == user_id)
+            .filter(Hackathon.ends_at >= now - timedelta(days=FEED_LOOKBACK_DAYS))
+            .filter(Hackathon.starts_at <= now + timedelta(days=FEED_LOOKAHEAD_DAYS))
+            .order_by(Hackathon.starts_at)
+            .all()
+        )
+
+    def milestones_for(self, user_id: uuid.UUID) -> Sequence[Milestone]:
+        """
+        Milestones on projects the user is an active member of.
+
+        Completed and archived milestones are excluded -- a done deadline in a
+        calendar is noise, and unlike the hackathon window there is no reason
+        to keep it around for reference.
+        """
+        now = datetime.now(timezone.utc)
+
+        return (
+            self.db.query(Milestone)
+            .join(ProjectMember, ProjectMember.project_id == Milestone.project_id)
+            .filter(ProjectMember.user_id == user_id)
+            .filter(ProjectMember.is_active.is_(True))
+            .filter(Milestone.due_date.isnot(None))
+            .filter(Milestone.is_completed.is_(False))
+            .filter(Milestone.is_archived.is_(False))
+            .filter(Milestone.due_date >= now - timedelta(days=FEED_LOOKBACK_DAYS))
+            .filter(Milestone.due_date <= now + timedelta(days=FEED_LOOKAHEAD_DAYS))
+            .order_by(Milestone.due_date)
+            .all()
+        )
+
+    # -- Conversion ----------------------------------------------------
+
+    @staticmethod
+    def hackathon_event(hackathon: Hackathon) -> Event:
+        """
+        A hackathon as a single timed event spanning start to end.
+
+        The UID is derived from the entity type and id and never changes, which
+        is what lets a subscribed client update the event in place instead of
+        creating a duplicate on every poll.
+        """
+        description_parts = [hackathon.description or ""]
+
+        if hackathon.theme:
+            description_parts.append(f"Theme: {hackathon.theme}")
+        if hackathon.prize:
+            description_parts.append(f"Prize: {hackathon.prize}")
+        if hackathon.registration_ends_at:
+            description_parts.append(
+                "Registration closes: "
+                f"{hackathon.registration_ends_at.strftime('%d %b %Y %H:%M UTC')}"
+            )
+
+        return Event(
+            uid=f"hackathon-{hackathon.id}@devlink",
+            summary=hackathon.name,
+            description="\n\n".join(p for p in description_parts if p),
+            starts_at=hackathon.starts_at,
+            ends_at=hackathon.ends_at,
+            url=hackathon.website_url,
+            status=_ics_status(hackathon.status.value),
+            created_at=hackathon.created_at,
+            alarms=[
+                Alarm(
+                    minutes_before=HACKATHON_ALARM_MINUTES,
+                    description=f"{hackathon.name} starts in an hour",
+                )
+            ],
+        )
+
+    @staticmethod
+    def milestone_event(milestone: Milestone) -> Event:
+        """
+        A milestone as an all-day event on its due date.
+
+        All-day rather than timed because a due date has no meaningful time of
+        day; rendering it at midnight would put every deadline in the small
+        hours of the client's display.
+        """
+        return Event(
+            uid=f"milestone-{milestone.id}@devlink",
+            summary=f"Due: {milestone.title}",
+            description=milestone.description,
+            starts_at=milestone.due_date,
+            all_day=True,
+            created_at=milestone.created_at,
+            alarms=[
+                Alarm(
+                    minutes_before=MILESTONE_ALARM_MINUTES,
+                    description=f"{milestone.title} is due tomorrow",
+                )
+            ],
+        )
+
+    # -- Rendering -----------------------------------------------------
+
+    def build_feed(self, user_id: uuid.UUID) -> Calendar:
+        """Everything dated for one user, as a calendar."""
+        calendar = Calendar(
+            name="DevLink",
+            description="Your hackathons and project milestones.",
+            refresh_minutes=settings.CALENDAR_FEED_REFRESH_MINUTES,
+        )
+
+        for hackathon in self.hackathons_for(user_id):
+            calendar.add(self.hackathon_event(hackathon))
+
+        for milestone in self.milestones_for(user_id):
+            calendar.add(self.milestone_event(milestone))
+
+        return calendar
+
+    def render_feed(self, user_id: uuid.UUID) -> str:
+        return self.build_feed(user_id).render()
+
+    def render_hackathon(self, hackathon: Hackathon) -> str:
+        calendar = Calendar(name=hackathon.name)
+        calendar.add(self.hackathon_event(hackathon))
+        return calendar.render()
+
+    def render_milestone(self, milestone: Milestone) -> str:
+        calendar = Calendar(name=milestone.title)
+        calendar.add(self.milestone_event(milestone))
+        return calendar.render()
+
+    # -- Access checks -------------------------------------------------
+
+    def can_read_hackathon(self, hackathon: Hackathon, user_id: uuid.UUID) -> bool:
+        """
+        Published hackathons are readable by anyone; drafts by their organiser.
+
+        A registration also grants access, which matters for a hackathon that
+        was published, taken back to draft, and still has people signed up.
+        """
+        if hackathon.is_published:
+            return True
+        if hackathon.created_by == user_id:
+            return True
+
+        return (
+            self.db.query(HackathonRegistration)
+            .filter(
+                HackathonRegistration.hackathon_id == hackathon.id,
+                HackathonRegistration.user_id == user_id,
+            )
+            .first()
+            is not None
+        )
+
+    def can_read_milestone(self, milestone: Milestone, user_id: uuid.UUID) -> bool:
+        """Milestones are visible to active members of their project."""
+        return (
+            self.db.query(ProjectMember)
+            .filter(
+                ProjectMember.project_id == milestone.project_id,
+                ProjectMember.user_id == user_id,
+                or_(
+                    ProjectMember.is_active.is_(True),
+                    ProjectMember.is_active.is_(None),
+                ),
+            )
+            .first()
+            is not None
+        )
+
+
+def _ics_status(status: str) -> Optional[str]:
+    """
+    Map our hackathon status onto the three values RFC 5545 allows.
+
+    Anything we cannot map returns ``None`` and the property is omitted, which
+    is better than emitting a value clients will reject.
+    """
+    if status == "cancelled":
+        return "CANCELLED"
+    if status == "draft":
+        return "TENTATIVE"
+    return "CONFIRMED"

--- a/backend/app/utils/ics.py
+++ b/backend/app/utils/ics.py
@@ -1,0 +1,268 @@
+"""
+Writing iCalendar (RFC 5545) documents.
+
+Calendar clients are strict in ways that are easy to miss and hard to notice,
+because the failure mode is not an error -- it is Outlook quietly truncating a
+project name at the first comma, or Google creating a duplicate event on every
+poll. So this module is fussy on purpose about four things:
+
+* **Line folding at 75 octets.** Folded on octet boundaries, never in the middle
+  of a UTF-8 sequence, because a split codepoint corrupts the field.
+* **Escaping.** ``\\``, ``;``, ``,`` and newlines are special inside a text
+  value. An unescaped comma silently ends the field in several clients.
+* **CRLF line endings.** The spec says CRLF; some parsers accept ``\\n`` and
+  some do not, and the ones that do not fail obscurely.
+* **Stable UIDs.** If a UID changes between polls, the client does not update
+  the event, it creates a second one. Deriving the UID from the entity type and
+  id is what makes a subscribed feed converge instead of accumulating.
+
+Deliberately hand-rolled rather than pulling in ``icalendar``: what we emit is
+a small, fixed subset, and the dependency would be larger than the code.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime, timezone
+from typing import Iterable, Optional
+
+PRODUCT_ID = "-//DevLink//Calendar Feed//EN"
+
+# RFC 5545 section 3.1: lines are folded so no line exceeds 75 octets, not
+# counting the CRLF. Continuation lines begin with a single space.
+MAX_LINE_OCTETS = 75
+
+
+def escape_text(value: str) -> str:
+    """
+    Escape a string for use as an iCalendar TEXT value.
+
+    Backslash first, or we would then escape the backslashes we just added.
+    """
+    return (
+        value.replace("\\", "\\\\")
+        .replace(";", "\\;")
+        .replace(",", "\\,")
+        .replace("\r\n", "\\n")
+        .replace("\n", "\\n")
+        .replace("\r", "\\n")
+    )
+
+
+def fold_line(line: str) -> str:
+    """
+    Fold a content line to 75 octets per physical line.
+
+    The limit is in **octets**, not characters, and the fold must not land in
+    the middle of a multi-byte sequence -- a split codepoint corrupts the value
+    for every parser. So this walks the encoded bytes and only breaks where a
+    character actually ends.
+    """
+    encoded = line.encode("utf-8")
+
+    if len(encoded) <= MAX_LINE_OCTETS:
+        return line
+
+    pieces: list[str] = []
+    current: list[str] = []
+    current_octets = 0
+
+    # A continuation line carries a leading space that counts toward its own
+    # limit, so subsequent lines have one octet less room.
+    limit = MAX_LINE_OCTETS
+
+    for char in line:
+        char_octets = len(char.encode("utf-8"))
+
+        if current_octets + char_octets > limit:
+            pieces.append("".join(current))
+            current = [char]
+            current_octets = char_octets
+            limit = MAX_LINE_OCTETS - 1
+        else:
+            current.append(char)
+            current_octets += char_octets
+
+    pieces.append("".join(current))
+
+    return "\r\n ".join(pieces)
+
+
+def format_utc(moment: datetime) -> str:
+    """
+    Format an instant as a UTC date-time value: ``YYYYMMDDTHHMMSSZ``.
+
+    A naive datetime is assumed to be UTC. That assumption is safe here because
+    every column this module reads is ``DateTime(timezone=True)``; it exists
+    only so a hand-built object in a test does not have to be explicit.
+    """
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+
+    return moment.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def format_date(day: date) -> str:
+    """Format a calendar date for a ``VALUE=DATE`` property."""
+    return day.strftime("%Y%m%d")
+
+
+@dataclass
+class Alarm:
+    """
+    A reminder, expressed as an offset before the event starts.
+
+    ``minutes_before`` rather than a raw duration string because every reminder
+    we generate is "some time before the start", and the string form is easy to
+    get subtly wrong.
+    """
+
+    minutes_before: int
+    description: str = "Reminder"
+
+    def to_lines(self) -> list[str]:
+        return [
+            "BEGIN:VALARM",
+            "ACTION:DISPLAY",
+            f"DESCRIPTION:{escape_text(self.description)}",
+            f"TRIGGER:-PT{self.minutes_before}M",
+            "END:VALARM",
+        ]
+
+
+@dataclass
+class Event:
+    """
+    One ``VEVENT``.
+
+    ``uid`` must be stable for the life of the thing it describes. See the
+    module docstring: an unstable UID turns every poll into a duplicate.
+
+    Set ``all_day`` for something with a due date but no meaningful time -- a
+    milestone deadline, say. All-day events use ``VALUE=DATE`` and an exclusive
+    end date, which is why the end is bumped by a day below.
+    """
+
+    uid: str
+    summary: str
+    starts_at: datetime
+    ends_at: Optional[datetime] = None
+    description: Optional[str] = None
+    location: Optional[str] = None
+    url: Optional[str] = None
+    all_day: bool = False
+    status: Optional[str] = None
+    # Incremented when the event is edited. Clients ignore an update whose
+    # SEQUENCE has not moved.
+    sequence: int = 0
+    created_at: Optional[datetime] = None
+    alarms: list[Alarm] = field(default_factory=list)
+
+    def to_lines(self, *, stamp: datetime) -> list[str]:
+        lines = [
+            "BEGIN:VEVENT",
+            f"UID:{self.uid}",
+            # DTSTAMP is when this representation was generated, which is not
+            # the same thing as when the event was created.
+            f"DTSTAMP:{format_utc(stamp)}",
+        ]
+
+        if self.all_day:
+            lines.append(f"DTSTART;VALUE=DATE:{format_date(self.starts_at.date())}")
+            # DTEND is exclusive for all-day events: a one-day event on the 5th
+            # ends on the 6th. Omitting it makes the event one day long, which
+            # is what we want for a deadline, so only emit an explicit end when
+            # the caller gave a different one.
+            if self.ends_at is not None:
+                lines.append(f"DTEND;VALUE=DATE:{format_date(self.ends_at.date())}")
+        else:
+            lines.append(f"DTSTART:{format_utc(self.starts_at)}")
+            if self.ends_at is not None:
+                lines.append(f"DTEND:{format_utc(self.ends_at)}")
+
+        lines.append(f"SUMMARY:{escape_text(self.summary)}")
+
+        if self.description:
+            lines.append(f"DESCRIPTION:{escape_text(self.description)}")
+
+        if self.location:
+            lines.append(f"LOCATION:{escape_text(self.location)}")
+
+        if self.url:
+            # URI values are not TEXT and must not be escaped -- a comma in a
+            # query string is legal and escaping it breaks the link.
+            lines.append(f"URL:{self.url}")
+
+        if self.status:
+            lines.append(f"STATUS:{self.status}")
+
+        if self.created_at is not None:
+            lines.append(f"CREATED:{format_utc(self.created_at)}")
+
+        if self.sequence:
+            lines.append(f"SEQUENCE:{self.sequence}")
+
+        for alarm in self.alarms:
+            lines.extend(alarm.to_lines())
+
+        lines.append("END:VEVENT")
+        return lines
+
+
+@dataclass
+class Calendar:
+    """A ``VCALENDAR`` wrapping a set of events."""
+
+    name: str
+    description: Optional[str] = None
+    events: list[Event] = field(default_factory=list)
+    # X-PUBLISHED-TTL is a hint to the client about how often to poll. Without
+    # it, clients pick their own interval, which is often an hour for a feed
+    # that changes daily.
+    refresh_minutes: int = 60
+
+    def add(self, event: Event) -> None:
+        self.events.append(event)
+
+    def render(self, *, stamp: Optional[datetime] = None) -> str:
+        """
+        Serialise to an iCalendar document.
+
+        ``stamp`` is injectable so tests can assert on exact output.
+        """
+        stamp = stamp or datetime.now(timezone.utc)
+
+        lines = [
+            "BEGIN:VCALENDAR",
+            "VERSION:2.0",
+            f"PRODID:{PRODUCT_ID}",
+            "CALSCALE:GREGORIAN",
+            # PUBLISH means "here is a calendar", as opposed to REQUEST, which
+            # would be an invitation the recipient is expected to answer.
+            "METHOD:PUBLISH",
+            f"X-WR-CALNAME:{escape_text(self.name)}",
+            f"REFRESH-INTERVAL;VALUE=DURATION:PT{self.refresh_minutes}M",
+            f"X-PUBLISHED-TTL:PT{self.refresh_minutes}M",
+        ]
+
+        if self.description:
+            lines.append(f"X-WR-CALDESC:{escape_text(self.description)}")
+
+        for event in self.events:
+            lines.extend(event.to_lines(stamp=stamp))
+
+        lines.append("END:VCALENDAR")
+
+        return "".join(fold_line(line) + "\r\n" for line in lines)
+
+
+def render_calendar(
+    name: str,
+    events: Iterable[Event],
+    *,
+    description: Optional[str] = None,
+    stamp: Optional[datetime] = None,
+) -> str:
+    """Convenience wrapper for the common "render this list" case."""
+    calendar = Calendar(name=name, description=description, events=list(events))
+    return calendar.render(stamp=stamp)

--- a/backend/tests/test_calendar_feed.py
+++ b/backend/tests/test_calendar_feed.py
@@ -1,0 +1,355 @@
+"""
+Tests for the iCalendar writer and the feed token.
+
+The writer tests are the important ones. iCalendar failures are not exceptions,
+they are Outlook silently truncating a project name at the first comma, or
+Google creating a duplicate event on every poll. Those only show up in a real
+client, so the format details have to be pinned here instead.
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.services.calendar_feed_service import (
+    InvalidFeedToken,
+    generate_feed_token,
+    parse_feed_token,
+)
+from app.utils.ics import (
+    Alarm,
+    Calendar,
+    Event,
+    escape_text,
+    fold_line,
+    format_date,
+    format_utc,
+    render_calendar,
+)
+
+STAMP = datetime(2026, 3, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# ----------------------------------------------------------------------
+# Escaping
+# ----------------------------------------------------------------------
+
+
+def test_escapes_a_comma():
+    # An unescaped comma silently ends the field in several clients, so a
+    # project called "Fast, cheap, good" loses two thirds of its name.
+    assert escape_text("Fast, cheap, good") == "Fast\\, cheap\\, good"
+
+
+def test_escapes_a_semicolon():
+    assert escape_text("a;b") == "a\\;b"
+
+
+def test_escapes_a_backslash_before_anything_else():
+    # Order matters: escaping commas first and backslashes second would then
+    # escape the backslashes we had just introduced.
+    assert escape_text("a\\,b") == "a\\\\\\,b"
+
+
+def test_turns_newlines_into_the_literal_escape():
+    assert escape_text("line one\nline two") == "line one\\nline two"
+
+
+def test_normalises_crlf_and_lone_cr():
+    assert escape_text("a\r\nb") == "a\\nb"
+    assert escape_text("a\rb") == "a\\nb"
+
+
+# ----------------------------------------------------------------------
+# Folding
+# ----------------------------------------------------------------------
+
+
+def test_short_lines_are_untouched():
+    assert fold_line("SUMMARY:Hello") == "SUMMARY:Hello"
+
+
+def test_long_lines_fold_at_seventy_five_octets():
+    line = "DESCRIPTION:" + "a" * 200
+    folded = fold_line(line)
+
+    physical = folded.split("\r\n")
+    assert len(physical) > 1
+    assert len(physical[0].encode("utf-8")) <= 75
+
+    # Every continuation begins with the single space the spec requires.
+    for continuation in physical[1:]:
+        assert continuation.startswith(" ")
+        assert len(continuation.encode("utf-8")) <= 75
+
+
+def test_folding_never_splits_a_multi_byte_character():
+    # The limit is in octets, and a fold landing mid-sequence corrupts the
+    # value for every parser. Emoji are four octets each, so a naive character
+    # count gets this wrong immediately.
+    line = "SUMMARY:" + "🎉" * 60
+    folded = fold_line(line)
+
+    for physical in folded.split("\r\n"):
+        assert len(physical.encode("utf-8")) <= 75
+        # Round-tripping proves nothing was cut mid-codepoint.
+        physical.encode("utf-8").decode("utf-8")
+
+    assert folded.replace("\r\n ", "") == line
+
+
+def test_unfolding_recovers_the_original_line():
+    line = "DESCRIPTION:" + ("word " * 60).strip()
+
+    assert fold_line(line).replace("\r\n ", "") == line
+
+
+# ----------------------------------------------------------------------
+# Timestamps
+# ----------------------------------------------------------------------
+
+
+def test_formats_utc_timestamps():
+    assert format_utc(datetime(2026, 3, 1, 9, 30, 0, tzinfo=timezone.utc)) == (
+        "20260301T093000Z"
+    )
+
+
+def test_converts_a_non_utc_timestamp():
+    tz = timezone(timedelta(hours=5, minutes=30))
+    moment = datetime(2026, 3, 1, 15, 0, 0, tzinfo=tz)
+
+    assert format_utc(moment) == "20260301T093000Z"
+
+
+def test_treats_a_naive_timestamp_as_utc():
+    assert format_utc(datetime(2026, 3, 1, 9, 30, 0)) == "20260301T093000Z"
+
+
+def test_formats_dates():
+    assert format_date(datetime(2026, 3, 1).date()) == "20260301"
+
+
+# ----------------------------------------------------------------------
+# Events
+# ----------------------------------------------------------------------
+
+
+def simple_event(**overrides):
+    defaults = dict(
+        uid="hackathon-123@devlink",
+        summary="Spring Hack",
+        starts_at=datetime(2026, 4, 1, 9, 0, tzinfo=timezone.utc),
+        ends_at=datetime(2026, 4, 3, 18, 0, tzinfo=timezone.utc),
+    )
+    defaults.update(overrides)
+    return Event(**defaults)
+
+
+def render_one(event):
+    return render_calendar("Test", [event], stamp=STAMP)
+
+
+def test_a_timed_event_has_start_and_end():
+    output = render_one(simple_event())
+
+    assert "DTSTART:20260401T090000Z\r\n" in output
+    assert "DTEND:20260403T180000Z\r\n" in output
+
+
+def test_the_uid_is_emitted_verbatim():
+    # Stability is the whole point: a changing UID makes a subscribed client
+    # create a second event instead of updating the first.
+    assert "UID:hackathon-123@devlink\r\n" in render_one(simple_event())
+
+
+def test_an_all_day_event_uses_a_date_value():
+    output = render_one(
+        simple_event(
+            all_day=True,
+            starts_at=datetime(2026, 4, 1, 0, 0, tzinfo=timezone.utc),
+            ends_at=None,
+        )
+    )
+
+    assert "DTSTART;VALUE=DATE:20260401\r\n" in output
+    # No DTEND: a single-day all-day event is the default, which is exactly
+    # what a deadline should be.
+    assert "DTEND" not in output
+
+
+def test_a_url_is_not_escaped():
+    # URI values are not TEXT. A comma in a query string is legal, and
+    # escaping it produces a broken link.
+    output = render_one(simple_event(url="https://example.com/e?a=1,2"))
+
+    assert "URL:https://example.com/e?a=1,2\r\n" in output
+
+
+def test_a_summary_is_escaped():
+    output = render_one(simple_event(summary="Ship, then iterate"))
+
+    assert "SUMMARY:Ship\\, then iterate\r\n" in output
+
+
+def test_sequence_is_omitted_when_zero():
+    assert "SEQUENCE" not in render_one(simple_event())
+
+
+def test_sequence_is_emitted_when_set():
+    # Clients ignore an update whose SEQUENCE has not moved.
+    assert "SEQUENCE:3\r\n" in render_one(simple_event(sequence=3))
+
+
+def test_alarms_are_rendered():
+    output = render_one(
+        simple_event(alarms=[Alarm(minutes_before=60, description="Starting soon")])
+    )
+
+    assert "BEGIN:VALARM\r\n" in output
+    assert "TRIGGER:-PT60M\r\n" in output
+    assert "DESCRIPTION:Starting soon\r\n" in output
+    assert "END:VALARM\r\n" in output
+
+
+def test_status_is_emitted_when_set():
+    assert "STATUS:CANCELLED\r\n" in render_one(simple_event(status="CANCELLED"))
+
+
+# ----------------------------------------------------------------------
+# Calendar envelope
+# ----------------------------------------------------------------------
+
+
+def test_the_document_is_well_formed():
+    output = render_one(simple_event())
+
+    assert output.startswith("BEGIN:VCALENDAR\r\n")
+    assert output.endswith("END:VCALENDAR\r\n")
+    assert "VERSION:2.0\r\n" in output
+    assert "PRODID:-//DevLink//Calendar Feed//EN\r\n" in output
+
+
+def test_every_line_ends_with_crlf():
+    # Some parsers accept a bare \n and some do not, and the ones that do not
+    # fail in ways that are hard to trace back here.
+    output = render_one(simple_event())
+
+    for line in output.split("\r\n")[:-1]:
+        assert "\n" not in line
+
+
+def test_the_stamp_is_the_generation_time_not_the_event_time():
+    assert "DTSTAMP:20260301T120000Z\r\n" in render_one(simple_event())
+
+
+def test_an_empty_calendar_still_renders():
+    # A user with nothing scheduled must get a valid empty calendar, not an
+    # error -- their client polls this URL regardless.
+    output = Calendar(name="Empty").render(stamp=STAMP)
+
+    assert output.startswith("BEGIN:VCALENDAR\r\n")
+    assert output.endswith("END:VCALENDAR\r\n")
+    assert "BEGIN:VEVENT" not in output
+
+
+def test_multiple_events_are_all_present():
+    output = render_calendar(
+        "Test",
+        [simple_event(uid="a@devlink"), simple_event(uid="b@devlink")],
+        stamp=STAMP,
+    )
+
+    assert output.count("BEGIN:VEVENT\r\n") == 2
+    assert "UID:a@devlink\r\n" in output
+    assert "UID:b@devlink\r\n" in output
+
+
+def test_the_refresh_interval_is_advertised():
+    output = Calendar(name="Test", refresh_minutes=180).render(stamp=STAMP)
+
+    assert "REFRESH-INTERVAL;VALUE=DURATION:PT180M\r\n" in output
+    assert "X-PUBLISHED-TTL:PT180M\r\n" in output
+
+
+def test_a_calendar_name_containing_a_comma_is_escaped():
+    output = Calendar(name="Work, and play").render(stamp=STAMP)
+
+    assert "X-WR-CALNAME:Work\\, and play\r\n" in output
+
+
+# ----------------------------------------------------------------------
+# Feed tokens
+# ----------------------------------------------------------------------
+
+
+def test_a_token_round_trips():
+    user_id = uuid.uuid4()
+
+    assert parse_feed_token(generate_feed_token(user_id)) == user_id
+
+
+def test_tokens_are_url_safe():
+    token = generate_feed_token(uuid.uuid4())
+
+    # It goes in a query string, so anything needing percent-encoding would
+    # break a naive client.
+    assert "+" not in token
+    assert "/" not in token
+    assert "=" not in token
+
+
+def test_a_tampered_user_id_is_rejected():
+    token = generate_feed_token(uuid.uuid4())
+    version, encoded_id, issued, signature = token.split(".")
+
+    forged = f"{version}.{generate_feed_token(uuid.uuid4()).split('.')[1]}.{issued}.{signature}"
+
+    with pytest.raises(InvalidFeedToken):
+        parse_feed_token(forged)
+
+
+def test_a_tampered_signature_is_rejected():
+    token = generate_feed_token(uuid.uuid4())
+    version, encoded_id, issued, _ = token.split(".")
+
+    with pytest.raises(InvalidFeedToken):
+        parse_feed_token(f"{version}.{encoded_id}.{issued}.AAAAAAAA")
+
+
+def test_an_expired_token_is_rejected():
+    old = datetime.now(timezone.utc) - timedelta(days=400)
+
+    with pytest.raises(InvalidFeedToken):
+        parse_feed_token(generate_feed_token(uuid.uuid4(), issued_at=old))
+
+
+def test_a_token_just_inside_the_window_is_accepted():
+    user_id = uuid.uuid4()
+    recent = datetime.now(timezone.utc) - timedelta(days=364)
+
+    assert parse_feed_token(generate_feed_token(user_id, issued_at=recent)) == user_id
+
+
+@pytest.mark.parametrize(
+    "token",
+    ["", "nonsense", "v1.a.b", "v1.a.b.c.d", "v2.a.b.c"],
+)
+def test_malformed_tokens_are_rejected(token):
+    with pytest.raises(InvalidFeedToken):
+        parse_feed_token(token)
+
+
+def test_two_tokens_for_the_same_user_differ_by_issue_time():
+    user_id = uuid.uuid4()
+    now = datetime.now(timezone.utc)
+
+    first = generate_feed_token(user_id, issued_at=now)
+    second = generate_feed_token(user_id, issued_at=now + timedelta(seconds=1))
+
+    assert first != second
+    # Both are still valid: issuing a new one does not invalidate the old,
+    # which is the documented limitation of stateless tokens.
+    assert parse_feed_token(first) == user_id
+    assert parse_feed_token(second) == user_id

--- a/docs/calendar_feeds.md
+++ b/docs/calendar_feeds.md
@@ -1,0 +1,136 @@
+# Calendar Feeds
+
+DevLink knows about two kinds of dated commitment — hackathons a user has
+registered for, and milestones on projects they are a member of. This exposes
+both as iCalendar (RFC 5545), the format Google Calendar, Apple Calendar and
+Outlook all understand.
+
+## Two shapes, two problems
+
+**A single-event download** works offline, works when the user is not signed in
+on their phone, and creates no ongoing relationship with us. Good for an "Add
+to calendar" button.
+
+**A subscribable feed** is a URL the user pastes into their calendar client
+once. The client then polls it forever and their DevLink dates stay in sync
+without them doing anything. This is the one people actually want.
+
+## Endpoints
+
+| Endpoint | Auth | Purpose |
+| --- | --- | --- |
+| `GET /api/calendar/feed-token` | Session | Mint a feed token and return the subscribe URL |
+| `GET /api/calendar/events.ics?token=…` | Feed token | The subscribable feed |
+| `GET /api/calendar/hackathons/{id}.ics` | Session | One hackathon |
+| `GET /api/calendar/milestones/{id}.ics` | Session | One milestone |
+
+The single-event endpoints send `Content-Disposition: attachment`, which is
+what makes a browser hand the file to the calendar application instead of
+rendering it as text. The feed endpoint deliberately does **not** — it is polled
+by a subscription, and an attachment header turns every manual visit into a
+download prompt.
+
+## Why the feed needs its own token
+
+Calendar clients do not do OAuth. They do "GET this URL, forever, with no
+headers I control". So the feed cannot use a session cookie or a bearer token;
+the secret has to live in the URL.
+
+The token is:
+
+* **Scoped.** It authenticates nothing except the calendar feed. A leaked feed
+  URL exposes the user's hackathon and milestone titles, and nothing else — no
+  messages, no profile edits, no session.
+* **Signed.** HMAC-SHA256 over the version, user id and issue time, using a key
+  derived from `SECRET_KEY` and `CALENDAR_FEED_TOKEN_SALT`. Deriving rather
+  than using `SECRET_KEY` directly means a feed token can never be confused
+  with a session token even if one format changes later.
+* **Expiring.** A year by default, so a URL abandoned in a browser history
+  stops working.
+* **Stateless.** No new table, no migration.
+
+A bad token gets **404, not 401**. A 401 that distinguishes "wrong token" from
+"no such feed" is an oracle for guessing tokens, and a calendar client cannot
+do anything useful with a 401 anyway.
+
+### The limitation, stated plainly
+
+Because tokens are stateless, **a single leaked token cannot be revoked on its
+own**. Two levers exist today:
+
+1. Wait for it to expire (365 days by default; lower
+   `CALENDAR_FEED_TOKEN_MAX_AGE_DAYS` to shorten that).
+2. Change `CALENDAR_FEED_TOKEN_SALT` and restart, which invalidates **every**
+   issued feed URL at once.
+
+Calling `GET /api/calendar/feed-token` again issues a new token but does not
+invalidate the old one.
+
+Proper per-user revocation needs something to revoke against — a
+`calendar_feed_tokens` table with a row per issued token, or a nonce column on
+`users`. That is a small change and a good follow-up; it was left out here
+because the repository already carries 13 alembic heads and adding a 14th
+inside a feature PR is not a trade worth making.
+
+## What ends up in the feed
+
+**Hackathons** the user has registered for. Not every hackathon on the platform
+— that is a newsletter, not a calendar. Rendered as a timed event from
+`starts_at` to `ends_at`, with the theme, prize and registration deadline in
+the description, and an alarm an hour before it starts.
+
+**Milestones** on projects the user is an active member of, with a due date,
+not completed and not archived. Rendered as an **all-day** event, because a due
+date has no meaningful time of day and rendering it at midnight puts every
+deadline in the small hours of the client's display. Alarm a day before.
+
+Both are limited to a rolling window: 90 days back, 365 forward. A hackathon
+that finished two years ago is not something anybody wants filling their
+calendar.
+
+## Getting the format right
+
+iCalendar failures are not exceptions. They are Outlook quietly truncating a
+project name at the first comma, or Google creating a duplicate event on every
+poll. Those only surface in a real client, which is why `app/utils/ics.py` is
+fussy about four things and the tests pin all of them:
+
+**Line folding at 75 octets.** The limit is in octets, not characters, and a
+fold that lands in the middle of a UTF-8 sequence corrupts the value for every
+parser. The folder walks encoded lengths and only breaks where a character
+ends. Continuation lines carry the leading space the spec requires — and that
+space counts toward the next line's own limit.
+
+**Escaping.** `\`, `;`, `,` and newlines are special inside a TEXT value.
+Backslash is escaped first, or we would escape the backslashes we had just
+introduced. URI values such as `URL:` are **not** TEXT and must not be escaped
+— a comma in a query string is legal and escaping it breaks the link.
+
+**CRLF.** The spec says CRLF. Some parsers accept a bare `\n` and some do not,
+and the ones that do not fail obscurely.
+
+**Stable UIDs.** `hackathon-{id}@devlink`, `milestone-{id}@devlink`. If a UID
+changes between polls, the client does not update the event — it creates a
+second one. This is the single most common way a hand-rolled feed goes wrong,
+and it only shows up after the user has been subscribed for a week.
+
+`SEQUENCE` is emitted when non-zero, because clients ignore an update whose
+sequence has not moved.
+
+## Configuration
+
+| Setting | Default | Notes |
+| --- | --- | --- |
+| `CALENDAR_FEED_TOKEN_SALT` | `devlink-calendar-feed` | Change to invalidate every issued feed URL. |
+| `CALENDAR_FEED_TOKEN_MAX_AGE_DAYS` | `365` | |
+| `CALENDAR_FEED_REFRESH_MINUTES` | `360` | Advertised via `REFRESH-INTERVAL` and `X-PUBLISHED-TTL`. Without a hint, clients pick their own interval. |
+
+## Subscribing
+
+1. `GET /api/calendar/feed-token` → copy `feed_url`.
+2. Google Calendar: *Other calendars → From URL*.
+   Apple Calendar: *File → New Calendar Subscription*.
+   Outlook: *Add calendar → Subscribe from web*.
+
+Clients cache aggressively and mostly ignore `REFRESH-INTERVAL`; an hour or two
+of lag on a newly added event is normal and not a bug in the feed.


### PR DESCRIPTION
Closes #877

## What this adds

```
GET /api/calendar/feed-token                 → mint a token, get the subscribe URL
GET /api/calendar/events.ics?token=…         → the subscribable feed
GET /api/calendar/hackathons/{id}.ics        → one hackathon
GET /api/calendar/milestones/{id}.ics        → one milestone
```

The single-event endpoints send `Content-Disposition: attachment`, which is what makes a browser hand the file to the calendar application instead of rendering it as text. The feed endpoint deliberately does **not** — it is polled by a subscription, and an attachment header turns every manual visit into a download prompt.

## Why the feed needs its own credential

Calendar clients do not do OAuth. They do *"GET this URL, forever, with no headers I control"*. So the feed cannot use a session cookie or a bearer token — the secret has to live in the URL.

The token is an HMAC-SHA256 over version, user id and issue time, keyed on a value derived from `SECRET_KEY` and `CALENDAR_FEED_TOKEN_SALT`. Deriving rather than using `SECRET_KEY` directly means a feed token can never be confused with a session token even if one of the formats changes later.

It is **scoped** — a leaked feed URL exposes hackathon and milestone titles and nothing else. No messages, no profile, no session. It **expires** after a year. And it is **stateless**, so no new table and no fourteenth alembic head.

A bad token gets **404, not 401**. A 401 that distinguishes "wrong token" from "no such feed" is an oracle for guessing tokens, and a calendar client cannot act on a 401 anyway.

### The limitation, stated plainly

Because the tokens are stateless, **a single leaked token cannot be revoked on its own**. The levers are: wait for expiry, or change `CALENDAR_FEED_TOKEN_SALT` and restart, which kills every issued feed URL at once. Calling `feed-token` again issues a new token but does not invalidate the old one.

Proper per-user revocation needs something to revoke against — a `calendar_feed_tokens` table, or a nonce column on `users`. Small change, good follow-up. It is not in this PR because the repo already carries **13 alembic heads**, and adding a 14th inside a feature PR is not a trade worth making. `docs/calendar_feeds.md` says all of this in the same words, so nobody has to rediscover it from the code.

## Where the care went

Most of the work is in `app/utils/ics.py`, because iCalendar failures are not exceptions. They are:

* Outlook silently truncating a project called `Fast, cheap, good` at the first comma.
* Google creating a *duplicate* event on every poll, forever, because the UID moved.

Both only appear in a real client, days later, and neither produces an error anywhere. So the writer is fussy about four things and the tests pin every one:

**Folding at 75 octets.** The limit is octets, not characters, and a fold landing mid-UTF-8-sequence corrupts the value for every parser. The folder walks encoded lengths. It also accounts for the continuation line's leading space eating one octet of its own budget — an easy off-by-one that produces 76-octet lines. Tested with emoji straddling the boundary, plus an unfold round-trip.

**Escaping.** Backslash first, or we escape the backslashes we just introduced. `;` `,` and newlines after. URI values are **not** TEXT and are left alone — a comma in a query string is legal and escaping it breaks the link.

**CRLF.** Some parsers accept a bare `\n` and some do not; the ones that do not fail obscurely.

**Stable UIDs.** `hackathon-{id}@devlink` / `milestone-{id}@devlink`, derived from the entity, never regenerated. `SEQUENCE` is emitted when non-zero, because clients ignore an update whose sequence has not moved.

## Modelling decisions

* **Milestones are all-day events.** A due date has no meaningful time of day; rendering it at midnight puts every deadline in the small hours of the client's display. All-day uses `VALUE=DATE`, and a single-day event correctly omits `DTEND`.
* **Only registered hackathons.** A feed of every hackathon on the platform is a newsletter, not a calendar.
* **Only active, incomplete, unarchived milestones.** A done deadline in a calendar is noise.
* **A rolling 90-back / 365-forward window.** A hackathon that finished two years ago is not something anybody wants filling their calendar.
* **Alarms are asymmetric** — a day before a deadline, an hour before an event. A deadline needs warning; an event needs a nudge.
* Access checks 404 rather than 403, so an unpublished hackathon does not confirm its own existence to somebody who cannot see it.

## Tests

```
$ pytest tests/test_calendar_feed.py -q
41 passed
```

Endpoints smoke-checked against the running app: bad feed token → `404`, `feed-token` unauthenticated → `401`, single-event unauthenticated → `401`.

`black --check` clean on all new files.

## Notes for review

* No new model, no migration.
* `main.py` gains two lines at line 530.
* Docs in `docs/calendar_feeds.md`, including subscribe instructions for the three major clients and a note that they cache aggressively and mostly ignore `REFRESH-INTERVAL` — an hour or two of lag on a new event is normal, not a bug in the feed.
