### PR TITLE
feat: add AI-powered insights to project cards (#749)

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -76,3 +76,11 @@ export type {
   Bookmark,
 } from "./modules/collections";
 export type { TeamMatchRequest, TeamMatchResponse } from "./modules/teamMatch";
+export { projectInsightsApi } from "./modules/projectInsights";
+export type {
+  ProjectInsightsResponse,
+  ProjectInsightsRequest,
+  SuggestedBuilder,
+  RoleGap,
+  RiskAlert,
+} from "./modules/projectInsights";

--- a/frontend/src/api/modules/projectInsights.ts
+++ b/frontend/src/api/modules/projectInsights.ts
@@ -1,0 +1,92 @@
+import { api, isBackendConfigured } from "../client";
+
+export interface SuggestedBuilder {
+  name: string;
+  role: string;
+  match_score: number;
+}
+
+export interface RoleGap {
+  role: string;
+  urgency: "low" | "medium" | "high";
+}
+
+export interface RiskAlert {
+  message: string;
+  severity: "info" | "warning" | "critical";
+}
+
+export interface ProjectInsightsResponse {
+  project_id: string;
+  summary: string;
+  suggested_builders: SuggestedBuilder[];
+  role_gaps: RoleGap[];
+  risk_alerts: RiskAlert[];
+}
+
+export interface ProjectInsightsRequest {
+  project_id: string;
+  title: string;
+  description: string;
+  tech_stack?: string;
+  status?: string;
+  members?: number;
+}
+
+const ROLE_KEYWORDS: Record<string, string[]> = {
+  frontend: ["react", "vue", "angular", "css", "ui", "ux", "tailwind", "frontend"],
+  backend: ["fastapi", "django", "node", "express", "api", "backend", "server"],
+  devops: ["docker", "kubernetes", "ci/cd", "deploy", "aws", "cloud", "devops"],
+  "ml/ai": ["ai", "ml", "machine learning", "tensorflow", "pytorch", "nlp"],
+  mobile: ["mobile", "react native", "flutter", "ios", "android", "swift", "kotlin"],
+};
+
+function fallbackInsights(data: ProjectInsightsRequest): ProjectInsightsResponse {
+  const text = `${data.title} ${data.description} ${data.tech_stack ?? ""}`.toLowerCase();
+  const members = data.members ?? 1;
+
+  // Detect role gaps from missing keywords
+  const detectedRoles = Object.entries(ROLE_KEYWORDS)
+    .filter(([, kws]) => kws.some((kw) => text.includes(kw)))
+    .map(([role]) => role);
+  const allRoles = Object.keys(ROLE_KEYWORDS);
+  const gaps: RoleGap[] = allRoles
+    .filter((r) => !detectedRoles.includes(r))
+    .slice(0, 2)
+    .map((role) => ({ role, urgency: "medium" as const }));
+
+  // Risk alerts based on heuristics
+  const risks: RiskAlert[] = [];
+  if (members === 1)
+    risks.push({ message: "Solo project — consider finding collaborators", severity: "warning" });
+  if (data.status === "recruiting" && members < 3)
+    risks.push({ message: "Team is small for the scope", severity: "info" });
+
+  // Suggested builders based on detected roles
+  const suggested: SuggestedBuilder[] = detectedRoles.slice(0, 2).map((role) => ({
+    name: `${role.charAt(0).toUpperCase() + role.slice(1)} Developer`,
+    role,
+    match_score: 0.75,
+  }));
+
+  const summary =
+    `This project uses ${detectedRoles.join(", ") || "general"} technologies.` +
+    (gaps.length ? ` It may benefit from ${gaps.map((g) => g.role).join(" and ")} expertise.` : "");
+
+  return {
+    project_id: data.project_id,
+    summary,
+    suggested_builders: suggested,
+    role_gaps: gaps,
+    risk_alerts: risks,
+  };
+}
+
+export const projectInsightsApi = {
+  generate: async (data: ProjectInsightsRequest): Promise<ProjectInsightsResponse> => {
+    if (!isBackendConfigured()) {
+      return Promise.resolve(fallbackInsights(data));
+    }
+    return api.post<ProjectInsightsResponse>("/api/project-insights", data);
+  },
+};

--- a/frontend/src/components/projects/ProjectInsightsCard.tsx
+++ b/frontend/src/components/projects/ProjectInsightsCard.tsx
@@ -1,0 +1,252 @@
+import { useMutation } from "@tanstack/react-query";
+import { Sparkles, Users2, AlertTriangle, Info, ChevronDown, ChevronUp } from "lucide-react";
+import { useState } from "react";
+import { projectInsightsApi } from "@/api/modules/projectInsights";
+import type { ProjectInsightsResponse } from "@/api/modules/projectInsights";
+import { Skeleton } from "@/components/shared/primitives";
+import { cn } from "@/lib/utils";
+
+interface ProjectInsightsCardProps {
+  projectId: string;
+  title: string;
+  description: string;
+  techStack?: string[];
+  status?: string;
+  members?: number;
+  /** Compact mode: single collapsed row for use inside listing cards */
+  compact?: boolean;
+}
+
+const severityStyles = {
+  info: "text-primary bg-primary/10 border-primary/20",
+  warning: "text-warning bg-warning/10 border-warning/30",
+  critical: "text-destructive bg-destructive/10 border-destructive/30",
+} as const;
+
+const urgencyDot = {
+  low: "bg-success",
+  medium: "bg-warning",
+  high: "bg-destructive",
+} as const;
+
+export function ProjectInsightsCard({
+  projectId,
+  title,
+  description,
+  techStack,
+  status,
+  members,
+  compact = false,
+}: ProjectInsightsCardProps) {
+  const [insights, setInsights] = useState<ProjectInsightsResponse | null>(null);
+  const [expanded, setExpanded] = useState(false);
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      projectInsightsApi.generate({
+        project_id: projectId,
+        title,
+        description,
+        tech_stack: techStack?.join(", "),
+        status,
+        members,
+      }),
+    onSuccess: (data) => {
+      setInsights(data);
+      setExpanded(true);
+    },
+  });
+
+  const handleToggle = () => {
+    if (!insights && !mutation.isPending) {
+      mutation.mutate();
+    } else {
+      setExpanded((v) => !v);
+    }
+  };
+
+  if (compact) {
+    return (
+      <div className="mt-3 border-t border-border pt-3">
+        <button
+          onClick={(e) => {
+            e.preventDefault();
+            handleToggle();
+          }}
+          className="inline-flex items-center gap-1.5 text-[11px] font-medium text-muted-foreground hover:text-primary transition-colors"
+          aria-expanded={expanded}
+          aria-label="Toggle AI insights"
+        >
+          <Sparkles size={11} className={cn(mutation.isPending && "animate-pulse text-primary")} />
+          AI Insights
+          {!mutation.isPending &&
+            (expanded ? <ChevronUp size={11} /> : <ChevronDown size={11} />)}
+        </button>
+
+        {mutation.isPending && (
+          <div className="mt-2 space-y-1.5">
+            <Skeleton className="h-3 w-full" />
+            <Skeleton className="h-3 w-2/3" />
+          </div>
+        )}
+
+        {expanded && insights && (
+          <div className="mt-2 space-y-2">
+            {insights.summary && (
+              <p className="text-[11px] text-muted-foreground leading-relaxed line-clamp-2">
+                {insights.summary}
+              </p>
+            )}
+
+            {insights.risk_alerts.length > 0 && (
+              <div className="flex flex-wrap gap-1">
+                {insights.risk_alerts.slice(0, 2).map((alert, i) => (
+                  <span
+                    key={i}
+                    className={cn(
+                      "inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-[10px] font-medium",
+                      severityStyles[alert.severity],
+                    )}
+                  >
+                    <AlertTriangle size={9} />
+                    {alert.message}
+                  </span>
+                ))}
+              </div>
+            )}
+
+            {insights.role_gaps.length > 0 && (
+              <div className="flex flex-wrap gap-1">
+                {insights.role_gaps.slice(0, 2).map((gap, i) => (
+                  <span
+                    key={i}
+                    className="inline-flex items-center gap-1 rounded-md border border-border/60 bg-muted/60 px-1.5 py-0.5 text-[10px] text-muted-foreground"
+                  >
+                    <span className={cn("h-1.5 w-1.5 rounded-full", urgencyDot[gap.urgency])} />
+                    {gap.role} needed
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // Full card mode (used in project detail)
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <p className="flex items-center gap-2 text-[13px] font-semibold text-foreground">
+          <Sparkles size={14} className="text-primary" />
+          AI Insights
+        </p>
+        <button
+          onClick={handleToggle}
+          className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] text-muted-foreground hover:bg-muted/50 hover:text-foreground transition-colors"
+          aria-expanded={expanded}
+        >
+          {mutation.isPending
+            ? "Generating…"
+            : insights
+              ? expanded
+                ? "Hide"
+                : "Show"
+              : "Generate"}
+          {!mutation.isPending && insights && (
+            expanded ? <ChevronUp size={11} /> : <ChevronDown size={11} />
+          )}
+        </button>
+      </div>
+
+      {mutation.isPending && (
+        <div className="mt-3 space-y-2">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-3/4" />
+          <Skeleton className="h-4 w-1/2" />
+        </div>
+      )}
+
+      {mutation.isError && (
+        <p className="mt-2 text-[11px] text-destructive">
+          Failed to generate insights. Try again.
+        </p>
+      )}
+
+      {expanded && insights && (
+        <div className="mt-3 space-y-4">
+          {/* Summary */}
+          {insights.summary && (
+            <p className="text-[12px] leading-relaxed text-muted-foreground">{insights.summary}</p>
+          )}
+
+          {/* Suggested builders */}
+          {insights.suggested_builders.length > 0 && (
+            <div>
+              <p className="mb-1.5 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                <Users2 size={11} />
+                Suggested Roles
+              </p>
+              <div className="space-y-1.5">
+                {insights.suggested_builders.map((b, i) => (
+                  <div key={i} className="flex items-center justify-between">
+                    <span className="text-[12px] text-foreground">{b.name}</span>
+                    <span className="text-[10px] text-muted-foreground">
+                      {Math.round(b.match_score * 100)}% match
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Role gaps */}
+          {insights.role_gaps.length > 0 && (
+            <div>
+              <p className="mb-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                Role Gaps
+              </p>
+              <div className="flex flex-wrap gap-1.5">
+                {insights.role_gaps.map((gap, i) => (
+                  <span
+                    key={i}
+                    className="inline-flex items-center gap-1.5 rounded-md border border-border/60 bg-muted/60 px-2 py-1 text-[11px] text-muted-foreground"
+                  >
+                    <span className={cn("h-2 w-2 rounded-full", urgencyDot[gap.urgency])} />
+                    {gap.role}
+                    <span className="text-[10px] capitalize opacity-70">· {gap.urgency}</span>
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Risk alerts */}
+          {insights.risk_alerts.length > 0 && (
+            <div>
+              <p className="mb-1.5 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                <AlertTriangle size={11} />
+                Risk Alerts
+              </p>
+              <div className="space-y-1.5">
+                {insights.risk_alerts.map((alert, i) => (
+                  <div
+                    key={i}
+                    className={cn(
+                      "flex items-start gap-2 rounded-md border px-2.5 py-2 text-[11px] font-medium",
+                      severityStyles[alert.severity],
+                    )}
+                  >
+                    <Info size={12} className="mt-px shrink-0" />
+                    {alert.message}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/routes/_app.projects.$projectId.tsx
+++ b/frontend/src/routes/_app.projects.$projectId.tsx
@@ -32,6 +32,7 @@ import { addRecentlyViewedProject } from "@/lib/recentlyViewedProjects";
 
 import { usePermissions } from "@/hooks/usePermissions";
 import { ProjectTimeline } from "@/components/project/ProjectTimeline";
+import { ProjectInsightsCard } from "@/components/projects/ProjectInsightsCard";
 
 export const Route = createFileRoute("/_app/projects/$projectId")({
   head: ({ params }) => ({
@@ -292,6 +293,17 @@ function ProjectDetail() {
                 </div>
               )}
             </div>
+          </Card>
+
+          <Card className="p-4 lg:col-span-3">
+            <ProjectInsightsCard
+              projectId={projectId}
+              title={p.name}
+              description={p.description}
+              techStack={p.stack}
+              status={p.status}
+              members={p.members}
+            />
           </Card>
 
           <ProjectTimeline className="mt-6" />

--- a/frontend/src/routes/_app.projects.tsx
+++ b/frontend/src/routes/_app.projects.tsx
@@ -15,6 +15,7 @@ import { Star, GitFork, Users2, Plus, Search, SlidersHorizontal, X } from "lucid
 import { useEffect, useMemo, useState } from "react";
 import { CreateProjectDialog } from "@/components/projects/CreateProjectDialog";
 import { ProjectFilters } from "@/components/projects/ProjectFilters";
+import { ProjectInsightsCard } from "@/components/projects/ProjectInsightsCard";
 import { useProjectFilters } from "@/hooks/useProjectFilters";
 import { cn } from "@/lib/utils";
 import { getRecentlyViewedProjectIds } from "@/lib/recentlyViewedProjects";
@@ -431,6 +432,15 @@ function ProjectsPage() {
                         .join(" ")}
                     </span>
                   </div>
+                  <ProjectInsightsCard
+                    compact
+                    projectId={p.id}
+                    title={p.name}
+                    description={p.description}
+                    techStack={p.stack}
+                    status={p.status}
+                    members={p.members}
+                  />
                 </Card>
               </Link>
             ))}


### PR DESCRIPTION
## Summary

Closes #749

Surfaces contextual AI-powered recommendations directly on each project card, including suggested collaborator roles, team role gaps, risk alerts, and an AI-generated project summary.

## Changes

**`frontend/src/api/modules/projectInsights.ts`** (new)
- `projectInsightsApi.generate()` — calls `POST /api/project-insights`
- Offline fallback using keyword heuristics (same pattern as `projectTagsApi`): detects roles from the tech stack, infers gaps, surfaces solo/small-team risk alerts — works without a backend configured

**`frontend/src/components/projects/ProjectInsightsCard.tsx`** (new)
- Two render modes:
  - **compact** — collapsible inline row for use inside listing cards; lazy-fetches on first expand
  - **full** — expandable section for the project detail overview tab; shows summary, suggested roles with match %, role gaps with urgency dots, and risk alert badges
- On-demand generation (click to trigger), skeletons while loading, error state

**`frontend/src/routes/_app.projects.tsx`**
- Adds `<ProjectInsightsCard compact />` inside each project card in the listing grid

**`frontend/src/routes/_app.projects.$projectId.tsx`**
- Adds `<ProjectInsightsCard />` as a full-width `Card` row in the overview tab, spanning all 3 columns below the existing About and metadata cards

**`frontend/src/api/index.ts`**
- Exports the new API module and its types

## Acceptance criteria

- [x] Suggested builders/collaborators surfaced per project card
- [x] Gaps in team roles highlighted
- [x] Risk alerts shown
- [x] AI-generated project summary displayed