### PR TITLE
feat: add organization verification badge and apply option to header #418

### DIFF
--- a/frontend/src/features/organizations/components/OrganizationHeader.tsx
+++ b/frontend/src/features/organizations/components/OrganizationHeader.tsx
@@ -7,6 +7,8 @@ interface OrganizationHeaderProps {
   location?: string;
   website?: string;
   isHiring: boolean;
+  isVerified?: boolean;
+  onVerifyClick?: () => void;
 }
 
 export const OrganizationHeader: React.FC<OrganizationHeaderProps> = ({
@@ -16,6 +18,8 @@ export const OrganizationHeader: React.FC<OrganizationHeaderProps> = ({
   location,
   website,
   isHiring,
+  isVerified = false,
+  onVerifyClick,
 }) => {
   return (
     <div className="relative rounded-xl border border-gray-800 bg-gray-900/50 overflow-hidden mb-6">
@@ -39,8 +43,16 @@ export const OrganizationHeader: React.FC<OrganizationHeaderProps> = ({
           </div>
 
           <div className="mb-2">
-            <h1 className="text-2xl sm:text-3xl font-bold text-white flex items-center gap-2">
+            <h1 className="text-2xl sm:text-3xl font-bold text-white flex items-center gap-2 flex-wrap">
               {name}
+              {isVerified && (
+                <span
+                  title="Verified Organization"
+                  className="inline-flex items-center justify-center w-5 h-5 bg-blue-500 text-white rounded-full text-xs shadow-sm"
+                >
+                  ✓
+                </span>
+              )}
               {isHiring && (
                 <span className="text-xs px-2.5 py-1 rounded-full bg-emerald-500/10 text-emerald-400 border border-emerald-500/20 font-medium">
                   Hiring
@@ -51,16 +63,28 @@ export const OrganizationHeader: React.FC<OrganizationHeaderProps> = ({
           </div>
         </div>
 
-        {website && (
-          <a
-            href={website}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white font-medium text-sm transition-colors"
-          >
-            Visit Website
-          </a>
-        )}
+        <div className="flex items-center gap-3">
+          {!isVerified && onVerifyClick && (
+            <button
+              onClick={onVerifyClick}
+              type="button"
+              className="px-4 py-2 rounded-lg bg-gray-800 hover:bg-gray-700 text-gray-200 border border-gray-700 font-medium text-sm transition-colors"
+            >
+              Apply for Verification
+            </button>
+          )}
+
+          {website && (
+            <a
+              href={website}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white font-medium text-sm transition-colors"
+            >
+              Visit Website
+            </a>
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

This pull request implements **Organization Verification (#418)**, allowing organization profiles to display an official verification badge upon approval and providing an option for unverified organizations to apply for verification.

---

## Related Issue

Closes #418

---

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [x] UI/UX enhancement
- [ ] Tests
- [ ] Other

---

## Changes Made

- Updated `OrganizationHeader.tsx` to support `isVerified` and `onVerifyClick` props.
- Added a styled verification checkmark badge next to the organization name.
- Added an "Apply for Verification" action button for organizations that are not yet verified.

---

## Testing

- [x] Tested locally
- [x] Existing tests pass
- [x] UI verified
- [ ] Cross-browser tested (if applicable)

Additional testing notes:
- Verified that the badge renders correctly for verified organizations and the application trigger functions as expected.