### PR TITLE
fix: polish dashboard visual design with consistent card styling (#748)

### DIFF
--- a/frontend/src/components/shared/primitives.tsx
+++ b/frontend/src/components/shared/primitives.tsx
@@ -17,8 +17,7 @@ export function SectionHeader({
   className?: string;
 }) {
   return (
-    <div className={cn("flex items-center justify-between px-5 pt-4 pb-3.5", className)}>
-      <h3 className="text-[14px] font-bold tracking-tight text-foreground flex items-center gap-2">
+<div className={cn("flex items-center justify-between px-6 pt-5 pb-4", className)}>      <h3 className="text-[14px] font-bold tracking-tight text-foreground flex items-center gap-2">
         <span className="inline-block h-2 w-2 rounded-full bg-primary/80" />
         {title}
       </h3>
@@ -53,8 +52,7 @@ export function Card({
   return (
     <As
       className={cn(
-        "rounded-2xl border border-border/70 bg-card shadow-xs transition-all duration-200",
-        interactive && "hover-lift hover:border-primary/40 hover:shadow-card",
+"rounded-3xl border border-border/40 bg-card shadow-sm transition-all duration-200",        interactive && "hover-lift hover:border-primary/40 hover:shadow-card",
         className,
       )}
     >

--- a/frontend/src/features/dashboard/GreetingHero.tsx
+++ b/frontend/src/features/dashboard/GreetingHero.tsx
@@ -9,8 +9,7 @@ export function GreetingHero() {
   const first = currentUser.name.split(" ")[0];
 
   return (
-    <Card className="flex flex-col gap-4 p-4 sm:p-5 sm:flex-row sm:items-center sm:justify-between rounded-2xl bg-card border-border/60">
-      <div className="min-w-0 flex-1">
+<Card className="flex flex-col gap-5 p-5 sm:p-6 sm:flex-row sm:items-center sm:justify-between">      <div className="min-w-0 flex-1">
         <h1 className="text-xl font-semibold tracking-tight text-foreground sm:text-2xl">
           {greeting}, {first}
         </h1>
@@ -48,8 +47,7 @@ function MiniStat({
   progress?: number;
 }) {
   return (
-    <div className="flex flex-col justify-between gap-1.5 rounded-xl border border-border/50 bg-muted/20 p-3 min-w-[120px] sm:min-w-[130px] shrink-0">
-      <div className="flex items-center gap-1.5 text-muted-foreground">
+<div className="flex flex-col justify-between gap-2 rounded-2xl border border-border/40 bg-muted/20 p-3.5 min-w-[120px] sm:min-w-[130px] shrink-0">      <div className="flex items-center gap-1.5 text-muted-foreground">
         {icon}
         <p className="text-[10px] font-medium uppercase tracking-wider truncate">{label}</p>
       </div>

--- a/frontend/src/features/dashboard/StatsRow.tsx
+++ b/frontend/src/features/dashboard/StatsRow.tsx
@@ -49,8 +49,7 @@ export function StatsRow() {
           >
             <Card
               interactive
-              className="flex flex-col h-full gap-3 rounded-2xl p-4 transition-all duration-200 border-border/60 hover:border-border hover:shadow-md bg-card shadow-sm"
-            >
+className="flex flex-col h-full gap-3 p-4 transition-all duration-200 hover:border-border hover:shadow-md"            >
               <div className="flex items-center justify-between">
                 <span className="text-muted-foreground p-1.5 rounded-lg bg-muted/30">
                   <Icon size={16} />

--- a/frontend/src/features/dashboard/sections.tsx
+++ b/frontend/src/features/dashboard/sections.tsx
@@ -31,8 +31,7 @@ import { containerVariants, cardEntrance, cardHover } from "@/lib/animations";
 
 export function RecentActivity() {
   return (
-    <Card className="border-border/60 rounded-2xl bg-card shadow-sm hover:shadow-md transition-shadow duration-200 flex flex-col h-full">
-      <div className="px-5 pt-5 pb-2 font-semibold flex items-center gap-2 text-sm">
+<Card className="hover:shadow-md transition-shadow duration-200 flex flex-col h-full">      <div className="px-5 pt-5 pb-2 font-semibold flex items-center gap-2 text-sm">
         Recent Activity
       </div>
       <div className="flex-1 overflow-hidden">
@@ -51,8 +50,7 @@ export function BuilderRequests() {
     queryFn: dashboardService.builderRequests,
   });
   return (
-    <Card className="border-border/60 rounded-2xl bg-card shadow-sm hover:shadow-md transition-shadow duration-200">
-      <SectionHeader title="Builder Requests" action="View All" />
+<Card className="hover:shadow-md transition-shadow duration-200">      <SectionHeader title="Builder Requests" action="View All" />
       <ul className="divide-y divide-border/40">
         {data.slice(0, 3).map((r) => (
           <li key={r.id} className="px-5 py-4 transition-colors hover:bg-muted/20">
@@ -93,8 +91,7 @@ export function InviteRequests() {
     queryFn: dashboardService.inviteRequests,
   });
   return (
-    <Card className="border-border/60 rounded-2xl bg-card shadow-sm hover:shadow-md transition-shadow duration-200">
-      <SectionHeader title="Invite Requests" action="View All" />
+<Card className="hover:shadow-md transition-shadow duration-200">      <SectionHeader title="Invite Requests" action="View All" />
       <ul className="divide-y divide-border/40">
         {data.slice(0, 3).map((r) => (
           <li
@@ -128,8 +125,7 @@ export function SuggestedBuilders() {
   const prefersReducedMotion = useReducedMotion();
 
   return (
-    <Card className="border-border/60 rounded-2xl bg-card shadow-sm hover:shadow-md transition-shadow duration-200">
-      <SectionHeader title="Suggested Builders" action="View All" actionTo="/builders" />
+<Card className="hover:shadow-md transition-shadow duration-200">      <SectionHeader title="Suggested Builders" action="View All" actionTo="/builders" />
       <motion.div
         className="grid grid-cols-1 gap-4 p-5 pt-2 sm:grid-cols-2 lg:grid-cols-3"
         variants={containerVariants}
@@ -144,8 +140,7 @@ export function SuggestedBuilders() {
               key={b.id}
               variants={prefersReducedMotion ? undefined : cardEntrance}
               custom={i}
-              className="flex flex-col h-full rounded-2xl border border-border/60 bg-surface p-5 hover:border-border hover:shadow-sm transition-all"
-            >
+className="flex flex-col h-full rounded-3xl border border-border/40 bg-surface p-5 hover:border-border hover:shadow-sm transition-all"            >
               <div className="flex items-start justify-between gap-2">
                 <Avatar
                   src={b.avatar}
@@ -193,8 +188,7 @@ export function SuggestedBuilders() {
 export function TrendingProjects() {
   const { data = [] } = useQuery({ queryKey: ["trending"], queryFn: projectsService.trending });
   return (
-    <Card className="border-border/60 rounded-2xl bg-card shadow-sm hover:shadow-md transition-shadow duration-200">
-      <SectionHeader title="Trending Projects" action="View All" actionTo="/projects" />
+<Card className="hover:shadow-md transition-shadow duration-200">      <SectionHeader title="Trending Projects" action="View All" actionTo="/projects" />
       <ul className="divide-y divide-border/40">
         {data.slice(0, 4).map((p) => (
           <li
@@ -225,8 +219,7 @@ export function TrendingProjects() {
 
 export function AIRecommendations() {
   return (
-    <Card className="relative overflow-hidden border-border/60 rounded-2xl bg-card shadow-sm hover:shadow-md transition-shadow duration-200">
-      <SectionHeader title="AI Insights" />
+<Card className="relative overflow-hidden hover:shadow-md transition-shadow duration-200">      <SectionHeader title="AI Insights" />
       <div className="space-y-4 px-5 pb-5">
         <p className="text-sm text-foreground leading-relaxed">
           You need a <span className="font-semibold">Backend Developer</span> for your project{" "}
@@ -273,8 +266,7 @@ export function MessagesPreview() {
     queryFn: messagesService.conversations,
   });
   return (
-    <Card className="border-border/60 rounded-2xl bg-card shadow-sm hover:shadow-md transition-shadow duration-200">
-      <SectionHeader title="Messages" action="View All" actionTo="/messages" />
+<Card className="hover:shadow-md transition-shadow duration-200">      <SectionHeader title="Messages" action="View All" actionTo="/messages" />
       <ul className="divide-y divide-border/40">
         {data.slice(0, 4).map((c) => (
           <li key={c.id}>
@@ -321,14 +313,12 @@ export function QuickActions() {
     },
   ];
   return (
-    <Card className="border-border/60 bg-transparent shadow-none border-none">
-      <div className="grid grid-cols-2 gap-4">
+<Card className="bg-transparent shadow-none border-none">      <div className="grid grid-cols-2 gap-4">
         {actions.map((a) => (
           <Link
             key={a.label}
             to={a.to}
-            className="group flex flex-col items-start gap-4 rounded-2xl border border-border/60 bg-card p-5 transition-all hover:border-border hover:shadow-md hover:-translate-y-0.5"
-          >
+className="group flex flex-col items-start gap-4 rounded-3xl border border-border/40 bg-card p-5 transition-all hover:border-border hover:shadow-md hover:-translate-y-0.5"          >
             <span className="flex items-center justify-center h-10 w-10 rounded-xl bg-primary/10 text-primary group-hover:bg-primary group-hover:text-primary-foreground transition-colors">
               <a.icon size={20} />
             </span>
@@ -348,8 +338,7 @@ export function UpcomingDeadlines() {
     info: "text-info font-medium",
   } as const;
   return (
-    <Card className="border-border/60 rounded-2xl bg-card shadow-sm hover:shadow-md transition-shadow duration-200">
-      <SectionHeader title="Deadlines" action="Calendar" />
+<Card className="hover:shadow-md transition-shadow duration-200">      <SectionHeader title="Deadlines" action="Calendar" />
       <ul className="divide-y divide-border/40">
         {data.slice(0, 3).map((d) => (
           <li
@@ -377,8 +366,7 @@ export function NotificationsFeed() {
     queryFn: notificationsService.list,
   });
   return (
-    <Card className="border-border/60 rounded-2xl bg-card shadow-sm hover:shadow-md transition-shadow duration-200">
-      <SectionHeader title="Notifications" action="View All" actionTo="/notifications" />
+<Card className="hover:shadow-md transition-shadow duration-200">      <SectionHeader title="Notifications" action="View All" actionTo="/notifications" />
       <ul className="divide-y divide-border/40">
         {data.slice(0, 4).map((n) => (
           <li

--- a/frontend/src/routes/_app.dashboard.tsx
+++ b/frontend/src/routes/_app.dashboard.tsx
@@ -29,30 +29,25 @@ export const Route = createFileRoute("/_app/dashboard")({
 
 function Dashboard() {
   return (
-    <div className="mx-auto flex max-w-[1536px] w-full flex-col gap-6 pb-12 pt-4 px-4 sm:px-6">
-      <GreetingHero />
+<div className="mx-auto flex max-w-[1536px] w-full flex-col gap-8 pb-12 pt-6 px-4 sm:px-6">      <GreetingHero />
 
       <StatsRow />
 
       {/* Main Grid Grouping */}
-      <div className="grid gap-6 lg:grid-cols-12 items-start">
-        {/* Left/Main Column - 8 cols */}
-        <div className="lg:col-span-8 flex flex-col gap-6">
-          <SuggestedBuilders />
+<div className="grid gap-8 lg:grid-cols-12 items-start">        {/* Left/Main Column - 8 cols */}
+<div className="lg:col-span-8 flex flex-col gap-8">          <SuggestedBuilders />
           <TrendingProjects />
-          <div className="grid gap-6 sm:grid-cols-2">
-            <BuilderRequests />
+<div className="grid gap-8 sm:grid-cols-2">            <BuilderRequests />
             <InviteRequests />
           </div>
-          <div className="grid gap-6 sm:grid-cols-2">
+          <div className="grid gap-8 sm:grid-cols-2">
             <MessagesPreview />
             <RecentActivity />
           </div>
         </div>
 
         {/* Right Sidebar - 4 cols */}
-        <div className="lg:col-span-4 flex flex-col gap-6">
-          <QuickActions />
+<div className="lg:col-span-4 flex flex-col gap-8">          <QuickActions />
           <AIRecommendations />
           <UpcomingDeadlines />
           <NotificationsFeed />

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -183,8 +183,7 @@
  * All hex values live here; components use semantic classes only.
  */
 :root {
-  --radius: 0.5rem;
-
+--radius: 0.75rem;
   /* Neutrals — GitHub-like light */
   --background: #f6f8fa;
   --surface: #ffffff;
@@ -197,8 +196,7 @@
   --popover: #ffffff;
   --popover-foreground: #1f2328;
 
-  --border: #d0d7de;
-  --input: #d0d7de;
+--border: #dde3e9;  --input: #d0d7de;
   --ring: #05b7d7;
 
   /* Brand — cyan from AuthScreen */


### PR DESCRIPTION
## Summary
Improves the dashboard's visual polish by introducing a cleaner, more
consistent design system, as requested in #748.

## Changes
- Increased the base border-radius token and softened the border color
  in styles.css so the change cascades app-wide.
- Updated the shared `Card` component (rounded-3xl, softer border,
  shadow-sm) and `SectionHeader` padding for more internal whitespace.
- Removed duplicate/conflicting radius, border, and shadow classes from
  individual dashboard sections (StatsRow, GreetingHero, sections.tsx)
  so every card now consistently inherits the shared Card styling.
- Increased spacing (gap-6 → gap-8) across the dashboard route layout
  for better whitespace and card alignment.

## Acceptance Criteria
- [x] Consistent component styling across all dashboard cards
- [x] Modern SaaS appearance (softer borders, larger radius, subtle
      shadows, more whitespace)

Closes #748 

@nensii21 
I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.