### PR TITLE
feat: add content moderation and spam scoring for user-submitted text

### DIFF
--- a/backend/app/core/moderation_terms.py
+++ b/backend/app/core/moderation_terms.py
@@ -1,0 +1,192 @@
+"""
+The word lists and patterns the moderation service scores against.
+
+Kept apart from the scoring logic on purpose: a maintainer adding a term that
+keeps showing up should not have to read, or risk breaking, the scoring code.
+Everything here is data.
+
+Terms are written in ordinary spelling. The service normalises both the term
+and the text before comparing, so there is no need to enumerate ``f4ck``,
+``fυck`` and ``f.u.c.k`` -- see ``app/utils/text_normalize.py``.
+"""
+
+from __future__ import annotations
+
+import re
+
+# ----------------------------------------------------------------------
+# Profanity
+# ----------------------------------------------------------------------
+
+# Coarse language. On its own this is a *flag*, not a block: plenty of
+# perfectly good technical discussion is sweary, and a platform for developers
+# that blocks "this API is a shitshow" is a platform nobody uses.
+PROFANITY = frozenset(
+    {
+        "arse",
+        "arsehole",
+        "asshole",
+        "bastard",
+        "bitch",
+        "bollocks",
+        "bullshit",
+        "cock",
+        "crap",
+        "cunt",
+        "damn",
+        "dick",
+        "dickhead",
+        "douchebag",
+        "fuck",
+        "fucker",
+        "fucking",
+        "motherfucker",
+        "piss",
+        "prick",
+        "shit",
+        "shite",
+        "shithead",
+        "slut",
+        "twat",
+        "wanker",
+        "whore",
+    }
+)
+
+# Language aimed at a person rather than a situation. Weighted much harder
+# than profanity, because "this is shit" and "you are worthless" are not the
+# same act even though both contain a word from a list.
+HARASSMENT = frozenset(
+    {
+        "kill yourself",
+        "kys",
+        "go die",
+        "hope you die",
+        "nobody likes you",
+        "you are worthless",
+        "youre worthless",
+        "you should die",
+        "end yourself",
+        "neck yourself",
+    }
+)
+
+# Slurs are held separately and scored at the maximum. This list is
+# deliberately short and non-exhaustive in the repository; deployments are
+# expected to extend it, and the scoring code does not need to change when
+# they do.
+SLURS = frozenset(
+    {
+        "retard",
+        "retarded",
+        "tranny",
+        "faggot",
+        "fag",
+    }
+)
+
+# ----------------------------------------------------------------------
+# Spam
+# ----------------------------------------------------------------------
+
+# Phrasings that essentially never appear in a genuine project description or
+# a message between collaborators.
+SPAM_PHRASES = frozenset(
+    {
+        "act now",
+        "buy followers",
+        "cheap followers",
+        "click here now",
+        "crypto giveaway",
+        "double your money",
+        "dm me for",
+        "earn money fast",
+        "financial freedom",
+        "forex signals",
+        "free bitcoin",
+        "free gift card",
+        "guaranteed returns",
+        "investment opportunity",
+        "limited time offer",
+        "make money online",
+        "no experience needed",
+        "risk free",
+        "telegram me",
+        "text me on whatsapp",
+        "work from home",
+        "100% free",
+    }
+)
+
+# Shorteners hide their destination, which is the entire reason they get used
+# in spam. There is no legitimate reason for one in a project description.
+URL_SHORTENERS = frozenset(
+    {
+        "bit.ly",
+        "buff.ly",
+        "cutt.ly",
+        "goo.gl",
+        "is.gd",
+        "ow.ly",
+        "rb.gy",
+        "rebrand.ly",
+        "shorturl.at",
+        "t.co",
+        "tinyurl.com",
+        "t.me",
+        "tiny.cc",
+    }
+)
+
+# Domains that are ordinary in this context and should never count toward a
+# link-density score. A project description with five GitHub links is a
+# thorough project description.
+ALLOWED_DOMAINS = frozenset(
+    {
+        "github.com",
+        "gitlab.com",
+        "bitbucket.org",
+        "npmjs.com",
+        "pypi.org",
+        "crates.io",
+        "stackoverflow.com",
+        "developer.mozilla.org",
+        "docs.python.org",
+        "readthedocs.io",
+        "figma.com",
+        "notion.so",
+        "linkedin.com",
+        "devlink.dev",
+    }
+)
+
+# ----------------------------------------------------------------------
+# Patterns
+# ----------------------------------------------------------------------
+
+URL_PATTERN = re.compile(r"https?://[^\s<>\"')]+", re.IGNORECASE)
+
+EMAIL_PATTERN = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+")
+
+# Deliberately loose. Precision does not matter here: this is one weighted
+# signal among several, and the cost of matching a version string once in a
+# while is a slightly higher score, not a block.
+PHONE_PATTERN = re.compile(r"(?:\+?\d[\d\s().-]{7,}\d)")
+
+# Words that are only interesting next to a contact detail. "Reach me at" plus
+# an email is somebody routing around the platform; an email on its own in a
+# bug report is just an email.
+CONTACT_SOLICITATION = frozenset(
+    {
+        "whatsapp",
+        "telegram",
+        "signal",
+        "wechat",
+        "skype",
+        "dm me",
+        "message me",
+        "contact me at",
+        "reach me at",
+        "email me at",
+    }
+)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -544,6 +544,8 @@ app.include_router(followers.router, prefix="/api/followers", tags=["Followers"]
 app.include_router(bookmarks.router, prefix="/api/bookmarks", tags=["Bookmarks"])
 app.include_router(bookmark_collections.router, prefix="/api/bookmark-collections", tags=["Bookmark Collections"])
 app.include_router(activities.router, prefix="/api/activities", tags=["Activities"])
+from app.routers import moderation
+app.include_router(moderation.router, prefix="/api", tags=["Moderation"])
 app.include_router(conversations.router, prefix="/api/conversations", tags=["Conversations"])
 from app.routers import audit
 

--- a/backend/app/routers/moderation.py
+++ b/backend/app/routers/moderation.py
@@ -1,0 +1,79 @@
+"""
+Moderation preview endpoint.
+
+The service is meant to be called inline from write paths -- message send,
+project create, profile update -- rather than over HTTP. This endpoint exists
+so that:
+
+* the frontend can warn somebody *before* they hit send, which is a far better
+  experience than a rejection afterwards, and
+* moderators can check why a particular piece of text scored the way it did
+  without reading the source.
+
+It scores text and returns nothing about anybody else, so it is safe for any
+authenticated user to call about their own draft.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Request
+
+from app.dependencies import get_current_user
+from app.middleware.rate_limit import limiter
+from app.models.user import User
+from app.schemas.moderation import (
+    ModerationCheckRequest,
+    ModerationCheckResponse,
+    ModerationSignalResponse,
+)
+from app.services.moderation_service import AuthorContext, moderation_service
+
+router = APIRouter(
+    prefix="/moderation",
+    tags=["Moderation"],
+)
+
+MODERATION_LIMIT = "60/minute"
+
+
+@router.post(
+    "/check",
+    response_model=ModerationCheckResponse,
+    summary="Score a piece of text for abuse and spam",
+)
+@limiter.limit(MODERATION_LIMIT)
+def check_text(
+    request: Request,
+    body: ModerationCheckRequest,
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Score text and recommend an action.
+
+    Returns a recommendation, not a decision: the caller chooses what to do
+    with it, because a profile bio and a direct message do not warrant the same
+    threshold.
+    """
+    result = moderation_service.check(
+        body.text,
+        author=AuthorContext(
+            account_age_days=body.account_age_days,
+            prior_flags=body.prior_flags,
+            is_verified=body.is_verified,
+        ),
+    )
+
+    return ModerationCheckResponse(
+        action=result.action.value,
+        score=result.score,
+        signals=[
+            ModerationSignalResponse(
+                category=s.category.value,
+                rule=s.rule,
+                weight=s.weight,
+                detail=s.detail,
+            )
+            for s in result.signals
+        ],
+        explanation=result.explain(),
+    )

--- a/backend/app/schemas/moderation.py
+++ b/backend/app/schemas/moderation.py
@@ -1,0 +1,75 @@
+"""Request and response shapes for the moderation preview endpoint."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+MAX_TEXT_LENGTH = 20000
+
+
+class ModerationCheckRequest(BaseModel):
+    """Text to score, plus optional context about who wrote it."""
+
+    text: str = Field(min_length=1, max_length=MAX_TEXT_LENGTH)
+
+    account_age_days: Optional[int] = Field(
+        default=None,
+        ge=0,
+        description="Age of the author's account. Changes the weighting; a new account posting links is not the same event as an old one doing it.",
+    )
+    prior_flags: int = Field(
+        default=0,
+        ge=0,
+        description="How many of the author's previous submissions were flagged.",
+    )
+    is_verified: bool = False
+
+
+class ModerationSignalResponse(BaseModel):
+    """One rule that fired."""
+
+    category: str
+    rule: str
+    weight: float
+    detail: str = ""
+
+
+class ModerationCheckResponse(BaseModel):
+    """
+    The recommendation, and every rule behind it.
+
+    The signals are always returned. A moderation decision nobody can explain
+    is a moderation decision nobody can appeal, and somebody will eventually
+    have to answer a "why was my post blocked" ticket.
+    """
+
+    action: str = Field(description="One of: allow, flag, review, block.")
+    score: float
+    signals: list[ModerationSignalResponse]
+    explanation: str
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "action": "review",
+                "score": 0.75,
+                "signals": [
+                    {
+                        "category": "spam",
+                        "rule": "url_shortener",
+                        "weight": 0.4,
+                        "detail": "bit.ly",
+                    },
+                    {
+                        "category": "spam",
+                        "rule": "spam_phrase",
+                        "weight": 0.3,
+                        "detail": "guaranteed returns",
+                    },
+                ],
+                "explanation": "review @ 0.75: url_shortener (+0.40), spam_phrase (+0.30)",
+            }
+        }
+    }

--- a/backend/app/services/moderation_service.py
+++ b/backend/app/services/moderation_service.py
@@ -1,0 +1,479 @@
+"""
+Scoring user-submitted text for abuse and spam.
+
+DevLink's moderation story today is entirely reactive: something gets posted,
+somebody reads it, somebody reports it, a moderator eventually acts. That works
+for a small community and stops working the moment the platform is worth
+spamming.
+
+This is the deterministic layer that runs on every write. It returns a
+**recommendation**, not a verdict:
+
+    ALLOW   nothing interesting
+    FLAG    publish it, but queue it for review
+    REVIEW  hold it, a moderator decides
+    BLOCK   refuse it, and tell the author why
+
+The caller decides what to do with the recommendation, because a profile bio
+and a direct message should not share a threshold. That is a call-site
+decision, not a property of the text.
+
+Every result carries the rules that fired and what each contributed. An
+unexplainable moderation decision is an unappealable one, and somebody will
+eventually have to answer a "why was my post blocked" ticket.
+
+Deliberately not a model. A model cannot be unit-tested against "does
+Scunthorpe still work", and this layer has to be cheap enough to run inline on
+every submission.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+from urllib.parse import urlparse
+
+from app.core.moderation_terms import (
+    ALLOWED_DOMAINS,
+    CONTACT_SOLICITATION,
+    EMAIL_PATTERN,
+    HARASSMENT,
+    PHONE_PATTERN,
+    PROFANITY,
+    SLURS,
+    SPAM_PHRASES,
+    URL_PATTERN,
+    URL_SHORTENERS,
+)
+from app.utils.text_normalize import (
+    evasion_pattern,
+    normalise,
+    repeated_character_runs,
+    shout_ratio,
+    words,
+)
+
+# Compiled once at import. Only terms of four characters or more get an
+# evasion pattern: below that the pattern is loose enough to start matching
+# ordinary text, and the short terms on the list are the mild ones anyway.
+_EVASION_PATTERNS = [
+    (term, evasion_pattern(term))
+    for term in sorted(PROFANITY | SLURS)
+    if len(term) >= 4
+]
+
+
+class Action(str, Enum):
+    ALLOW = "allow"
+    FLAG = "flag"
+    REVIEW = "review"
+    BLOCK = "block"
+
+
+class Category(str, Enum):
+    PROFANITY = "profanity"
+    HARASSMENT = "harassment"
+    SLUR = "slur"
+    SPAM = "spam"
+    CONTACT_HARVESTING = "contact_harvesting"
+    FORMATTING = "formatting"
+
+
+# Score thresholds. These are the defaults; a caller that wants a stricter or
+# looser line passes its own.
+DEFAULT_THRESHOLDS = {
+    Action.BLOCK: 1.0,
+    Action.REVIEW: 0.6,
+    Action.FLAG: 0.3,
+}
+
+# Below this many characters the ratio-based signals are meaningless -- "OK!"
+# is 100% uppercase and is not shouting.
+MIN_LENGTH_FOR_RATIOS = 20
+
+
+@dataclass(frozen=True)
+class Signal:
+    """One rule that fired, and what it contributed."""
+
+    category: Category
+    rule: str
+    weight: float
+    detail: str = ""
+
+
+@dataclass
+class ModerationResult:
+    """
+    The verdict on a piece of text.
+
+    ``score`` is unbounded above; it saturates at the block threshold in
+    practice, but leaving it uncapped means the difference between "one swear
+    word" and "a wall of slurs" survives into the audit log.
+    """
+
+    action: Action
+    score: float
+    signals: list[Signal] = field(default_factory=list)
+
+    @property
+    def categories(self) -> set[Category]:
+        return {s.category for s in self.signals}
+
+    @property
+    def is_allowed(self) -> bool:
+        return self.action == Action.ALLOW
+
+    @property
+    def needs_human(self) -> bool:
+        return self.action in (Action.REVIEW, Action.BLOCK)
+
+    def explain(self) -> str:
+        """
+        A one-line, human-readable reason.
+
+        This is what ends up in a moderator queue and, in redacted form, in the
+        message shown to the author.
+        """
+        if not self.signals:
+            return "No moderation signals."
+
+        parts = [f"{s.rule} ({s.weight:+.2f})" for s in self.signals]
+        return f"{self.action.value} @ {self.score:.2f}: " + ", ".join(parts)
+
+
+@dataclass(frozen=True)
+class AuthorContext:
+    """
+    What we know about who is writing.
+
+    Optional, and the service works without it, but it changes the answer a
+    lot. A brand-new account posting five links is not the same event as a
+    two-year-old account doing it, and no amount of keyword matching can tell
+    those apart.
+    """
+
+    account_age_days: Optional[int] = None
+    prior_flags: int = 0
+    is_verified: bool = False
+
+
+class ModerationService:
+    """Pure scoring. No database, no network, no state."""
+
+    def check(
+        self,
+        text: str,
+        *,
+        author: Optional[AuthorContext] = None,
+        thresholds: Optional[dict] = None,
+    ) -> ModerationResult:
+        """Score a piece of text and recommend an action."""
+        if not text or not text.strip():
+            return ModerationResult(action=Action.ALLOW, score=0.0)
+
+        signals: list[Signal] = []
+        signals.extend(self._abuse_signals(text))
+        signals.extend(self._spam_signals(text))
+        signals.extend(self._formatting_signals(text))
+
+        score = sum(s.weight for s in signals)
+        score *= self._author_multiplier(author, signals)
+
+        return ModerationResult(
+            action=self._action_for(score, thresholds or DEFAULT_THRESHOLDS),
+            score=round(score, 3),
+            signals=signals,
+        )
+
+    # ------------------------------------------------------------------
+    # Abuse
+    # ------------------------------------------------------------------
+
+    def _abuse_signals(self, text: str) -> list[Signal]:
+        signals: list[Signal] = []
+
+        normalised = normalise(text)
+        token_set = set(words(text))
+
+        # Whole-word matching against the normalised text. This is what keeps
+        # "assignment" and "Scunthorpe" out of the results -- a substring check
+        # flags both, and the resulting bug report is embarrassing.
+        profanity_hits = sorted(token_set & PROFANITY)
+        if profanity_hits:
+            # Coarse language on its own is a flag, not a block. A developer
+            # platform that refuses "this API is a shitshow" is unusable.
+            signals.append(
+                Signal(
+                    category=Category.PROFANITY,
+                    rule="profanity",
+                    weight=min(0.3 + 0.15 * (len(profanity_hits) - 1), 0.6),
+                    detail=", ".join(profanity_hits),
+                )
+            )
+
+        slur_hits = sorted(token_set & SLURS)
+        if slur_hits:
+            signals.append(
+                Signal(
+                    category=Category.SLUR,
+                    rule="slur",
+                    weight=1.0,
+                    detail=", ".join(slur_hits),
+                )
+            )
+
+        # Harassment terms are phrases, so they are matched against the
+        # normalised string rather than the token set.
+        harassment_hits = sorted(p for p in HARASSMENT if p in normalised)
+        if harassment_hits:
+            signals.append(
+                Signal(
+                    category=Category.HARASSMENT,
+                    rule="harassment",
+                    weight=1.0,
+                    detail=", ".join(harassment_hits),
+                )
+            )
+
+        # Evasion. Each pattern tolerates separators and substitutions *inside*
+        # the term while still requiring a word boundary around the whole
+        # match, which is what catches "f u c k" without catching "Scunthorpe".
+        # Only checked when plain matching found nothing, since a plain hit
+        # already scored.
+        if not profanity_hits and not slur_hits:
+            evaded = [
+                term
+                for term, pattern in _EVASION_PATTERNS
+                if pattern.search(normalised)
+            ]
+            if evaded:
+                # Scored a little below a plain hit: deliberate obfuscation is
+                # evidence of intent, but the pattern is looser than an exact
+                # match and should not block on its own.
+                signals.append(
+                    Signal(
+                        category=Category.PROFANITY,
+                        rule="obfuscated_term",
+                        weight=0.35,
+                        detail=", ".join(evaded[:3]),
+                    )
+                )
+
+        return signals
+
+    # ------------------------------------------------------------------
+    # Spam
+    # ------------------------------------------------------------------
+
+    def _spam_signals(self, text: str) -> list[Signal]:
+        signals: list[Signal] = []
+        normalised = normalise(text)
+
+        urls = URL_PATTERN.findall(text)
+        domains = [self._domain(u) for u in urls]
+        notable = [d for d in domains if d and d not in ALLOWED_DOMAINS]
+
+        # Link density relative to length. Three links in a paragraph is a
+        # well-referenced paragraph; three links in fifteen words is a drop.
+        word_count = max(len(normalised.split()), 1)
+        if len(notable) >= 2 and word_count < len(notable) * 25:
+            signals.append(
+                Signal(
+                    category=Category.SPAM,
+                    rule="link_density",
+                    weight=min(0.2 * len(notable), 0.6),
+                    detail=f"{len(notable)} links in {word_count} words",
+                )
+            )
+
+        shorteners = sorted({d for d in domains if d in URL_SHORTENERS})
+        if shorteners:
+            # A shortener hides its destination, which is the whole reason it
+            # gets used here. There is no innocent version of this in a
+            # project description.
+            signals.append(
+                Signal(
+                    category=Category.SPAM,
+                    rule="url_shortener",
+                    weight=0.4 * len(shorteners),
+                    detail=", ".join(shorteners),
+                )
+            )
+
+        phrase_hits = sorted(p for p in SPAM_PHRASES if p in normalised)
+        if phrase_hits:
+            signals.append(
+                Signal(
+                    category=Category.SPAM,
+                    rule="spam_phrase",
+                    weight=min(0.3 * len(phrase_hits), 0.9),
+                    detail=", ".join(phrase_hits[:3]),
+                )
+            )
+
+        signals.extend(self._contact_signals(text, normalised))
+
+        return signals
+
+    def _contact_signals(self, text: str, normalised: str) -> list[Signal]:
+        """
+        Contact details, weighted by whether they are being *solicited*.
+
+        An email address in a bug report is an email address. "Reach me at"
+        followed by an email is somebody routing around the platform, which is
+        the shape of both recruitment spam and most scams.
+        """
+        signals: list[Signal] = []
+
+        solicits = sorted(p for p in CONTACT_SOLICITATION if p in normalised)
+        has_email = bool(EMAIL_PATTERN.search(text))
+        has_phone = bool(PHONE_PATTERN.search(text))
+
+        if solicits and (has_email or has_phone):
+            signals.append(
+                Signal(
+                    category=Category.CONTACT_HARVESTING,
+                    rule="solicited_contact_details",
+                    weight=0.5,
+                    detail=", ".join(solicits[:3]),
+                )
+            )
+        elif solicits:
+            signals.append(
+                Signal(
+                    category=Category.CONTACT_HARVESTING,
+                    rule="offsite_contact_request",
+                    weight=0.25,
+                    detail=", ".join(solicits[:3]),
+                )
+            )
+
+        return signals
+
+    # ------------------------------------------------------------------
+    # Formatting
+    # ------------------------------------------------------------------
+
+    def _formatting_signals(self, text: str) -> list[Signal]:
+        """
+        Shouting and character mashing.
+
+        Weak signals individually -- somebody is allowed to be excited -- but
+        they correlate strongly with everything else on this list, so they earn
+        their place as a tiebreaker.
+        """
+        signals: list[Signal] = []
+
+        if len(text) >= MIN_LENGTH_FOR_RATIOS:
+            ratio = shout_ratio(text)
+            if ratio > 0.7:
+                signals.append(
+                    Signal(
+                        category=Category.FORMATTING,
+                        rule="excessive_caps",
+                        weight=0.2,
+                        detail=f"{ratio:.0%} uppercase",
+                    )
+                )
+
+        runs = repeated_character_runs(text)
+        if runs >= 3:
+            signals.append(
+                Signal(
+                    category=Category.FORMATTING,
+                    rule="character_repetition",
+                    weight=0.15,
+                    detail=f"{runs} runs",
+                )
+            )
+
+        tokens = words(text)
+        if len(tokens) >= 8:
+            distinct_ratio = len(set(tokens)) / len(tokens)
+            if distinct_ratio < 0.35:
+                signals.append(
+                    Signal(
+                        category=Category.FORMATTING,
+                        rule="word_repetition",
+                        weight=0.25,
+                        detail=f"{distinct_ratio:.0%} distinct",
+                    )
+                )
+
+        return signals
+
+    # ------------------------------------------------------------------
+    # Context and thresholds
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _author_multiplier(
+        author: Optional[AuthorContext],
+        signals: list[Signal],
+    ) -> float:
+        """
+        Weight the score by who is writing.
+
+        Applied only when something already fired: a trusted account's clean
+        post and a new account's clean post are both zero, and multiplying zero
+        is pointless. The account-age effect deliberately does not apply to
+        slurs and harassment -- seniority is not a licence.
+        """
+        if author is None or not signals:
+            return 1.0
+
+        severe = {Category.SLUR, Category.HARASSMENT}
+        if severe & {s.category for s in signals}:
+            return 1.0
+
+        multiplier = 1.0
+
+        if author.account_age_days is not None:
+            if author.account_age_days < 1:
+                multiplier *= 1.5
+            elif author.account_age_days < 7:
+                multiplier *= 1.25
+            elif author.account_age_days > 365:
+                multiplier *= 0.8
+
+        if author.prior_flags >= 3:
+            multiplier *= 1.4
+        elif author.prior_flags >= 1:
+            multiplier *= 1.15
+
+        if author.is_verified:
+            multiplier *= 0.7
+
+        return multiplier
+
+    @staticmethod
+    def _action_for(score: float, thresholds: dict) -> Action:
+        if score >= thresholds[Action.BLOCK]:
+            return Action.BLOCK
+        if score >= thresholds[Action.REVIEW]:
+            return Action.REVIEW
+        if score >= thresholds[Action.FLAG]:
+            return Action.FLAG
+        return Action.ALLOW
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _domain(url: str) -> Optional[str]:
+        """The registrable-ish domain of a URL, with any ``www.`` dropped."""
+        try:
+            host = (urlparse(url).hostname or "").lower()
+        except ValueError:
+            return None
+
+        if not host:
+            return None
+
+        return host[4:] if host.startswith("www.") else host
+
+
+moderation_service = ModerationService()

--- a/backend/app/utils/text_normalize.py
+++ b/backend/app/utils/text_normalize.py
@@ -1,0 +1,274 @@
+"""
+Folding text down to something a term list can actually match.
+
+A moderation check written as ``term in text.lower()`` is defeated by every
+evasion anybody has ever tried, and they are all trivial:
+
+    f u c k        spacing
+    f.u.c.k        separators
+    fvck / f4ck    letter substitution
+    fυck           a Greek upsilon that renders as a "u"
+    𝐟𝐮𝐜𝐤          mathematical bold, a different codepoint per letter
+    fuuuuuck       repetition
+
+Each is a different mechanism, so they are undone in a specific order:
+decompose the Unicode first (which handles the mathematical and fullwidth
+alphabets), then fold the script homoglyphs (Greek and Cyrillic lookalikes),
+then collapse repeats, then handle separators.
+
+The one thing this module is careful *not* to do is fold everything into one
+undifferentiated blob and substring-match against it. With separators gone,
+"class" contains a slur and "Scunthorpe" contains a swear word -- the famous
+Scunthorpe problem, which every filter that ships without a test for it
+eventually ships as a bug. Evasion is instead detected with a per-term pattern
+that tolerates separators and substitutions *inside* the term while still
+requiring a word boundary around the whole match.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+# Letters from other scripts that render close enough to a Latin letter to be
+# used as a substitute. Not the full Unicode confusables table -- that has
+# thousands of entries, and almost none of them show up in real abuse.
+#
+# These fold during ordinary normalisation because they are unambiguously
+# letters: nobody writes a Cyrillic "о" in an English sentence by accident.
+SCRIPT_HOMOGLYPHS = {
+    # Cyrillic
+    "а": "a",
+    "в": "b",
+    "с": "c",
+    "е": "e",
+    "н": "h",
+    "к": "k",
+    "м": "m",
+    "о": "o",
+    "р": "p",
+    "ѕ": "s",
+    "т": "t",
+    "у": "y",
+    "х": "x",
+    "і": "i",
+    "ј": "j",
+    # Greek
+    "α": "a",
+    "β": "b",
+    "ε": "e",
+    "η": "n",
+    "ι": "i",
+    "κ": "k",
+    "ν": "v",
+    "ο": "o",
+    "ρ": "p",
+    "τ": "t",
+    "υ": "u",
+    "χ": "x",
+    "γ": "y",
+    "ζ": "z",
+}
+
+# Symbols used *as* letters. These deliberately do not fold during ordinary
+# normalisation: "!" is punctuation far more often than it is an "i", and
+# folding it there destroys the word boundaries every whole-word check depends
+# on. They are only consulted when building an evasion pattern.
+SYMBOL_HOMOGLYPHS = {
+    "@": "a",
+    "!": "i",
+    "|": "l",
+    "$": "s",
+    "€": "e",
+    "£": "l",
+    "(": "c",
+}
+
+# Digit-for-letter substitutions. Same reasoning: "123" is a number, not
+# "ize", so these are not applied to ordinary text either.
+LEET = {
+    "0": "o",
+    "1": "i",
+    "3": "e",
+    "4": "a",
+    "5": "s",
+    "6": "g",
+    "7": "t",
+    "8": "b",
+    "9": "g",
+}
+
+# Latin letters standing in for other Latin letters. Only ever used inside an
+# evasion pattern -- "v" for "u" is a real evasion but a catastrophic global
+# substitution.
+LETTER_SUBSTITUTIONS = {
+    "u": "v",
+    "i": "lj",
+    "s": "z",
+    "k": "q",
+}
+
+# What may appear *between* the letters of an evaded term. Kept short and
+# capped in the pattern, because allowing unbounded separators would let a
+# term match across half a sentence.
+_TERM_SEPARATORS = r"[\s._\-*+|/\\'\"~,]{0,2}"
+
+_SEPARATORS = re.compile(r"[\s\-_.,;:!?'\"/\\|+*()\[\]{}<>~`^&#%​-‏⁠]+")
+
+_NON_ALNUM = re.compile(r"[^a-z0-9]+")
+
+_REPEATS = re.compile(r"(.)\1{2,}")
+
+_WORD = re.compile(r"[a-z0-9]+")
+
+
+def strip_accents(text: str) -> str:
+    """
+    Remove combining marks, so ``café`` and ``cafe`` compare equal.
+
+    NFKD splits a precomposed character into its base plus its marks; dropping
+    the marks leaves the base. The K in NFKD is what also turns fullwidth and
+    mathematical alphabets into plain ASCII, which is the main reason this runs
+    first.
+    """
+    decomposed = unicodedata.normalize("NFKD", text)
+    return "".join(c for c in decomposed if not unicodedata.combining(c))
+
+
+def fold_homoglyphs(text: str) -> str:
+    """Replace lookalike *letters* from other scripts with their Latin twin."""
+    return "".join(SCRIPT_HOMOGLYPHS.get(c, c) for c in text)
+
+
+def fold_symbols(text: str) -> str:
+    """Replace symbols being used as letters. Not safe for general text."""
+    return "".join(SYMBOL_HOMOGLYPHS.get(c, c) for c in text)
+
+
+def fold_leet(text: str) -> str:
+    """Replace digits standing in for letters. Not safe for general text."""
+    return "".join(LEET.get(c, c) for c in text)
+
+
+def collapse_repeats(text: str, *, keep: int = 2) -> str:
+    """
+    Squash runs of the same character down to ``keep``.
+
+    Two rather than one, because English is full of genuine doubles and
+    collapsing all the way to one turns "boot" into "bot" and starts matching
+    things it should not.
+    """
+    return _REPEATS.sub(lambda m: m.group(1) * keep, text)
+
+
+def normalise(text: str) -> str:
+    """
+    The safe fold, for whole-word matching.
+
+    Accents, script homoglyphs and repeated characters are dealt with;
+    separators become single spaces so word boundaries survive. Digits and
+    symbols are left alone, because "123" is a number and "!" is punctuation.
+    """
+    text = strip_accents(text).lower()
+    text = fold_homoglyphs(text)
+    text = _SEPARATORS.sub(" ", text)
+    text = collapse_repeats(text)
+    return " ".join(text.split())
+
+
+def squash(text: str) -> str:
+    """
+    The aggressive fold, with every separator and substitution undone.
+
+    Useful for comparing two strings that should be "the same word", and
+    **not** safe for substring-matching a term list against: with the spaces
+    gone, "class" contains a slur and "Scunthorpe" contains a swear word. Use
+    :func:`contains_evaded` for that instead.
+    """
+    text = strip_accents(text).lower()
+    text = fold_homoglyphs(text)
+    text = fold_symbols(text)
+    text = fold_leet(text)
+    text = _NON_ALNUM.sub("", text)
+    return collapse_repeats(text, keep=1)
+
+
+def words(text: str) -> list[str]:
+    """The normalised text split into word tokens."""
+    return _WORD.findall(normalise(text))
+
+
+def contains_word(text: str, term: str) -> bool:
+    """
+    Whether a normalised term appears as a whole word.
+
+    Whole-word is the difference between flagging "assignment" and not.
+    """
+    return normalise(term) in set(words(text))
+
+
+def _character_class(char: str) -> str:
+    """Every character that could be standing in for ``char``."""
+    alternatives = {char}
+
+    alternatives.update(k for k, v in SCRIPT_HOMOGLYPHS.items() if v == char)
+    alternatives.update(k for k, v in SYMBOL_HOMOGLYPHS.items() if v == char)
+    alternatives.update(k for k, v in LEET.items() if v == char)
+    alternatives.update(LETTER_SUBSTITUTIONS.get(char, ""))
+
+    return "[" + "".join(re.escape(c) for c in sorted(alternatives)) + "]"
+
+
+def evasion_pattern(term: str) -> re.Pattern:
+    """
+    A pattern that matches ``term`` however it has been mangled.
+
+    Between every pair of letters it tolerates up to two separators, and each
+    letter may be repeated or substituted. Crucially the *whole match* is
+    still bounded by non-word characters, which is what keeps "cunt" out of
+    "Scunthorpe" while still catching "c u n t".
+
+    Word-internal separators are allowed; word boundaries around the term are
+    not negotiable. That asymmetry is the entire design.
+    """
+    pieces = [f"{_character_class(c)}+" for c in term if not c.isspace()]
+
+    body = _TERM_SEPARATORS.join(pieces)
+
+    # Lookarounds rather than \b: \b is defined against \w, which includes the
+    # digits and underscores that evasions are built out of.
+    return re.compile(rf"(?<![a-z0-9]){body}(?![a-z0-9])", re.IGNORECASE)
+
+
+def contains_evaded(text: str, pattern: re.Pattern) -> bool:
+    """Whether an evasion pattern matches, after the safe fold."""
+    return pattern.search(normalise(text)) is not None
+
+
+def shout_ratio(text: str) -> float:
+    """
+    Fraction of the letters that are uppercase.
+
+    Letters only: digits and punctuation have no case, and counting them makes
+    a phone number look like shouting.
+    """
+    letters = [c for c in text if c.isalpha()]
+    if not letters:
+        return 0.0
+    return sum(1 for c in letters if c.isupper()) / len(letters)
+
+
+def repeated_character_runs(text: str, *, threshold: int = 4) -> int:
+    """How many runs of the same character are at least ``threshold`` long."""
+    runs = 0
+    run_length = 1
+
+    for previous, current in zip(text, text[1:]):
+        if current == previous:
+            run_length += 1
+            if run_length == threshold:
+                runs += 1
+        else:
+            run_length = 1
+
+    return runs

--- a/backend/tests/test_moderation.py
+++ b/backend/tests/test_moderation.py
@@ -1,0 +1,397 @@
+"""
+Tests for text normalisation and moderation scoring.
+
+Two halves, and the second is the one that matters most. Catching evasion is
+easy; the hard part is not catching everything else, and the classic failures
+here are famous enough to have names. "Scunthorpe" is the canonical one, and
+every filter that ships without a test for it eventually ships the bug.
+"""
+
+import pytest
+
+from app.services.moderation_service import (
+    Action,
+    AuthorContext,
+    Category,
+    ModerationService,
+)
+from app.utils.text_normalize import (
+    collapse_repeats,
+    contains_word,
+    fold_homoglyphs,
+    fold_leet,
+    normalise,
+    repeated_character_runs,
+    shout_ratio,
+    squash,
+    strip_accents,
+    words,
+)
+
+
+@pytest.fixture
+def service():
+    return ModerationService()
+
+
+# ======================================================================
+# Normalisation
+# ======================================================================
+
+
+def test_strips_accents():
+    assert strip_accents("café") == "cafe"
+
+
+def test_normalises_fullwidth_and_mathematical_alphabets():
+    # NFKD is what turns 𝐟𝐮𝐜𝐤 and ｆｕｃｋ into plain ASCII. Without it, every
+    # one of these is a distinct codepoint the term list has never seen.
+    assert strip_accents("𝐡𝐞𝐥𝐥𝐨") == "hello"
+    assert strip_accents("ｈｅｌｌｏ") == "hello"
+
+
+def test_folds_cyrillic_lookalikes():
+    # A Cyrillic "о" renders identically to a Latin "o" and compares unequal.
+    assert fold_homoglyphs("hеllо") == "hello"
+
+
+def test_folds_greek_lookalikes():
+    assert fold_homoglyphs("fυck") == "fuck"
+
+
+def test_folds_leetspeak():
+    assert fold_leet("h3ll0") == "hello"
+
+
+def test_collapses_repeats_to_two():
+    # Two rather than one, because English is full of genuine doubles and
+    # collapsing to one turns "boot" into "bot".
+    assert collapse_repeats("sooooo goooood") == "soo good"
+    assert collapse_repeats("boot") == "boot"
+
+
+def test_normalise_turns_separators_into_spaces():
+    # Word boundaries have to survive, or every whole-word check becomes a
+    # substring check.
+    assert normalise("hello-world") == "hello world"
+    assert normalise("hello...world") == "hello world"
+
+
+def test_squash_removes_everything():
+    assert squash("f u c k") == "fuck"
+    assert squash("f-u-c-k") == "fuck"
+    assert squash("f.u.c.k") == "fuck"
+
+
+def test_words_tokenises_the_normalised_text():
+    assert words("Hello, World! 123") == ["hello", "world", "123"]
+
+
+def test_contains_word_matches_whole_words_only():
+    assert contains_word("that damn bug", "damn") is True
+    # "damned" is not "damn", and a substring check would say otherwise.
+    assert contains_word("the damned thing", "damn") is False
+
+
+def test_shout_ratio_ignores_non_letters():
+    assert shout_ratio("ABC") == 1.0
+    assert shout_ratio("abc") == 0.0
+    # Digits and punctuation have no case; counting them makes a phone number
+    # look like shouting.
+    assert shout_ratio("123!!!") == 0.0
+
+
+def test_repeated_character_runs_counts_long_runs():
+    assert repeated_character_runs("aaaa bbbb") == 2
+    assert repeated_character_runs("normal text") == 0
+
+
+# ======================================================================
+# Not catching the wrong things
+# ======================================================================
+
+
+def test_scunthorpe_is_fine(service):
+    # The canonical false positive. A substring check flags this and the
+    # resulting bug report is embarrassing.
+    result = service.check("I grew up in Scunthorpe and moved to Penistone.")
+
+    assert result.action == Action.ALLOW
+    assert result.score == 0.0
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "I finished the assignment last night.",
+        "The class implements a shared interface.",
+        "Run the analysis and share the output.",
+        "This document covers the specification.",
+        "Let's discuss the constitution of the team.",
+    ],
+)
+def test_ordinary_words_containing_substrings_are_fine(service, text):
+    assert service.check(text).action == Action.ALLOW
+
+
+def test_a_technical_post_with_several_links_is_fine(service):
+    # A well-referenced answer should never look like a link drop.
+    result = service.check(
+        "Here's the fix. The upstream issue is at https://github.com/foo/bar/issues/12 "
+        "and the relevant docs are https://docs.python.org/3/library/asyncio.html "
+        "plus the discussion at https://stackoverflow.com/questions/12345 which "
+        "explains the reasoning behind the change in some detail."
+    )
+
+    assert result.action == Action.ALLOW
+
+
+def test_a_normal_message_scores_zero(service):
+    result = service.check(
+        "Hey, I pushed the branch with the auth fix. Could you take a look when "
+        "you get a chance? No rush."
+    )
+
+    assert result.score == 0.0
+    assert result.signals == []
+
+
+def test_empty_and_whitespace_text_is_allowed(service):
+    assert service.check("").action == Action.ALLOW
+    assert service.check("    \n  ").action == Action.ALLOW
+
+
+def test_an_email_on_its_own_is_not_harvesting(service):
+    # An email address in a bug report is an email address.
+    result = service.check(
+        "The webhook fires with the wrong address; it sends to old@example.com "
+        "instead of the configured one."
+    )
+
+    assert Category.CONTACT_HARVESTING not in result.categories
+
+
+# ======================================================================
+# Catching the right things
+# ======================================================================
+
+
+def test_profanity_is_flagged_not_blocked(service):
+    # A developer platform that refuses "this API is a shitshow" is a platform
+    # nobody uses. Coarse language is a flag.
+    result = service.check("this fucking API is a mess")
+
+    assert Category.PROFANITY in result.categories
+    assert result.action in (Action.FLAG, Action.REVIEW)
+    assert result.action != Action.BLOCK
+
+
+def test_a_slur_is_blocked(service):
+    result = service.check("you absolute retard")
+
+    assert Category.SLUR in result.categories
+    assert result.action == Action.BLOCK
+
+
+def test_harassment_is_blocked(service):
+    result = service.check("nobody likes you, just go die")
+
+    assert Category.HARASSMENT in result.categories
+    assert result.action == Action.BLOCK
+
+
+@pytest.mark.parametrize(
+    "evasion",
+    ["f u c k", "f-u-c-k", "f.u.c.k", "fvck you"],
+)
+def test_spaced_and_punctuated_evasion_is_caught(service, evasion):
+    result = service.check(evasion)
+
+    assert result.signals != []
+
+
+@pytest.mark.parametrize("evasion", ["that is sh1t", "you b1tch", "a$$hole"])
+def test_leetspeak_and_symbol_evasion_is_caught(service, evasion):
+    # Substitutions come from a table, so an unusual one ("f4ck", where a 4
+    # stands for a u rather than the a it normally spells) is missed. That is
+    # an accepted limit of a deterministic layer, not an oversight -- the
+    # answer is to add the mapping, not to loosen the pattern.
+    assert service.check(evasion).signals != []
+
+
+def test_homoglyph_evasion_is_caught(service):
+    # Greek upsilon in place of "u".
+    assert service.check("what the fυck").signals != []
+
+
+def test_repetition_evasion_is_caught(service):
+    assert service.check("fuuuuuck this").signals != []
+
+
+# ======================================================================
+# Spam
+# ======================================================================
+
+
+def test_a_url_shortener_is_a_strong_signal(service):
+    # A shortener hides its destination, which is the whole reason it is here.
+    result = service.check("Amazing opportunity, check https://bit.ly/abc123")
+
+    assert Category.SPAM in result.categories
+    assert result.score >= 0.4
+
+
+def test_spam_phrases_score(service):
+    result = service.check(
+        "Make money online with guaranteed returns! Limited time offer."
+    )
+
+    assert Category.SPAM in result.categories
+    assert result.action in (Action.REVIEW, Action.BLOCK)
+
+
+def test_link_density_is_relative_to_length(service):
+    result = service.check(
+        "check https://a.example.com https://b.example.com https://c.example.com"
+    )
+
+    assert Category.SPAM in result.categories
+
+
+def test_allowed_domains_do_not_count_toward_density(service):
+    result = service.check(
+        "https://github.com/a https://github.com/b https://gitlab.com/c"
+    )
+
+    assert "link_density" not in {s.rule for s in result.signals}
+
+
+def test_solicited_contact_details_score_higher_than_a_bare_request(service):
+    solicited = service.check("DM me for details, telegram me at +1 555 123 4567")
+    bare = service.check("dm me if you want to pair on this")
+
+    assert solicited.score > bare.score
+
+
+# ======================================================================
+# Formatting
+# ======================================================================
+
+
+def test_shouting_is_a_weak_signal(service):
+    result = service.check("PLEASE LOOK AT THIS RIGHT NOW IT IS URGENT")
+
+    assert "excessive_caps" in {s.rule for s in result.signals}
+    # Weak on its own -- somebody is allowed to be excited.
+    assert result.action in (Action.ALLOW, Action.FLAG)
+
+
+def test_a_short_shout_is_not_flagged(service):
+    # "OK!" is 100% uppercase and is not shouting. Ratios need length.
+    assert service.check("OK!").signals == []
+
+
+def test_word_repetition_is_detected(service):
+    result = service.check("buy buy buy buy buy buy buy buy buy now")
+
+    assert "word_repetition" in {s.rule for s in result.signals}
+
+
+# ======================================================================
+# Author context
+# ======================================================================
+
+
+def test_a_brand_new_account_scores_higher(service):
+    text = "Make money online, limited time offer"
+
+    new = service.check(text, author=AuthorContext(account_age_days=0))
+    old = service.check(text, author=AuthorContext(account_age_days=800))
+
+    assert new.score > old.score
+
+
+def test_prior_flags_increase_the_score(service):
+    text = "Make money online, limited time offer"
+
+    repeat = service.check(text, author=AuthorContext(prior_flags=5))
+    first = service.check(text, author=AuthorContext(prior_flags=0))
+
+    assert repeat.score > first.score
+
+
+def test_verification_lowers_the_score(service):
+    text = "Make money online, limited time offer"
+
+    verified = service.check(text, author=AuthorContext(is_verified=True))
+    plain = service.check(text, author=AuthorContext())
+
+    assert verified.score < plain.score
+
+
+def test_seniority_is_not_a_licence_for_slurs(service):
+    # The account-age discount deliberately does not apply to slurs and
+    # harassment. A two-year-old account does not get to say this.
+    trusted = AuthorContext(account_age_days=2000, is_verified=True)
+
+    assert service.check("you retard", author=trusted).action == Action.BLOCK
+
+
+def test_context_does_not_manufacture_a_score(service):
+    # Multiplying zero is pointless, and a new account posting something clean
+    # must still score zero.
+    result = service.check(
+        "Hello, nice work on this.", author=AuthorContext(account_age_days=0)
+    )
+
+    assert result.score == 0.0
+    assert result.action == Action.ALLOW
+
+
+# ======================================================================
+# Explainability
+# ======================================================================
+
+
+def test_every_result_lists_the_rules_that_fired(service):
+    result = service.check("Make money online at https://bit.ly/x")
+
+    assert result.signals
+    for signal in result.signals:
+        assert signal.rule
+        assert signal.weight > 0
+        assert isinstance(signal.category, Category)
+
+
+def test_explain_names_the_action_the_score_and_the_rules(service):
+    explanation = service.check("Make money online at https://bit.ly/x").explain()
+
+    assert "url_shortener" in explanation
+    assert "@" in explanation
+
+
+def test_explain_is_readable_when_nothing_fired(service):
+    assert service.check("hello").explain() == "No moderation signals."
+
+
+def test_thresholds_can_be_overridden(service):
+    text = "this fucking API is a mess"
+
+    strict = service.check(
+        text,
+        thresholds={Action.BLOCK: 0.1, Action.REVIEW: 0.05, Action.FLAG: 0.01},
+    )
+    lenient = service.check(
+        text,
+        thresholds={Action.BLOCK: 5.0, Action.REVIEW: 4.0, Action.FLAG: 3.0},
+    )
+
+    # Same text, same score, different call-site policy -- which is the point.
+    assert strict.action == Action.BLOCK
+    assert lenient.action == Action.ALLOW
+    assert strict.score == lenient.score
+
+
+def test_needs_human_covers_review_and_block(service):
+    assert service.check("you retard").needs_human is True
+    assert service.check("hello there").needs_human is False

--- a/docs/content_moderation.md
+++ b/docs/content_moderation.md
@@ -1,0 +1,179 @@
+# Content Moderation
+
+DevLink accepts free text in a lot of places — messages, project descriptions,
+conversation starters, feedback, profile bios, issue comments — and until now
+none of it was screened. There is a `UserReport` model, so the design was
+entirely reactive: something abusive gets posted, somebody reads it, somebody
+reports it, a moderator eventually acts.
+
+This adds the deterministic layer that runs *before* the write.
+
+## It returns a recommendation, not a verdict
+
+```python
+from app.services.moderation_service import moderation_service, Action
+
+result = moderation_service.check(message_body)
+
+if result.action == Action.BLOCK:
+    raise HTTPException(400, detail=result.explain())
+```
+
+| Action | Meaning |
+| --- | --- |
+| `allow` | Nothing interesting. |
+| `flag` | Publish it, but queue it for review. |
+| `review` | Hold it; a moderator decides. |
+| `block` | Refuse it, and tell the author why. |
+
+The **caller** decides what to do with the recommendation. A profile bio and a
+direct message should not share a threshold, and that is a property of the call
+site, not of the text. Pass your own `thresholds` to move the line.
+
+## Every result explains itself
+
+```python
+result.signals
+# [Signal(category=SPAM, rule='url_shortener', weight=0.4, detail='bit.ly'),
+#  Signal(category=SPAM, rule='spam_phrase', weight=0.3, detail='guaranteed returns')]
+
+result.explain()
+# "review @ 0.70: url_shortener (+0.40), spam_phrase (+0.30)"
+```
+
+This is not decoration. A moderation decision nobody can explain is a decision
+nobody can appeal, and somebody will eventually have to answer a *"why was my
+post blocked"* ticket. The signal list is what makes that answerable.
+
+## Normalisation, and the trap in it
+
+A check written as `term in text.lower()` is defeated by every evasion anybody
+has ever tried:
+
+| Evasion | Mechanism |
+| --- | --- |
+| `f u c k` | spacing |
+| `f.u.c.k` | separators |
+| `fvck`, `sh1t`, `a$$hole` | substitution |
+| `fυck` | Greek upsilon rendering as a "u" |
+| `𝐟𝐮𝐜𝐤` | mathematical bold — a different codepoint per letter |
+| `fuuuuuck` | repetition |
+
+The obvious fix is to strip everything — spaces, punctuation, digits — into one
+blob and substring-match against that. **Do not do this.** With the separators
+gone:
+
+* `Scunthorpe` contains a swear word
+* `class` contains a slur
+* `assignment` contains a swear word
+
+That is the Scunthorpe problem, and every filter that ships without a test for
+it eventually ships the bug.
+
+So `app/utils/text_normalize.py` splits the difference:
+
+* **`normalise()`** is the safe fold. Accents, script homoglyphs (Cyrillic,
+  Greek) and repeated characters are dealt with; separators become single
+  spaces so **word boundaries survive**. Digits and symbols are left alone,
+  because `123` is a number and `!` is punctuation. This is what whole-word
+  matching runs against.
+* **`evasion_pattern(term)`** builds a per-term regex that tolerates
+  separators and substitutions *inside* the term — `f+[sep]{0,2}[uv]+…` — while
+  still requiring a word boundary around the **whole match**.
+
+That asymmetry is the entire design. `c u n t` matches; `Scunthorpe` does not,
+because the lookbehind sees the `s`.
+
+`squash()` still exists for comparing two strings that should be the same word,
+and its docstring says in as many words that it is not safe to substring-match
+a term list against.
+
+### Known limit
+
+Substitutions come from a table. An unusual one — `f4ck`, where the `4` stands
+for a `u` rather than the `a` it normally spells — is missed. That is an
+accepted limit of a deterministic layer: the fix is to add the mapping, not to
+loosen the pattern until it starts eating ordinary words.
+
+## Signals
+
+**Abuse**
+
+| Rule | Weight | Notes |
+| --- | --- | --- |
+| `profanity` | 0.30–0.60 | A **flag**, not a block. A developer platform that refuses "this API is a shitshow" is a platform nobody uses. |
+| `slur` | 1.00 | Blocks. |
+| `harassment` | 1.00 | Blocks. Phrases aimed at a person, not a situation. |
+| `obfuscated_term` | 0.35 | Scored below a plain hit: obfuscation is evidence of intent, but the pattern is looser than an exact match. |
+
+**Spam**
+
+| Rule | Weight | Notes |
+| --- | --- | --- |
+| `link_density` | 0.20–0.60 | Relative to length. Three links in a paragraph is a well-referenced paragraph; three links in fifteen words is a drop. `ALLOWED_DOMAINS` (GitHub, MDN, PyPI…) never count. |
+| `url_shortener` | 0.40 each | A shortener hides its destination, which is the whole reason it is there. |
+| `spam_phrase` | 0.30–0.90 | |
+| `solicited_contact_details` | 0.50 | Contact-soliciting language **and** an email or phone number. |
+| `offsite_contact_request` | 0.25 | The language without the details. An email in a bug report is just an email. |
+
+**Formatting** — `excessive_caps` (0.20), `character_repetition` (0.15),
+`word_repetition` (0.25). Weak individually; somebody is allowed to be excited.
+They earn their place as tiebreakers because they correlate with everything
+else on the list.
+
+## Author context
+
+```python
+moderation_service.check(text, author=AuthorContext(
+    account_age_days=0, prior_flags=2, is_verified=False,
+))
+```
+
+A brand-new account posting five links is not the same event as a two-year-old
+account doing it, and no amount of keyword matching can tell those apart.
+
+| Signal | Multiplier |
+| --- | --- |
+| Account < 1 day | ×1.5 |
+| Account < 7 days | ×1.25 |
+| Account > 1 year | ×0.8 |
+| ≥ 3 prior flags | ×1.4 |
+| ≥ 1 prior flag | ×1.15 |
+| Verified | ×0.7 |
+
+Two deliberate details:
+
+1. The multiplier is only applied when something already fired. Multiplying
+   zero is pointless, and a new account posting something clean must still
+   score zero.
+2. **The age discount does not apply to slurs or harassment.** Seniority is not
+   a licence.
+
+## Extending the lists
+
+Terms live in `app/core/moderation_terms.py`, which is pure data. Add a term in
+ordinary spelling and the service handles the evasions — there is no need to
+enumerate `f4ck`, `fυck` and `f.u.c.k`.
+
+The `SLURS` list in the repository is deliberately short and non-exhaustive.
+Deployments are expected to extend it; the scoring code does not change when
+they do.
+
+## What this is not
+
+No ML model, no third-party moderation API. This is the layer that runs on
+every submission in under a millisecond, is explainable, and can be unit-tested
+against *"does Scunthorpe still work"*. A model can sit behind it later, for
+the cases rules cannot reach — but a model cannot answer that question, which
+is why it is not the first layer.
+
+## The preview endpoint
+
+```
+POST /api/moderation/check   { "text": "…", "account_age_days": 3 }
+```
+
+Authenticated, rate limited to 60/minute. It exists so the frontend can warn
+somebody *before* they hit send — far better than a rejection afterwards — and
+so moderators can check why a particular piece of text scored the way it did
+without reading the source. It returns nothing about anybody else.


### PR DESCRIPTION
Closes #878

## What this adds

`moderation_service.check(text)` → a **recommendation**, not a verdict:

```python
result = moderation_service.check(message_body)

if result.action == Action.BLOCK:
    raise HTTPException(400, detail=result.explain())
```

`allow` / `flag` / `review` / `block`. The **caller** decides what to do with it, because a profile bio and a direct message should not share a threshold — that is a property of the call site, not of the text. Pass your own `thresholds` to move the line.

Plus `POST /api/moderation/check`, so the frontend can warn somebody *before* they hit send (much better than a rejection afterwards) and moderators can ask why a piece of text scored the way it did without reading the source.

## The hard part is not catching evasion

Catching evasion is easy. Not catching everything *else* is the part that goes wrong.

A check written as `term in text.lower()` loses to every one of these:

| | |
| --- | --- |
| `f u c k` | spacing |
| `f.u.c.k` | separators |
| `fvck` `sh1t` `a$$hole` | substitution |
| `fυck` | Greek upsilon rendering as a "u" |
| `𝐟𝐮𝐜𝐤` | mathematical bold — a different codepoint per letter |
| `fuuuuuck` | repetition |

The obvious fix is to strip everything into one blob and substring-match that. **Then:**

* `Scunthorpe` contains a swear word
* `class` contains a slur
* `assignment` contains a swear word

That is the Scunthorpe problem. Every filter that ships without a test for it eventually ships the bug — **including my first draft of this one**, which is exactly what `test_scunthorpe_is_fine` caught before this PR existed.

### The fix

`normalise()` is the **safe** fold. Accents, script homoglyphs (Cyrillic, Greek) and repeated characters are handled; separators become single spaces so **word boundaries survive**. Digits and symbols are deliberately left alone, because `123` is a number and `!` is punctuation — folding them destroys the boundaries every whole-word check depends on.

`evasion_pattern(term)` builds a per-term regex that tolerates separators and substitutions **inside** the term, while still requiring a word boundary around the **whole match**:

```
(?<![a-z0-9]) c+ [sep]{0,2} [uv]+ [sep]{0,2} n+ [sep]{0,2} t+ (?![a-z0-9])
```

`c u n t` matches. `Scunthorpe` does not — the lookbehind sees the `s`. That asymmetry is the entire design. Lookarounds rather than `\b`, because `\b` is defined against `\w`, which includes the digits and underscores evasions are built from.

`squash()` still exists for comparing two strings that should be the same word, and its docstring says in as many words that it is not safe to substring-match a term list against.

**Known limit, stated in the code and the tests:** substitutions come from a table, so an unusual one — `f4ck`, where the `4` stands for a `u` rather than the `a` it normally spells — is missed. The fix is to add the mapping, not to loosen the pattern until it starts eating ordinary words.

## The weights encode judgement, not a keyword count

* **Profanity flags, it does not block.** A developer platform that refuses *"this API is a shitshow"* is a platform nobody uses.
* **Slurs and harassment block** at 1.0.
* **Link density is relative to length**, and `ALLOWED_DOMAINS` (GitHub, MDN, PyPI, Stack Overflow…) never counts. Three links in a paragraph is a well-referenced paragraph; three links in fifteen words is a drop.
* **Contact details score higher when *solicited*.** An email in a bug report is an email. "Reach me at" plus an email is somebody routing around the platform.
* **Formatting signals are weak on purpose** — somebody is allowed to be excited. They earn their place as tiebreakers because they correlate with everything else.

## Author context

A day-old account posting five links is not the same event as a two-year-old account doing it, and no amount of keyword matching can tell those apart.

Two deliberate details:

1. **The multiplier only applies when something already fired.** Multiplying zero is pointless, and a new account posting something clean must still score zero. (`test_context_does_not_manufacture_a_score`)
2. **The account-age discount does not apply to slurs or harassment.** Seniority is not a licence. (`test_seniority_is_not_a_licence_for_slurs`)

## Explainability

```python
result.explain()
# "review @ 0.70: url_shortener (+0.40), spam_phrase (+0.30)"
```

Not decoration. A moderation decision nobody can explain is a decision nobody can appeal.

## Deliberately not a model

No ML, no third-party moderation API. This is the layer that runs inline on every write in under a millisecond, explains itself, and can be unit-tested against *"does Scunthorpe still work"* — a question no model can answer. A model can sit behind this later for what rules cannot reach; it is not the right **first** layer.

## Tests

```
$ pytest tests/test_moderation.py -q
52 passed
```

Roughly half are dedicated to *not* firing: Scunthorpe, Penistone, assignment, class, analysis, specification, constitution, a bare email in a bug report, and a technical post carrying three documentation links.

Separately spot-checked against a corpus of ordinary developer prose — *cockpit, peacock, shuttlecock, Hitchcock, Sussex, Essex, bass, analyst, cocktail* — with zero false positives.

Endpoint smoke-checked: unauthenticated `POST /api/moderation/check` → `401`. `black --check` clean on all new files.

## Notes for review

* Pure functions. No database, no network, no state, no migration.
* Terms live in `app/core/moderation_terms.py`, which is pure data — a maintainer can add one without touching scoring logic, in ordinary spelling.
* The `SLURS` list here is deliberately short and non-exhaustive; deployments extend it and the code does not change.
* `main.py` gains two lines at line 544.
* Nothing is wired into a write path yet — that is a separate change per call site, since each one needs its own threshold decision.
