### PR TITLE
feat: add shared accessibility primitives for focus management and announcements

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -1,0 +1,179 @@
+# Accessibility Primitives
+
+The frontend has a lot of interactive surfaces — the command palette, dialogs,
+dropdowns, the notification centre, the sidebar — and no shared accessibility
+building blocks. So each one re-solves the same problems, slightly differently
+and slightly wrong.
+
+This is the shared layer. No new dependency; a few hundred lines of DOM code
+with tests.
+
+## What was broken
+
+* **No skip link.** A keyboard user landing on any page had to tab through the
+  entire sidebar and header before reaching the content. On the dashboard that
+  is roughly forty stops, on *every single navigation*.
+* **Nothing trapped focus in a modal.** Tab enough times in a dialog and focus
+  walks into the page behind it — still there, still focusable, covered by an
+  overlay. The user is now typing into something they cannot see.
+* **Focus was never restored.** Closing a dialog dropped focus to `<body>`, so
+  the next Tab started from the top of the document instead of the button just
+  used.
+* **Nothing was announced.** Toasts, "saved", "3 new notifications", search
+  result counts — invisible to a screen reader, because there was no live
+  region. `aria-live` appeared in three files, each hand-rolled.
+* **Composite widgets were N tab stops.** A toolbar should be one stop with
+  arrow-key navigation between items.
+
+## `lib/a11y/tabbable.ts`
+
+The primitive everything else is built on, and the fiddly part.
+
+`container.querySelectorAll("button, a[href], input, …")` gets the common case
+right and then goes wrong on:
+
+* a `disabled` button — **and** one inside a `disabled` fieldset, except
+  anything inside that fieldset's first `<legend>`, which stays interactive
+* anything inside an `inert` subtree
+* `display: none` / `visibility: hidden` / `hidden`
+* collapsed `<details>` content, while keeping its `<summary>`
+* `tabindex="-1"` — focusable by script, skipped by Tab
+* **radio groups**, which are *one* tab stop: the checked member, or the first
+  if none is checked. Treating each as its own stop makes a focus trap loop
+  through a form's radio options one at a time.
+* **positive `tabindex`**, which the browser visits *before* everything in
+  document order
+
+That last one is the most commonly missed. A trap that ignores it wraps in a
+different order than Tab does, and the user ends up somewhere they did not
+expect.
+
+```ts
+import { getTabbableElements, getTabbableEdges, focusFirst } from "@/lib/a11y";
+```
+
+`focusFirst` falls back to focusing the container itself when nothing inside is
+tabbable — focus has to land *somewhere* inside a dialog, or a screen reader
+stays on the page behind it.
+
+## `useFocusTrap`
+
+```tsx
+const ref = useFocusTrap<HTMLDivElement>({
+  active: open,
+  onEscape: () => setOpen(false),
+});
+
+return <div ref={ref} role="dialog">…</div>;
+```
+
+Two details that a minimal version gets wrong:
+
+**Edges are recomputed on every keypress**, not cached when the trap opens.
+Dialog content changes — a validation error appears, a disclosure expands, a
+button becomes enabled — and a cached "last element" sends focus to something
+that is no longer there.
+
+**Focus is pulled back when it has escaped.** The user can click something
+behind the overlay, or a script can move focus. If the trap only handles the
+wrap case, that situation is unrecoverable by keyboard.
+
+Focus is restored to the previously focused element on release, and the hook
+checks the element is still in the document first — it may have been removed
+while the dialog was open.
+
+## `useRovingTabIndex`
+
+Makes a group of controls a single tab stop, with arrow keys moving inside it.
+The WAI-ARIA authoring-practices pattern: exactly one item carries
+`tabIndex={0}`, the rest carry `-1`, and the index moves as the user arrows
+around.
+
+```tsx
+const { containerRef, getItemProps, containerProps } = useRovingTabIndex({
+  orientation: "horizontal",
+});
+
+<div ref={containerRef} role="toolbar" {...containerProps}>
+  {items.map((item, i) => (
+    <button key={item.id} {...getItemProps(i)}>{item.label}</button>
+  ))}
+</div>
+```
+
+| Option | Default | |
+| --- | --- | --- |
+| `orientation` | `"horizontal"` | `"vertical"` or `"both"` |
+| `loop` | `true` | Wrap at the ends |
+| `typeahead` | `false` | Jump by typing a label's first letters |
+
+`getItemProps` includes an `onFocus` handler, and it matters as much as the
+keyboard handling: somebody can click or shift-tab straight into the middle of
+the group, and if the index does not follow, the next arrow press jumps back to
+wherever the index was left.
+
+A horizontal group deliberately ignores `ArrowUp`/`ArrowDown` — the page still
+needs to scroll.
+
+## The announcer
+
+```tsx
+const { announce } = useAnnouncer();
+
+announce("Project saved");                    // polite
+announce("Upload failed", "assertive");       // interrupts
+```
+
+`AnnouncerProvider` is mounted once in `__root.tsx` and renders two live
+regions. **Two, not one**, because `aria-live` is read when the region is first
+seen — flipping the attribute on an existing region does nothing on most screen
+readers.
+
+Use `polite` for anything the user can catch up on. Reserve `assertive` for
+errors that block what they were doing.
+
+### The zero-width space
+
+Screen readers only re-announce a live region when its **text changes**.
+Announcing "3 results", then "3 results" again after a different search,
+produces *silence* the second time — and the user concludes nothing happened.
+
+Appending U+200B makes the text technically different while being inaudible and
+invisible. It is the standard workaround, and it is the kind of thing every
+hand-rolled live region rediscovers the hard way.
+
+The regions are clipped, not `hidden` and not `display: none` — either of those
+removes them from the accessibility tree, which is exactly the opposite of what
+they are for.
+
+`useAnnouncer` falls back to a no-op outside a provider, so a component using it
+still works in isolation and in tests that do not care.
+
+## `SkipLink`
+
+Mounted first in `__root.tsx`, so it is the first thing in the tab order.
+Target is `#main-content` on the `<main>` in `DashboardLayout`.
+
+A bare `href="#main-content"` moves the **scroll position but not focus**
+unless the target is focusable — so the next Tab starts from the top of the
+document again and the user is back where they began. The link therefore sets
+`tabindex="-1"` on the target and focuses it explicitly.
+
+## `useFocusVisible`
+
+Whether the user is currently navigating by keyboard. Prefer the
+`:focus-visible` CSS pseudo-class where it works; this is for cases CSS cannot
+reach — deciding whether to *render* an affordance, whether to scroll a newly
+focused item into view, whether to open a menu on focus.
+
+## Notes
+
+* **Everything is SSR-safe.** This app server-renders; nothing here touches
+  `document` at module scope, and `useFocusVisible` guards for it.
+* **No new runtime dependency.**
+* 61 tests, covering each exclusion rule in `tabbable` individually.
+
+## If you are building a menu
+
+Use these. The point of the layer is that there is not a sixth hand-rolled
+focus trap in the codebase.

--- a/frontend/src/components/a11y/Announcer.tsx
+++ b/frontend/src/components/a11y/Announcer.tsx
@@ -1,0 +1,129 @@
+import { createContext, useCallback, useContext, useMemo, useRef, useState } from "react";
+import type { ReactNode } from "react";
+
+export type Urgency = "polite" | "assertive";
+
+interface AnnouncerContextValue {
+  announce: (message: string, urgency?: Urgency) => void;
+}
+
+const AnnouncerContext = createContext<AnnouncerContextValue | null>(null);
+
+/**
+ * Screen readers only re-announce a live region when its **text changes**.
+ * Announcing the same string twice -- "3 results", then "3 results" again
+ * after a different search -- produces silence the second time, and the user
+ * concludes nothing happened.
+ *
+ * Appending a zero-width space makes the text technically different while
+ * being inaudible and invisible. It is the standard workaround, and it is the
+ * kind of thing every hand-rolled live region rediscovers the hard way.
+ *
+ * Written as an escape rather than a literal, so it is visible to whoever
+ * reads this file next.
+ */
+const ZERO_WIDTH_SPACE = "\u200B";
+
+function differentiate(previous: string, next: string): string {
+  return previous === next ? `${next}${ZERO_WIDTH_SPACE}` : next;
+}
+
+/**
+ * Mounts the two live regions and provides `announce`.
+ *
+ * Two regions rather than one, because `aria-live` cannot be changed on the
+ * fly reliably -- most screen readers read the attribute when the region is
+ * first seen, so flipping it between polite and assertive on an existing
+ * region has no effect.
+ *
+ * Mount this once, near the root.
+ */
+export function AnnouncerProvider({ children }: { children: ReactNode }) {
+  const [polite, setPolite] = useState("");
+  const [assertive, setAssertive] = useState("");
+
+  const lastPolite = useRef("");
+  const lastAssertive = useRef("");
+
+  const announce = useCallback((message: string, urgency: Urgency = "polite") => {
+    if (!message) return;
+
+    if (urgency === "assertive") {
+      const next = differentiate(lastAssertive.current, message);
+      lastAssertive.current = next;
+      setAssertive(next);
+      return;
+    }
+
+    const next = differentiate(lastPolite.current, message);
+    lastPolite.current = next;
+    setPolite(next);
+  }, []);
+
+  const value = useMemo(() => ({ announce }), [announce]);
+
+  return (
+    <AnnouncerContext.Provider value={value}>
+      {children}
+      <LiveRegion urgency="polite" message={polite} />
+      <LiveRegion urgency="assertive" message={assertive} />
+    </AnnouncerContext.Provider>
+  );
+}
+
+function LiveRegion({ urgency, message }: { urgency: Urgency; message: string }) {
+  return (
+    <div
+      // `aria-atomic` makes the reader announce the whole region rather than
+      // diffing it, which is what we want for a self-contained status message.
+      aria-atomic="true"
+      aria-live={urgency}
+      // `role="status"` and `role="alert"` are what older screen readers
+      // actually respond to; aria-live alone is not enough on all of them.
+      role={urgency === "assertive" ? "alert" : "status"}
+      // Not `hidden` and not `display: none` -- either removes the region from
+      // the accessibility tree, which is exactly what we do not want. This is
+      // the standard visually-hidden recipe: present, sized to nothing, and
+      // clipped.
+      style={{
+        position: "absolute",
+        width: 1,
+        height: 1,
+        margin: -1,
+        padding: 0,
+        overflow: "hidden",
+        clip: "rect(0, 0, 0, 0)",
+        whiteSpace: "nowrap",
+        border: 0,
+      }}
+    >
+      {message}
+    </div>
+  );
+}
+
+/**
+ * Announce a message to screen reader users.
+ *
+ * Use `"polite"` (the default) for anything the user can catch up on --
+ * "Saved", "12 results". Use `"assertive"` only when the current utterance
+ * should be interrupted, which in practice means errors that block what the
+ * user was doing.
+ *
+ * Falls back to a no-op outside a provider, so a component using it is still
+ * usable in isolation and in tests that do not care about announcements.
+ */
+export function useAnnouncer(): AnnouncerContextValue {
+  const context = useContext(AnnouncerContext);
+
+  const fallback = useMemo<AnnouncerContextValue>(
+    () => ({
+      announce: () => {
+        /* no provider mounted; announcing is a no-op rather than a crash */
+      },
+    }),
+    [],
+  );
+
+  return context ?? fallback;
+}

--- a/frontend/src/components/a11y/SkipLink.tsx
+++ b/frontend/src/components/a11y/SkipLink.tsx
@@ -1,0 +1,67 @@
+import type { MouseEvent } from "react";
+
+export interface SkipLinkProps {
+  /** Id of the element to jump to, without the `#`. */
+  targetId?: string;
+  children?: React.ReactNode;
+}
+
+/**
+ * The first thing in the tab order: a link straight to the main content.
+ *
+ * Without one, a keyboard user landing on any page has to tab through the
+ * entire sidebar and header before reaching what they came for. On the
+ * dashboard that is roughly forty stops, on **every single navigation**.
+ *
+ * Visually hidden until focused, then it appears. That is the whole pattern:
+ * `display: none` would remove it from the tab order and defeat the point, so
+ * it is clipped instead.
+ */
+export function SkipLink({
+  targetId = "main-content",
+  children = "Skip to main content",
+}: SkipLinkProps) {
+  /**
+   * A bare `href="#main-content"` moves the *scroll position* but not focus,
+   * unless the target is focusable. So the target gets `tabindex="-1"` on
+   * demand and is focused explicitly -- otherwise the next Tab press starts
+   * from the top of the document again and the user is back where they began.
+   */
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    const target = document.getElementById(targetId);
+    if (!target) return;
+
+    event.preventDefault();
+
+    if (!target.hasAttribute("tabindex")) {
+      target.setAttribute("tabindex", "-1");
+    }
+
+    target.focus();
+
+    // Focusing usually scrolls on its own; this just makes sure the target
+    // lands at the top rather than wherever the browser chose. Guarded
+    // because it is not implemented in every environment (jsdom, notably) and
+    // it is a refinement, not the point of the link.
+    target.scrollIntoView?.({ block: "start" });
+  };
+
+  return (
+    <a
+      href={`#${targetId}`}
+      onClick={handleClick}
+      className={[
+        // Clipped rather than hidden: it has to stay in the tab order.
+        "sr-only",
+        // focus:not-sr-only undoes the clipping once it is reached.
+        "focus:not-sr-only",
+        "focus:fixed focus:left-4 focus:top-4 focus:z-[100]",
+        "focus:rounded-md focus:bg-primary focus:px-4 focus:py-2",
+        "focus:text-sm focus:font-semibold focus:text-primary-foreground",
+        "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+      ].join(" ")}
+    >
+      {children}
+    </a>
+  );
+}

--- a/frontend/src/components/a11y/__tests__/Announcer.test.tsx
+++ b/frontend/src/components/a11y/__tests__/Announcer.test.tsx
@@ -1,0 +1,180 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import { AnnouncerProvider, useAnnouncer } from "../Announcer";
+import { SkipLink } from "../SkipLink";
+
+function Trigger({ message, urgency }: { message: string; urgency?: "polite" | "assertive" }) {
+  const { announce } = useAnnouncer();
+
+  return <button onClick={() => announce(message, urgency)}>say</button>;
+}
+
+describe("AnnouncerProvider", () => {
+  it("mounts a polite and an assertive live region", () => {
+    render(
+      <AnnouncerProvider>
+        <span>content</span>
+      </AnnouncerProvider>,
+    );
+
+    // Two regions rather than one, because aria-live is read when the region
+    // is first seen -- flipping it on an existing region does nothing.
+    expect(screen.getByRole("status")).toHaveAttribute("aria-live", "polite");
+    expect(screen.getByRole("alert")).toHaveAttribute("aria-live", "assertive");
+  });
+
+  it("puts a polite message in the status region", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <AnnouncerProvider>
+        <Trigger message="Saved" />
+      </AnnouncerProvider>,
+    );
+
+    await user.click(screen.getByText("say"));
+
+    expect(screen.getByRole("status")).toHaveTextContent("Saved");
+    expect(screen.getByRole("alert")).toHaveTextContent("");
+  });
+
+  it("puts an assertive message in the alert region", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <AnnouncerProvider>
+        <Trigger message="Upload failed" urgency="assertive" />
+      </AnnouncerProvider>,
+    );
+
+    await user.click(screen.getByText("say"));
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Upload failed");
+    expect(screen.getByRole("status")).toHaveTextContent("");
+  });
+
+  it("changes the text when the same message is announced twice", async () => {
+    // Screen readers only re-announce when the text *changes*. Saying "3
+    // results" twice would be silent the second time, and the user concludes
+    // nothing happened. A zero-width space makes it technically different.
+    const user = userEvent.setup();
+
+    render(
+      <AnnouncerProvider>
+        <Trigger message="3 results" />
+      </AnnouncerProvider>,
+    );
+
+    const button = screen.getByText("say");
+    const region = screen.getByRole("status");
+
+    await user.click(button);
+    const first = region.textContent;
+
+    await user.click(button);
+    const second = region.textContent;
+
+    expect(second).not.toBe(first);
+    // Still reads as the same sentence to a person.
+    expect(region).toHaveTextContent("3 results");
+  });
+
+  it("ignores an empty message", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <AnnouncerProvider>
+        <Trigger message="" />
+      </AnnouncerProvider>,
+    );
+
+    await user.click(screen.getByText("say"));
+
+    expect(screen.getByRole("status")).toHaveTextContent("");
+  });
+
+  it("keeps the live regions out of sight but in the accessibility tree", () => {
+    render(
+      <AnnouncerProvider>
+        <span>content</span>
+      </AnnouncerProvider>,
+    );
+
+    const region = screen.getByRole("status");
+
+    // `hidden` or `display: none` would remove it from the accessibility
+    // tree, which is exactly what we do not want.
+    expect(region).not.toHaveAttribute("hidden");
+    expect(region.style.position).toBe("absolute");
+    expect(region.style.overflow).toBe("hidden");
+  });
+});
+
+describe("useAnnouncer outside a provider", () => {
+  it("is a no-op rather than a crash", async () => {
+    // A component using announce() should still be usable in isolation and in
+    // tests that do not care about announcements.
+    const user = userEvent.setup();
+
+    render(<Trigger message="nobody is listening" />);
+
+    await expect(user.click(screen.getByText("say"))).resolves.not.toThrow();
+  });
+});
+
+describe("SkipLink", () => {
+  it("renders a link to the main content", () => {
+    render(<SkipLink />);
+
+    expect(screen.getByRole("link")).toHaveAttribute("href", "#main-content");
+  });
+
+  it("stays in the tab order while visually hidden", () => {
+    // display:none would remove it from the tab order and defeat the point.
+    render(<SkipLink />);
+
+    expect(screen.getByRole("link").className).toContain("sr-only");
+    expect(screen.getByRole("link").className).toContain("focus:not-sr-only");
+  });
+
+  it("moves focus to the target, not just the scroll position", async () => {
+    // A bare href="#main" scrolls but does not move focus unless the target is
+    // focusable -- so the next Tab would start from the top of the document
+    // again and the user is back where they began.
+    const user = userEvent.setup();
+
+    render(
+      <>
+        <SkipLink />
+        <main id="main-content">
+          <button>first thing</button>
+        </main>
+      </>,
+    );
+
+    await user.click(screen.getByRole("link"));
+
+    const main = document.getElementById("main-content")!;
+    expect(main.getAttribute("tabindex")).toBe("-1");
+    expect(document.activeElement).toBe(main);
+  });
+
+  it("does nothing when the target is missing", async () => {
+    const user = userEvent.setup();
+
+    render(<SkipLink targetId="not-here" />);
+
+    await expect(user.click(screen.getByRole("link"))).resolves.not.toThrow();
+  });
+
+  it("accepts a custom target and label", () => {
+    render(<SkipLink targetId="results">Skip to results</SkipLink>);
+
+    const link = screen.getByRole("link");
+
+    expect(link).toHaveAttribute("href", "#results");
+    expect(link).toHaveTextContent("Skip to results");
+  });
+});

--- a/frontend/src/components/layout/DashboardLayout.tsx
+++ b/frontend/src/components/layout/DashboardLayout.tsx
@@ -29,10 +29,18 @@ export function DashboardLayout() {
         <TopNavbar />
 
         <main
+          // The skip link's destination. tabIndex={-1} makes it focusable so
+          // the link can move focus here, not just the scroll position --
+          // otherwise the next Tab starts from the top of the document again.
+          id="main-content"
+          tabIndex={-1}
           className={[
             "flex-1 overflow-y-auto",
             // On mobile add bottom padding so bottom nav never obscures content
             "pb-16 md:pb-0",
+            // No focus ring: focus lands here programmatically, and a ring
+            // around the whole page reads as a rendering bug.
+            "outline-none",
           ].join(" ")}
         >
           <AnimatePresence mode="wait">

--- a/frontend/src/hooks/__tests__/useFocusTrap.test.tsx
+++ b/frontend/src/hooks/__tests__/useFocusTrap.test.tsx
@@ -1,0 +1,174 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useFocusTrap } from "../useFocusTrap";
+
+function Dialog({
+  active,
+  onEscape,
+  extra,
+}: {
+  active: boolean;
+  onEscape?: () => void;
+  extra?: boolean;
+}) {
+  const ref = useFocusTrap<HTMLDivElement>({ active, onEscape });
+
+  return (
+    <div ref={ref} role="dialog">
+      <button>first</button>
+      <button>middle</button>
+      {extra ? <button>added later</button> : null}
+      <button>last</button>
+    </div>
+  );
+}
+
+function Page({ extra = false, onEscape }: { extra?: boolean; onEscape?: () => void }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>open</button>
+      <button>outside</button>
+      {open ? <Dialog active onEscape={onEscape ?? (() => setOpen(false))} extra={extra} /> : null}
+    </>
+  );
+}
+
+describe("useFocusTrap", () => {
+  it("moves focus into the container when it activates", async () => {
+    const user = userEvent.setup();
+    render(<Page />);
+
+    await user.click(screen.getByText("open"));
+
+    expect(document.activeElement).toBe(screen.getByText("first"));
+  });
+
+  it("wraps forward from the last element to the first", async () => {
+    const user = userEvent.setup();
+    render(<Page />);
+    await user.click(screen.getByText("open"));
+
+    screen.getByText("last").focus();
+    await user.tab();
+
+    expect(document.activeElement).toBe(screen.getByText("first"));
+  });
+
+  it("wraps backward from the first element to the last", async () => {
+    const user = userEvent.setup();
+    render(<Page />);
+    await user.click(screen.getByText("open"));
+
+    screen.getByText("first").focus();
+    await user.tab({ shift: true });
+
+    expect(document.activeElement).toBe(screen.getByText("last"));
+  });
+
+  it("keeps focus inside across a full cycle", async () => {
+    // The failure this guards against is subtle: focus escaping into the page
+    // behind an overlay, where the user is typing into something covered.
+    const user = userEvent.setup();
+    render(<Page />);
+    await user.click(screen.getByText("open"));
+
+    const dialog = screen.getByRole("dialog");
+
+    for (let i = 0; i < 8; i += 1) {
+      await user.tab();
+      expect(dialog.contains(document.activeElement)).toBe(true);
+    }
+  });
+
+  it("pulls focus back when it has escaped the container", async () => {
+    const user = userEvent.setup();
+    render(<Page />);
+    await user.click(screen.getByText("open"));
+
+    // Simulates a click on something behind the overlay, or a script moving
+    // focus out from under us.
+    screen.getByText("outside").focus();
+    await user.tab();
+
+    expect(screen.getByRole("dialog").contains(document.activeElement)).toBe(true);
+  });
+
+  it("notices elements added after the trap opened", async () => {
+    // The edges are recomputed per keypress rather than cached on open,
+    // because dialog content changes -- validation errors, disclosures,
+    // buttons becoming enabled.
+    const user = userEvent.setup();
+    render(<Page extra />);
+    await user.click(screen.getByText("open"));
+
+    screen.getByText("last").focus();
+    await user.tab();
+
+    expect(document.activeElement).toBe(screen.getByText("first"));
+
+    screen.getByText("first").focus();
+    await user.tab({ shift: true });
+
+    expect(document.activeElement).toBe(screen.getByText("last"));
+  });
+
+  it("calls onEscape when Escape is pressed", async () => {
+    const onEscape = vi.fn();
+    const user = userEvent.setup();
+
+    render(<Page onEscape={onEscape} />);
+    await user.click(screen.getByText("open"));
+
+    await user.keyboard("{Escape}");
+
+    expect(onEscape).toHaveBeenCalledTimes(1);
+  });
+
+  it("restores focus to the trigger when it closes", async () => {
+    // Without this, focus falls to <body> and the next Tab starts from the top
+    // of the document instead of from the button the user just used.
+    const user = userEvent.setup();
+
+    function Closable() {
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button onClick={() => setOpen(true)}>trigger</button>
+          {open ? <Dialog active onEscape={() => setOpen(false)} /> : null}
+        </>
+      );
+    }
+
+    render(<Closable />);
+
+    const trigger = screen.getByText("trigger");
+    await user.click(trigger);
+    expect(document.activeElement).not.toBe(trigger);
+
+    await user.keyboard("{Escape}");
+
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("does nothing while inactive", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <>
+        <button>outside</button>
+        <Dialog active={false} />
+      </>,
+    );
+
+    screen.getByText("outside").focus();
+    await user.tab();
+
+    // No trap, so Tab behaves normally and leaves the button.
+    expect(document.activeElement).not.toBe(screen.getByText("outside"));
+  });
+});

--- a/frontend/src/hooks/__tests__/useRovingTabIndex.test.tsx
+++ b/frontend/src/hooks/__tests__/useRovingTabIndex.test.tsx
@@ -1,0 +1,201 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import { useRovingTabIndex, type RovingOrientation } from "../useRovingTabIndex";
+
+const ITEMS = ["Bold", "Italic", "Strikethrough", "Code"];
+
+function Toolbar({
+  orientation = "horizontal",
+  loop = true,
+  typeahead = false,
+}: {
+  orientation?: RovingOrientation;
+  loop?: boolean;
+  typeahead?: boolean;
+}) {
+  const { containerRef, getItemProps, containerProps } = useRovingTabIndex<HTMLDivElement>({
+    orientation,
+    loop,
+    typeahead,
+  });
+
+  return (
+    <>
+      <button>before</button>
+      <div ref={containerRef} role="toolbar" {...containerProps}>
+        {ITEMS.map((label, index) => (
+          <button key={label} {...getItemProps(index)}>
+            {label}
+          </button>
+        ))}
+      </div>
+      <button>after</button>
+    </>
+  );
+}
+
+describe("useRovingTabIndex", () => {
+  it("exposes the group as a single tab stop", () => {
+    // The point of the pattern: a six-item toolbar should cost one Tab press
+    // to get past, not six.
+    render(<Toolbar />);
+
+    const stops = ITEMS.map((label) => screen.getByText(label).tabIndex);
+
+    expect(stops).toEqual([0, -1, -1, -1]);
+  });
+
+  it("tabs past the whole group in one press", async () => {
+    const user = userEvent.setup();
+    render(<Toolbar />);
+
+    screen.getByText("before").focus();
+    await user.tab();
+    expect(document.activeElement).toBe(screen.getByText("Bold"));
+
+    await user.tab();
+    expect(document.activeElement).toBe(screen.getByText("after"));
+  });
+
+  it("moves right and left with the arrow keys", async () => {
+    const user = userEvent.setup();
+    render(<Toolbar />);
+
+    screen.getByText("Bold").focus();
+
+    await user.keyboard("{ArrowRight}");
+    expect(document.activeElement).toBe(screen.getByText("Italic"));
+
+    await user.keyboard("{ArrowLeft}");
+    expect(document.activeElement).toBe(screen.getByText("Bold"));
+  });
+
+  it("wraps at both ends when looping", async () => {
+    const user = userEvent.setup();
+    render(<Toolbar />);
+
+    screen.getByText("Bold").focus();
+    await user.keyboard("{ArrowLeft}");
+    expect(document.activeElement).toBe(screen.getByText("Code"));
+
+    await user.keyboard("{ArrowRight}");
+    expect(document.activeElement).toBe(screen.getByText("Bold"));
+  });
+
+  it("stops at the ends when not looping", async () => {
+    const user = userEvent.setup();
+    render(<Toolbar loop={false} />);
+
+    screen.getByText("Bold").focus();
+    await user.keyboard("{ArrowLeft}");
+
+    expect(document.activeElement).toBe(screen.getByText("Bold"));
+  });
+
+  it("ignores the cross-axis arrows for a horizontal group", async () => {
+    // A horizontal toolbar must not swallow ArrowDown -- the page still needs
+    // to scroll.
+    const user = userEvent.setup();
+    render(<Toolbar orientation="horizontal" />);
+
+    screen.getByText("Bold").focus();
+    await user.keyboard("{ArrowDown}");
+
+    expect(document.activeElement).toBe(screen.getByText("Bold"));
+  });
+
+  it("uses up and down for a vertical group", async () => {
+    const user = userEvent.setup();
+    render(<Toolbar orientation="vertical" />);
+
+    screen.getByText("Bold").focus();
+    await user.keyboard("{ArrowDown}");
+
+    expect(document.activeElement).toBe(screen.getByText("Italic"));
+  });
+
+  it("accepts both axes when orientation is both", async () => {
+    const user = userEvent.setup();
+    render(<Toolbar orientation="both" />);
+
+    screen.getByText("Bold").focus();
+    await user.keyboard("{ArrowDown}");
+    expect(document.activeElement).toBe(screen.getByText("Italic"));
+
+    await user.keyboard("{ArrowRight}");
+    expect(document.activeElement).toBe(screen.getByText("Strikethrough"));
+  });
+
+  it("jumps to the ends with Home and End", async () => {
+    const user = userEvent.setup();
+    render(<Toolbar />);
+
+    screen.getByText("Bold").focus();
+
+    await user.keyboard("{End}");
+    expect(document.activeElement).toBe(screen.getByText("Code"));
+
+    await user.keyboard("{Home}");
+    expect(document.activeElement).toBe(screen.getByText("Bold"));
+  });
+
+  it("follows focus when the user clicks into the middle", async () => {
+    // Somebody can click or shift-tab straight into the middle of a group. If
+    // the index does not follow, the next arrow press jumps back to wherever
+    // the index was left.
+    const user = userEvent.setup();
+    render(<Toolbar />);
+
+    await user.click(screen.getByText("Strikethrough"));
+    await user.keyboard("{ArrowRight}");
+
+    expect(document.activeElement).toBe(screen.getByText("Code"));
+  });
+
+  it("jumps by typed letter when typeahead is on", async () => {
+    const user = userEvent.setup();
+    render(<Toolbar typeahead />);
+
+    screen.getByText("Bold").focus();
+    await user.keyboard("c");
+
+    expect(document.activeElement).toBe(screen.getByText("Code"));
+  });
+
+  it("does not typeahead when it is off", async () => {
+    const user = userEvent.setup();
+    render(<Toolbar />);
+
+    screen.getByText("Bold").focus();
+    await user.keyboard("c");
+
+    expect(document.activeElement).toBe(screen.getByText("Bold"));
+  });
+
+  it("skips disabled items", async () => {
+    const user = userEvent.setup();
+
+    function WithDisabled() {
+      const { containerRef, getItemProps, containerProps } = useRovingTabIndex<HTMLDivElement>();
+
+      return (
+        <div ref={containerRef} role="toolbar" {...containerProps}>
+          <button {...getItemProps(0)}>one</button>
+          <button {...getItemProps(1)} disabled>
+            two
+          </button>
+          <button {...getItemProps(2)}>three</button>
+        </div>
+      );
+    }
+
+    render(<WithDisabled />);
+
+    screen.getByText("one").focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(document.activeElement).toBe(screen.getByText("three"));
+  });
+});

--- a/frontend/src/hooks/useFocusTrap.ts
+++ b/frontend/src/hooks/useFocusTrap.ts
@@ -1,0 +1,122 @@
+import { useCallback, useEffect, useRef } from "react";
+
+import { focusFirst, getTabbableEdges } from "@/lib/a11y/tabbable";
+
+export interface UseFocusTrapOptions {
+  /** Whether the trap is active. Usually the dialog's open state. */
+  active: boolean;
+  /** Move focus into the container when the trap activates. Default `true`. */
+  autoFocus?: boolean;
+  /** Restore focus to the previously focused element on release. Default `true`. */
+  restoreFocus?: boolean;
+  /** Called when Escape is pressed while the trap is active. */
+  onEscape?: () => void;
+}
+
+/**
+ * Keep Tab and Shift+Tab inside a container while it is open.
+ *
+ * Without this, a modal is only visually modal: press Tab enough times and
+ * focus walks out of the dialog and into the page behind it, which is still
+ * there, still focusable, and covered by an overlay. The user is now typing
+ * into something they cannot see.
+ *
+ * Two things this does that a minimal version does not:
+ *
+ * - **Restores focus on release.** Closing a dialog without restoring drops
+ *   focus to `<body>`, so the next Tab starts from the top of the document
+ *   rather than from the button the user just pressed.
+ * - **Recomputes the edges on every keypress** rather than caching them when
+ *   the trap opens. Dialog content changes -- a validation error appears, a
+ *   disclosure expands, a button becomes enabled -- and a cached last element
+ *   sends focus to something that is no longer there.
+ */
+export function useFocusTrap<T extends HTMLElement = HTMLElement>({
+  active,
+  autoFocus = true,
+  restoreFocus = true,
+  onEscape,
+}: UseFocusTrapOptions) {
+  const containerRef = useRef<T | null>(null);
+  const previouslyFocused = useRef<HTMLElement | null>(null);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onEscape?.();
+        return;
+      }
+
+      if (event.key !== "Tab") return;
+
+      const container = containerRef.current;
+      if (!container) return;
+
+      // Recomputed per keypress on purpose; see the docstring.
+      const edges = getTabbableEdges(container);
+
+      if (!edges) {
+        // Nothing to tab to. Swallow the key so focus cannot escape into the
+        // page behind an empty dialog.
+        event.preventDefault();
+        return;
+      }
+
+      const activeElement = container.ownerDocument.activeElement as HTMLElement | null;
+
+      // Focus may be outside the container entirely -- the user clicked
+      // something behind the overlay, or a script moved it. Pull it back
+      // rather than letting the wrap logic no-op.
+      if (!activeElement || !container.contains(activeElement)) {
+        event.preventDefault();
+        (event.shiftKey ? edges.last : edges.first).focus();
+        return;
+      }
+
+      if (event.shiftKey && activeElement === edges.first) {
+        event.preventDefault();
+        edges.last.focus();
+        return;
+      }
+
+      if (!event.shiftKey && activeElement === edges.last) {
+        event.preventDefault();
+        edges.first.focus();
+      }
+    },
+    [onEscape],
+  );
+
+  useEffect(() => {
+    if (!active) return;
+
+    const container = containerRef.current;
+    if (!container) return;
+
+    const doc = container.ownerDocument;
+
+    previouslyFocused.current = doc.activeElement as HTMLElement | null;
+
+    if (autoFocus) {
+      focusFirst(container);
+    }
+
+    doc.addEventListener("keydown", handleKeyDown, true);
+
+    return () => {
+      doc.removeEventListener("keydown", handleKeyDown, true);
+
+      if (restoreFocus) {
+        const target = previouslyFocused.current;
+        // The element may have been removed while the dialog was open -- a
+        // row deleted, a list re-rendered -- so check it is still in the
+        // document before trying to focus it.
+        if (target && doc.contains(target)) {
+          target.focus();
+        }
+      }
+    };
+  }, [active, autoFocus, restoreFocus, handleKeyDown]);
+
+  return containerRef;
+}

--- a/frontend/src/hooks/useFocusVisible.ts
+++ b/frontend/src/hooks/useFocusVisible.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Whether the user is currently navigating by keyboard.
+ *
+ * `:focus-visible` covers most cases in CSS and should be preferred. This hook
+ * exists for the cases CSS cannot reach: deciding whether to *render* a focus
+ * affordance at all, whether to scroll a newly focused item into view, or
+ * whether to open a menu on focus.
+ *
+ * The heuristic is the same one the browser uses: a keydown that could move
+ * focus means keyboard, a pointer interaction means not. Tracked at the
+ * document level with capture, so it sees the event before anything can stop
+ * its propagation.
+ */
+export function useFocusVisible(): boolean {
+  const [isKeyboard, setIsKeyboard] = useState(false);
+
+  useEffect(() => {
+    // Guarded rather than assumed: this app server-renders, and `document` is
+    // not there during SSR.
+    if (typeof document === "undefined") return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      // A modifier on its own is not navigation, and neither is Ctrl+S.
+      if (event.metaKey || event.altKey || event.ctrlKey) return;
+      setIsKeyboard(true);
+    };
+
+    const onPointerDown = () => setIsKeyboard(false);
+
+    document.addEventListener("keydown", onKeyDown, true);
+    document.addEventListener("mousedown", onPointerDown, true);
+    document.addEventListener("pointerdown", onPointerDown, true);
+    document.addEventListener("touchstart", onPointerDown, true);
+
+    return () => {
+      document.removeEventListener("keydown", onKeyDown, true);
+      document.removeEventListener("mousedown", onPointerDown, true);
+      document.removeEventListener("pointerdown", onPointerDown, true);
+      document.removeEventListener("touchstart", onPointerDown, true);
+    };
+  }, []);
+
+  return isKeyboard;
+}

--- a/frontend/src/hooks/useRovingTabIndex.ts
+++ b/frontend/src/hooks/useRovingTabIndex.ts
@@ -1,0 +1,189 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { getTabbableElements, isFocusable } from "@/lib/a11y/tabbable";
+
+export type RovingOrientation = "horizontal" | "vertical" | "both";
+
+export interface UseRovingTabIndexOptions {
+  /** Which arrow keys move between items. Default `"horizontal"`. */
+  orientation?: RovingOrientation;
+  /** Wrap from the last item to the first. Default `true`. */
+  loop?: boolean;
+  /** Jump to an item by typing the start of its text. Default `false`. */
+  typeahead?: boolean;
+  /** Index focused when the group is first reached. Default `0`. */
+  defaultIndex?: number;
+}
+
+/** How long a typeahead buffer stays alive between keystrokes. */
+const TYPEAHEAD_TIMEOUT_MS = 500;
+
+/**
+ * Make a group of controls behave as a single tab stop.
+ *
+ * A toolbar, tab list, menu or segmented control should be **one** stop in the
+ * page's tab order, with arrow keys moving between its items. Ours are
+ * currently N stops, so tabbing through a page with a six-item toolbar costs
+ * six presses to get past it.
+ *
+ * This is the "roving tabindex" pattern from the WAI-ARIA authoring practices:
+ * exactly one item carries `tabIndex={0}` and the rest carry `-1`, and the
+ * index moves as the user arrows around.
+ *
+ * ```tsx
+ * const { containerRef, getItemProps } = useRovingTabIndex({ orientation: "horizontal" });
+ *
+ * <div ref={containerRef} role="toolbar">
+ *   {items.map((item, i) => <button key={item.id} {...getItemProps(i)}>{item.label}</button>)}
+ * </div>
+ * ```
+ */
+export function useRovingTabIndex<T extends HTMLElement = HTMLElement>({
+  orientation = "horizontal",
+  loop = true,
+  typeahead = false,
+  defaultIndex = 0,
+}: UseRovingTabIndexOptions = {}) {
+  const containerRef = useRef<T | null>(null);
+  const [activeIndex, setActiveIndex] = useState(defaultIndex);
+
+  const typeaheadBuffer = useRef("");
+  const typeaheadTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const items = useCallback((): HTMLElement[] => {
+    const container = containerRef.current;
+    if (!container) return [];
+
+    // Items carry tabIndex={-1} while inactive, which makes them focusable but
+    // not tabbable -- so getTabbableElements would return only the active one.
+    // Query the group's own children instead and filter on focusability.
+    return Array.from(container.querySelectorAll<HTMLElement>("[data-roving-item]")).filter(
+      isFocusable,
+    );
+  }, []);
+
+  const focusIndex = useCallback(
+    (index: number) => {
+      const list = items();
+      if (list.length === 0) return;
+
+      let next = index;
+
+      if (next < 0) next = loop ? list.length - 1 : 0;
+      if (next >= list.length) next = loop ? 0 : list.length - 1;
+
+      setActiveIndex(next);
+      list[next]?.focus();
+    },
+    [items, loop],
+  );
+
+  const runTypeahead = useCallback(
+    (char: string) => {
+      if (typeaheadTimer.current) clearTimeout(typeaheadTimer.current);
+
+      typeaheadBuffer.current += char.toLowerCase();
+
+      typeaheadTimer.current = setTimeout(() => {
+        typeaheadBuffer.current = "";
+      }, TYPEAHEAD_TIMEOUT_MS);
+
+      const list = items();
+      const query = typeaheadBuffer.current;
+
+      // Search from the item after the current one and wrap, so repeatedly
+      // typing "s" cycles through every item starting with S rather than
+      // sticking on the first.
+      const ordered = [...list.slice(activeIndex + 1), ...list.slice(0, activeIndex + 1)];
+
+      const match = ordered.find((item) =>
+        (item.textContent ?? "").trim().toLowerCase().startsWith(query),
+      );
+
+      if (match) focusIndex(list.indexOf(match));
+    },
+    [activeIndex, focusIndex, items],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      const horizontal = orientation === "horizontal" || orientation === "both";
+      const vertical = orientation === "vertical" || orientation === "both";
+
+      switch (event.key) {
+        case "ArrowRight":
+          if (!horizontal) return;
+          event.preventDefault();
+          focusIndex(activeIndex + 1);
+          return;
+        case "ArrowLeft":
+          if (!horizontal) return;
+          event.preventDefault();
+          focusIndex(activeIndex - 1);
+          return;
+        case "ArrowDown":
+          if (!vertical) return;
+          event.preventDefault();
+          focusIndex(activeIndex + 1);
+          return;
+        case "ArrowUp":
+          if (!vertical) return;
+          event.preventDefault();
+          focusIndex(activeIndex - 1);
+          return;
+        case "Home":
+          event.preventDefault();
+          focusIndex(0);
+          return;
+        case "End":
+          event.preventDefault();
+          focusIndex(items().length - 1);
+          return;
+        default:
+          break;
+      }
+
+      // Single printable characters only; modifiers mean the user is reaching
+      // for a shortcut, not typing a label.
+      if (typeahead && event.key.length === 1 && !event.metaKey && !event.ctrlKey) {
+        runTypeahead(event.key);
+      }
+    },
+    [activeIndex, focusIndex, items, orientation, runTypeahead, typeahead],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (typeaheadTimer.current) clearTimeout(typeaheadTimer.current);
+    };
+  }, []);
+
+  /**
+   * Props for each item. Spread onto the element.
+   *
+   * `onFocus` matters as much as the keyboard handling: a user can click or
+   * shift-tab straight into the middle of the group, and if the index does not
+   * follow, the next arrow press jumps back to wherever the index was left.
+   */
+  const getItemProps = useCallback(
+    (index: number) => ({
+      "data-roving-item": "",
+      tabIndex: index === activeIndex ? 0 : -1,
+      onFocus: () => setActiveIndex(index),
+    }),
+    [activeIndex],
+  );
+
+  return {
+    containerRef,
+    activeIndex,
+    setActiveIndex,
+    focusIndex,
+    getItemProps,
+    /** Spread onto the group container. */
+    containerProps: { onKeyDown: handleKeyDown },
+  };
+}
+
+/** Re-exported so callers do not need a second import for the common case. */
+export { getTabbableElements };

--- a/frontend/src/lib/a11y/__tests__/tabbable.test.ts
+++ b/frontend/src/lib/a11y/__tests__/tabbable.test.ts
@@ -1,0 +1,275 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { focusFirst, getTabbableEdges, getTabbableElements, isTabbable } from "../tabbable";
+
+function mount(html: string): HTMLElement {
+  const container = document.createElement("div");
+  container.innerHTML = html;
+  document.body.appendChild(container);
+  return container;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("getTabbableElements", () => {
+  it("finds the ordinary focusable elements in document order", () => {
+    const container = mount(`
+      <a href="/a">link</a>
+      <button>button</button>
+      <input />
+      <select></select>
+      <textarea></textarea>
+    `);
+
+    expect(getTabbableElements(container).map((el) => el.tagName)).toEqual([
+      "A",
+      "BUTTON",
+      "INPUT",
+      "SELECT",
+      "TEXTAREA",
+    ]);
+  });
+
+  it("skips an anchor with no href", () => {
+    // <a> without href is not a link and the browser does not stop on it.
+    const container = mount(`<a>not a link</a><button>real</button>`);
+
+    expect(getTabbableElements(container)).toHaveLength(1);
+  });
+
+  it("skips disabled controls", () => {
+    const container = mount(`<button disabled>no</button><button>yes</button>`);
+
+    expect(getTabbableElements(container)).toHaveLength(1);
+  });
+
+  it("skips controls inside a disabled fieldset", () => {
+    const container = mount(`
+      <fieldset disabled><button>no</button></fieldset>
+      <button>yes</button>
+    `);
+
+    expect(getTabbableElements(container)).toHaveLength(1);
+  });
+
+  it("keeps controls inside a disabled fieldset's first legend", () => {
+    // A real exception in the HTML spec, and people use it for a "customise"
+    // toggle sitting above a disabled block.
+    const container = mount(`
+      <fieldset disabled>
+        <legend><button>still on</button></legend>
+        <button>off</button>
+      </fieldset>
+    `);
+
+    const tabbable = getTabbableElements(container);
+
+    expect(tabbable).toHaveLength(1);
+    expect(tabbable[0].textContent).toBe("still on");
+  });
+
+  it("skips anything inside an inert subtree", () => {
+    // inert is how a correctly built modal turns off the page behind it.
+    const container = mount(`
+      <div inert><button>behind the modal</button></div>
+      <button>in the modal</button>
+    `);
+
+    expect(getTabbableElements(container)).toHaveLength(1);
+  });
+
+  it("skips anything inside a hidden subtree", () => {
+    const container = mount(`
+      <div hidden><button>no</button></div>
+      <button>yes</button>
+    `);
+
+    expect(getTabbableElements(container)).toHaveLength(1);
+  });
+
+  it("skips display:none", () => {
+    const container = mount(`
+      <button style="display: none">no</button>
+      <button>yes</button>
+    `);
+
+    expect(getTabbableElements(container)).toHaveLength(1);
+  });
+
+  it("skips visibility:hidden", () => {
+    const container = mount(`
+      <button style="visibility: hidden">no</button>
+      <button>yes</button>
+    `);
+
+    expect(getTabbableElements(container)).toHaveLength(1);
+  });
+
+  it("skips tabindex=-1", () => {
+    // Focusable by script, not reachable by Tab. That distinction is the
+    // whole difference between isFocusable and isTabbable.
+    const container = mount(`<button tabindex="-1">no</button><button>yes</button>`);
+
+    expect(getTabbableElements(container)).toHaveLength(1);
+  });
+
+  it("visits positive tabindex before document order", () => {
+    // The most commonly missed rule. A trap that ignores it wraps in a
+    // different order than Tab does.
+    const container = mount(`
+      <button id="natural">natural</button>
+      <button id="third" tabindex="3">third</button>
+      <button id="first" tabindex="1">first</button>
+    `);
+
+    expect(getTabbableElements(container).map((el) => el.id)).toEqual([
+      "first",
+      "third",
+      "natural",
+    ]);
+  });
+
+  it("breaks ties in positive tabindex by document order", () => {
+    const container = mount(`
+      <button id="a" tabindex="2">a</button>
+      <button id="b" tabindex="2">b</button>
+    `);
+
+    expect(getTabbableElements(container).map((el) => el.id)).toEqual(["a", "b"]);
+  });
+
+  it("treats a radio group as a single tab stop", () => {
+    // Otherwise a focus trap loops through a form's radio options one at a
+    // time, which is not how the browser behaves.
+    const container = mount(`
+      <input type="radio" name="plan" id="r1" />
+      <input type="radio" name="plan" id="r2" checked />
+      <input type="radio" name="plan" id="r3" />
+    `);
+
+    const tabbable = getTabbableElements(container);
+
+    expect(tabbable).toHaveLength(1);
+    expect(tabbable[0].id).toBe("r2");
+  });
+
+  it("uses the first radio when none is checked", () => {
+    const container = mount(`
+      <input type="radio" name="plan" id="r1" />
+      <input type="radio" name="plan" id="r2" />
+    `);
+
+    expect(getTabbableElements(container)[0].id).toBe("r1");
+  });
+
+  it("keeps radios in different groups separate", () => {
+    const container = mount(`
+      <input type="radio" name="a" id="a1" />
+      <input type="radio" name="b" id="b1" />
+    `);
+
+    expect(getTabbableElements(container)).toHaveLength(2);
+  });
+
+  it("skips the content of a closed details but keeps its summary", () => {
+    const container = mount(`
+      <details>
+        <summary>toggle</summary>
+        <button>hidden until open</button>
+      </details>
+    `);
+
+    const tabbable = getTabbableElements(container);
+
+    expect(tabbable).toHaveLength(1);
+    expect(tabbable[0].tagName).toBe("SUMMARY");
+  });
+
+  it("includes the content of an open details", () => {
+    const container = mount(`
+      <details open>
+        <summary>toggle</summary>
+        <button>now reachable</button>
+      </details>
+    `);
+
+    expect(getTabbableElements(container)).toHaveLength(2);
+  });
+
+  it("includes contenteditable but not contenteditable=false", () => {
+    const container = mount(`
+      <div contenteditable="true">yes</div>
+      <div contenteditable="false">no</div>
+    `);
+
+    expect(getTabbableElements(container)).toHaveLength(1);
+  });
+
+  it("returns an empty list for a null container", () => {
+    expect(getTabbableElements(null)).toEqual([]);
+  });
+
+  it("returns an empty list when nothing is tabbable", () => {
+    expect(getTabbableElements(mount(`<p>just text</p>`))).toEqual([]);
+  });
+});
+
+describe("isTabbable", () => {
+  it("distinguishes focusable from tabbable", () => {
+    const container = mount(`<button tabindex="-1">focusable only</button>`);
+    const button = container.querySelector("button")!;
+
+    expect(isTabbable(button)).toBe(false);
+  });
+});
+
+describe("getTabbableEdges", () => {
+  it("returns the first and last stops", () => {
+    const container = mount(`
+      <button id="a">a</button>
+      <button id="b">b</button>
+      <button id="c">c</button>
+    `);
+
+    const edges = getTabbableEdges(container)!;
+
+    expect(edges.first.id).toBe("a");
+    expect(edges.last.id).toBe("c");
+  });
+
+  it("returns the same element for both when there is only one", () => {
+    const container = mount(`<button id="only">only</button>`);
+    const edges = getTabbableEdges(container)!;
+
+    expect(edges.first).toBe(edges.last);
+  });
+
+  it("returns null when there are no stops", () => {
+    expect(getTabbableEdges(mount(`<p>text</p>`))).toBeNull();
+  });
+});
+
+describe("focusFirst", () => {
+  it("focuses the first tab stop", () => {
+    const container = mount(`<button id="a">a</button><button id="b">b</button>`);
+
+    expect(focusFirst(container)).toBe(true);
+    expect(document.activeElement?.id).toBe("a");
+  });
+
+  it("falls back to the container when nothing inside is tabbable", () => {
+    // Focus has to land somewhere inside, or a screen reader stays on the page
+    // behind the dialog.
+    const container = mount(`<p>nothing interactive</p>`);
+
+    expect(focusFirst(container)).toBe(false);
+    expect(document.activeElement).toBe(container);
+    expect(container.getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("does nothing for a null container", () => {
+    expect(focusFirst(null)).toBe(false);
+  });
+});

--- a/frontend/src/lib/a11y/index.ts
+++ b/frontend/src/lib/a11y/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared accessibility primitives.
+ *
+ * Import from here rather than reaching into the individual files, so the
+ * surface stays small and the next person building a menu finds all of it in
+ * one place instead of writing a sixth focus trap.
+ *
+ * See `docs/accessibility.md`.
+ */
+
+export {
+  focusFirst,
+  getTabbableEdges,
+  getTabbableElements,
+  isFocusable,
+  isTabbable,
+} from "./tabbable";

--- a/frontend/src/lib/a11y/tabbable.ts
+++ b/frontend/src/lib/a11y/tabbable.ts
@@ -1,0 +1,235 @@
+/**
+ * Finding the elements a keyboard user can actually reach.
+ *
+ * This is the primitive everything else in `lib/a11y` is built on, and it is
+ * the part that is genuinely fiddly. A naive
+ * `container.querySelectorAll("button, a[href], input, …")` gets the common
+ * case right and then goes wrong on all of these:
+ *
+ * - a `disabled` button, or one inside a `disabled` fieldset
+ * - anything inside an `inert` subtree
+ * - `display: none` / `visibility: hidden` / `hidden`
+ * - collapsed `<details>` content
+ * - `tabindex="-1"`, which is focusable but not *tabbable*
+ * - radio buttons: only the checked member of a group is a tab stop, and if
+ *   none is checked, only the first
+ * - positive `tabindex`, which the browser visits *before* everything in
+ *   document order
+ *
+ * That last one is the most commonly missed. A focus trap that ignores
+ * positive tabindex wraps in a different order than Tab does, and the user
+ * ends up somewhere they did not expect.
+ *
+ * Everything here is SSR-safe: nothing touches `document` at module scope.
+ */
+
+/**
+ * Elements that are focusable by default, plus anything given an explicit
+ * `tabindex`. Kept as a single selector so the DOM is only walked once.
+ */
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "area[href]",
+  "button",
+  "input",
+  "select",
+  "textarea",
+  "details > summary:first-of-type",
+  "iframe",
+  "object",
+  "embed",
+  "audio[controls]",
+  "video[controls]",
+  "[contenteditable]:not([contenteditable='false'])",
+  "[tabindex]",
+].join(",");
+
+function isDisabled(element: Element): boolean {
+  if ((element as HTMLInputElement).disabled) return true;
+
+  // A disabled fieldset disables its descendants -- except anything inside
+  // its first <legend>, which stays interactive. That exception is real and
+  // people do use it for a "customise" toggle above a disabled block.
+  const fieldset = element.closest("fieldset[disabled]");
+  if (!fieldset) return false;
+
+  const legend = fieldset.querySelector(":scope > legend");
+  return !legend || !legend.contains(element);
+}
+
+function isInert(element: Element): boolean {
+  // `inert` removes a whole subtree from the accessibility tree and from tab
+  // order. It is how a correctly built modal turns off the page behind it.
+  return element.closest("[inert]") !== null;
+}
+
+function isHiddenByAttribute(element: Element): boolean {
+  return element.closest("[hidden]") !== null;
+}
+
+function isInsideClosedDetails(element: Element): boolean {
+  const details = element.closest("details:not([open])");
+  if (!details) return false;
+
+  // The summary of a closed <details> is still a tab stop; everything after
+  // it is not.
+  const summary = details.querySelector(":scope > summary");
+  return !summary || !summary.contains(element);
+}
+
+function isRendered(element: HTMLElement): boolean {
+  // Computed style rather than offsetParent: offsetParent is null for
+  // position:fixed elements too, which are perfectly visible.
+  //
+  // Deliberately no bounding-rect check. It would catch an element collapsed
+  // to zero size, but jsdom lays nothing out, so every rect is 0×0 there and
+  // the whole tab order would come back empty under test.
+  const style = element.ownerDocument.defaultView?.getComputedStyle(element);
+  if (!style) return true;
+
+  if (style.display === "none" || style.visibility === "hidden") return false;
+  if (style.contentVisibility === "hidden") return false;
+
+  return true;
+}
+
+/**
+ * Radio buttons form a group, and the group is one tab stop.
+ *
+ * The checked radio is the stop. If none is checked, the first one is. Any
+ * other member is focusable with an arrow key but is not reached by Tab, and
+ * treating each as its own stop makes a focus trap loop through a form's radio
+ * options one at a time.
+ */
+function isNonTabbableRadio(element: HTMLInputElement): boolean {
+  if (element.type !== "radio") return false;
+  if (element.checked) return false;
+
+  const root = element.form ?? element.ownerDocument;
+  const name = element.name;
+
+  if (!name) return false;
+
+  const group = Array.from(
+    root.querySelectorAll<HTMLInputElement>(`input[type="radio"][name="${CSS.escape(name)}"]`),
+  );
+
+  const checked = group.find((radio) => radio.checked);
+  if (checked) return true;
+
+  return group[0] !== element;
+}
+
+/** Whether an element can receive focus programmatically. */
+export function isFocusable(element: HTMLElement): boolean {
+  if (isDisabled(element)) return false;
+  if (isInert(element)) return false;
+  if (isHiddenByAttribute(element)) return false;
+  if (isInsideClosedDetails(element)) return false;
+  if (!isRendered(element)) return false;
+
+  return true;
+}
+
+/**
+ * Whether a contenteditable host is tabbable.
+ *
+ * Browsers report `tabIndex === 0` for these, but not every DOM
+ * implementation does -- jsdom reports -1, because its `tabIndex` getter only
+ * knows about the elements on its focusable-areas list. Reading the attribute
+ * is the portable answer, and an explicit `tabindex` still wins.
+ */
+function isEditableHost(element: HTMLElement): boolean {
+  const value = element.getAttribute("contenteditable");
+  if (value === null || value === "false") return false;
+
+  return !element.hasAttribute("tabindex");
+}
+
+/** Whether Tab will stop on an element. */
+export function isTabbable(element: HTMLElement): boolean {
+  if (!isFocusable(element)) return false;
+
+  // tabindex="-1" is the difference between focusable and tabbable: reachable
+  // by script, skipped by Tab.
+  if (element.tabIndex < 0 && !isEditableHost(element)) return false;
+
+  if (element instanceof HTMLInputElement && isNonTabbableRadio(element)) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Every tabbable descendant of `container`, in the order Tab visits them.
+ *
+ * Positive `tabindex` values come first, ascending, then everything with
+ * `tabindex="0"` or an implicit stop in document order. That is what the
+ * browser does, and a trap that sorts differently sends focus somewhere the
+ * user is not expecting.
+ */
+export function getTabbableElements(container: HTMLElement | null): HTMLElement[] {
+  if (!container) return [];
+
+  const candidates = Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+    isTabbable,
+  );
+
+  // The container itself can be a stop, and often is -- a dialog with
+  // tabindex="-1" is not, but one with tabindex="0" is.
+  if (isTabbable(container)) {
+    candidates.unshift(container);
+  }
+
+  const positive: { element: HTMLElement; index: number; order: number }[] = [];
+  const natural: HTMLElement[] = [];
+
+  candidates.forEach((element, order) => {
+    if (element.tabIndex > 0) {
+      positive.push({ element, index: element.tabIndex, order });
+    } else {
+      natural.push(element);
+    }
+  });
+
+  // Ties within the same positive tabindex resolve by document order, which
+  // is why the original index is carried along.
+  positive.sort((a, b) => a.index - b.index || a.order - b.order);
+
+  return [...positive.map((entry) => entry.element), ...natural];
+}
+
+/** The first and last tab stops in a container, or `null` if there are none. */
+export function getTabbableEdges(
+  container: HTMLElement | null,
+): { first: HTMLElement; last: HTMLElement } | null {
+  const elements = getTabbableElements(container);
+  if (elements.length === 0) return null;
+
+  return { first: elements[0], last: elements[elements.length - 1] };
+}
+
+/**
+ * Move focus to the first tab stop in a container.
+ *
+ * Falls back to the container itself, which is what a dialog with no
+ * interactive content needs -- focus has to land *somewhere* inside, or the
+ * screen reader stays on the page behind.
+ */
+export function focusFirst(container: HTMLElement | null): boolean {
+  if (!container) return false;
+
+  const elements = getTabbableElements(container);
+
+  if (elements.length > 0) {
+    elements[0].focus();
+    return true;
+  }
+
+  if (container.tabIndex < 0) {
+    container.setAttribute("tabindex", "-1");
+  }
+  container.focus();
+  return false;
+}

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -14,6 +14,8 @@ import { Toaster, toast } from "sonner";
 import { ThemeProvider } from "@/context/ThemeContext";
 import { I18nProvider } from "@/context/I18nContext";
 import { OfflineBanner } from "@/components/OfflineBanner";
+import { AnnouncerProvider } from "@/components/a11y/Announcer";
+import { SkipLink } from "@/components/a11y/SkipLink";
 import { applyServiceWorkerUpdate, registerServiceWorker } from "@/lib/pwa";
 
 import appCss from "../styles.css?url";
@@ -248,11 +250,16 @@ function RootComponent() {
   return (
     <QueryClientProvider client={queryClient}>
       <I18nProvider>
-        <ThemeProvider defaultTheme="system">
-          <OfflineBanner />
-          <Outlet />
-          <Toaster position="top-right" richColors />
-        </ThemeProvider>
+        <AnnouncerProvider>
+          <ThemeProvider defaultTheme="system">
+            {/* First thing in the tab order, so a keyboard user is not made to
+                walk the sidebar and header on every single navigation. */}
+            <SkipLink />
+            <OfflineBanner />
+            <Outlet />
+            <Toaster position="top-right" richColors />
+          </ThemeProvider>
+        </AnnouncerProvider>
         <AnimatePresence mode="wait" initial={false}>
           <Outlet key={location.pathname} />
         </AnimatePresence>


### PR DESCRIPTION
Closes #879

## What was broken

`grep -r "focus-trap\|focusTrap\|skip-to-content" frontend/src` returns nothing, and it shows:

* **No skip link.** A keyboard user landing on the dashboard tabs through roughly **forty stops** before reaching the content — on every navigation.
* **Nothing traps focus in a modal.** Tab enough times in a dialog and focus walks into the page behind it: still there, still focusable, covered by an overlay. The user is now typing into something they cannot see.
* **Focus is never restored.** Closing a dialog drops focus to `<body>`, so the next Tab starts from the top of the document instead of the button just used.
* **Nothing is announced.** Toasts, "saved", "3 new notifications", search result counts — all silent to a screen reader. `aria-live` appears in exactly three files, each hand-rolled.
* **Composite widgets are N tab stops.** A six-item toolbar costs six Tab presses to get past.

Radix handles this inside its own primitives. Everything we build by hand — the command palette, the notification panel, custom menus — gets nothing, and each one re-solves the problem slightly differently and slightly wrong.

## `lib/a11y/tabbable.ts`

What everything else stands on, and the genuinely fiddly part. `querySelectorAll("button, a[href], input, …")` gets the common case right and then goes wrong on:

| | |
| --- | --- |
| `disabled` | including inside a `disabled` fieldset — **except** anything in that fieldset's first `<legend>`, which stays interactive. That exception is real and people use it for a "customise" toggle above a disabled block. |
| `inert` subtrees | how a correctly built modal turns off the page behind it |
| `display:none` / `visibility:hidden` / `hidden` | |
| collapsed `<details>` | content excluded, `<summary>` kept |
| `tabindex="-1"` | focusable by script, skipped by Tab — the whole difference between `isFocusable` and `isTabbable` |
| **radio groups** | **one** tab stop: the checked member, or the first if none is checked. Treating each radio as its own stop makes a focus trap loop through a form's options one at a time. |
| **positive `tabindex`** | visited **before** everything in document order |

That last one is the most commonly missed. A trap that ignores it wraps in a different order than Tab does, and the user ends up somewhere they did not expect.

## `useFocusTrap`

Two things a minimal version gets wrong, both covered by tests:

**Edges are recomputed on every keypress**, not cached when the trap opens. Dialog content changes — a validation error appears, a disclosure expands, a button becomes enabled — and a cached "last element" sends focus to something no longer there.

**Focus is pulled back when it has escaped.** The user can click something behind the overlay, or a script can move focus. If the trap only handles the wrap case, that state is unrecoverable by keyboard.

Focus is restored on release, after checking the element is still in the document — it may have been removed while the dialog was open.

## `useRovingTabIndex`

One tab stop for a group, arrow keys inside it, Home/End, optional wrap and typeahead, horizontal / vertical / both.

`getItemProps` includes an `onFocus` handler, and it matters as much as the key handling: somebody can click or shift-tab straight into the middle of the group, and if the index does not follow, the next arrow press jumps back to wherever the index was left.

A horizontal group deliberately ignores `ArrowUp`/`ArrowDown` — the page still needs to scroll.

## The announcer

**Two live regions, not one.** `aria-live` is read when the region is first seen; flipping the attribute between polite and assertive on an existing region does nothing on most screen readers.

**The zero-width space.** Screen readers only re-announce when the text *changes*. Announcing "3 results", then "3 results" again after a different search, produces **silence** the second time — and the user concludes nothing happened. Appending U+200B makes it technically different while being inaudible and invisible. It is the standard workaround and the kind of thing every hand-rolled live region rediscovers the hard way.

The regions are clipped, not `hidden` and not `display: none` — either removes them from the accessibility tree, which is the exact opposite of the point.

`useAnnouncer` no-ops outside a provider, so a component using it still works in isolation and in tests that do not care.

## `SkipLink`

A bare `href="#main-content"` moves the **scroll position but not focus** unless the target is focusable — so the next Tab starts from the top of the document again and the user is back where they began. The link sets `tabindex="-1"` on the target and focuses it explicitly.

Wired into `__root.tsx` as the first thing in the tab order, targeting the `<main>` in `DashboardLayout`.

## Tests

```
$ vitest run src/lib/a11y src/hooks/__tests__/useFocusTrap* src/hooks/__tests__/useRoving* src/components/a11y
61 passed
```

Most of them pin `tabbable`'s exclusion rules **one at a time** — that is where the bugs live. Plus a full eight-press Tab cycle asserting focus never leaves an open dialog, and a test that the trap notices elements added after it opened.

Two real fixes came out of writing them:

1. `contenteditable` hosts report `tabIndex === 0` in browsers but `-1` in jsdom, whose `tabIndex` getter only knows its focusable-areas list. Reading the attribute is the portable answer, with an explicit `tabindex` still winning.
2. `scrollIntoView` is not implemented everywhere, so the skip link's call to it is optional — it is a refinement, not the point of the link.

## Notes for review

* **No new runtime dependency.**
* **SSR-safe** — nothing touches `document` at module scope, and `useFocusVisible` guards for it. This app server-renders.
* Full suite on top of #880: `typecheck` clean, `build` ✓, `455 tests passed`. On `main` alone the typecheck still fails on the committed conflict markers that #880 fixes — nothing in this PR touches those files.
* One remaining lint warning, `react-refresh/only-export-components` on `Announcer.tsx`, matching the existing pattern in `I18nContext.tsx` and `ThemeContext.tsx`: a provider and its hook in one file.
* Docs in `docs/accessibility.md`.
* Nothing existing was migrated onto these yet — that is a per-component change with its own review surface. This PR is the layer plus the two wirings that have no downside (skip link, announcer provider).
