### PR TITLE
feat(notifications): build notification delivery analytics with database tracking and API endpoints

### DIFF
--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -248,6 +248,16 @@ class Notification(Base):
         index=True,
     )
 
+    delivered_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        index=True,
+    )
+
+    clicked_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        index=True,
+    )
+
     sent_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
     )

--- a/backend/app/routers/notifications.py
+++ b/backend/app/routers/notifications.py
@@ -249,3 +249,43 @@ def update_preferences(
         db, user_id=current_user.id, update_in=prefs
     )
     return NotificationPreferenceResponse.model_validate(pref)
+
+
+@router.post(
+    "/{notification_id}/click",
+    response_model=NotificationResponse,
+    summary="Track notification click interaction",
+)
+def track_click(
+    notification_id: uuid.UUID,
+    db: Session = Depends(get_database),
+):
+    notification = NotificationService.get_notification(db, notification_id)
+    if not notification:
+        raise HTTPException(status_code=404, detail="Notification not found")
+    return NotificationService.track_click(db, notification)
+
+
+@router.post(
+    "/{notification_id}/delivered",
+    response_model=NotificationResponse,
+    summary="Track notification delivery status",
+)
+def track_delivered(
+    notification_id: uuid.UUID,
+    db: Session = Depends(get_database),
+):
+    notification = NotificationService.get_notification(db, notification_id)
+    if not notification:
+        raise HTTPException(status_code=404, detail="Notification not found")
+    return NotificationService.track_delivered(db, notification)
+
+
+@router.get(
+    "/analytics/delivery",
+    summary="Get notification delivery and interaction analytics dashboard responses",
+)
+def get_delivery_analytics(
+    db: Session = Depends(get_database),
+):
+    return NotificationService.get_delivery_analytics(db)

--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -64,6 +64,8 @@ class NotificationResponse(NotificationBase):
 
     is_read: bool
     read_at: Optional[datetime] = None
+    delivered_at: Optional[datetime] = None
+    clicked_at: Optional[datetime] = None
 
     created_at: datetime
     updated_at: datetime

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -206,6 +206,69 @@ class NotificationService:
         db.flush()
 
     @staticmethod
+    def track_click(
+        db: Session,
+        db_notification: Notification,
+    ) -> Notification:
+        db_notification.clicked_at = datetime.utcnow()
+        if not db_notification.is_read:
+            db_notification.is_read = True
+            db_notification.read_at = datetime.utcnow()
+        db.flush()
+        db.refresh(db_notification)
+        return db_notification
+
+    @staticmethod
+    def track_delivered(
+        db: Session,
+        db_notification: Notification,
+    ) -> Notification:
+        db_notification.delivered_at = datetime.utcnow()
+        from app.models.notification import NotificationStatus
+        db_notification.status = NotificationStatus.SENT
+        db.flush()
+        db.refresh(db_notification)
+        return db_notification
+
+    @staticmethod
+    def get_delivery_analytics(db: Session) -> dict:
+        total_sent = db.scalar(
+            select(func.count(Notification.id)).where(Notification.sent_at.isnot(None))
+        ) or 0
+        total_delivered = db.scalar(
+            select(func.count(Notification.id)).where(Notification.delivered_at.isnot(None))
+        ) or 0
+        total_read = db.scalar(
+            select(func.count(Notification.id)).where(Notification.read_at.isnot(None))
+        ) or 0
+        total_clicked = db.scalar(
+            select(func.count(Notification.id)).where(Notification.clicked_at.isnot(None))
+        ) or 0
+        from app.models.notification import NotificationStatus
+        total_failed = db.scalar(
+            select(func.count(Notification.id)).where(Notification.status == NotificationStatus.FAILED)
+        ) or 0
+
+        delivery_rate = (total_delivered / total_sent * 100) if total_sent > 0 else 0.0
+        read_rate = (total_read / total_delivered * 100) if total_delivered > 0 else 0.0
+        click_rate = (total_clicked / total_read * 100) if total_read > 0 else 0.0
+
+        return {
+            "metrics": {
+                "sent": total_sent,
+                "delivered": total_delivered,
+                "read": total_read,
+                "clicked": total_clicked,
+                "failed": total_failed,
+            },
+            "rates": {
+                "delivery_rate_pct": round(delivery_rate, 2),
+                "read_rate_pct": round(read_rate, 2),
+                "click_rate_pct": round(click_rate, 2),
+            },
+        }
+
+    @staticmethod
     def enqueue(
         db: Session,
         recipient_id,

--- a/backend/tests/test_notification_analytics.py
+++ b/backend/tests/test_notification_analytics.py
@@ -1,0 +1,38 @@
+import pytest
+import uuid
+
+def test_notification_delivery_analytics(client, register_and_login):
+    user_id, token = register_and_login("notif_analytics@example.com", "notif_analytics")
+    headers = {"Authorization": f"Bearer {token}"}
+
+    # Create notification
+    create_payload = {
+        "recipient_id": user_id,
+        "type": "system",
+        "title": "Analytics Test Notification",
+        "message": "Testing notification delivery analytics"
+    }
+    res = client.post("/api/notifications/", json=create_payload, headers=headers)
+    assert res.status_code == 201
+    notif = res.json()
+    notif_id = notif["id"]
+
+    # Track delivered
+    res = client.post(f"/api/notifications/{notif_id}/delivered", headers=headers)
+    assert res.status_code == 200
+    assert res.json()["delivered_at"] is not None
+
+    # Track clicked
+    res = client.post(f"/api/notifications/{notif_id}/click", headers=headers)
+    assert res.status_code == 200
+    assert res.json()["clicked_at"] is not None
+    assert res.json()["is_read"] is True
+
+    # Get Analytics Dashboard response
+    res = client.get("/api/notifications/analytics/delivery", headers=headers)
+    assert res.status_code == 200
+    data = res.json()
+    assert "metrics" in data
+    assert "rates" in data
+    assert data["metrics"]["clicked"] >= 1
+    assert data["metrics"]["delivered"] >= 1

--- a/docs/notification_analytics.md
+++ b/docs/notification_analytics.md
@@ -1,0 +1,15 @@
+# Notification Delivery Analytics (#611)
+
+DevLink tracks the end-to-end lifecycle and delivery status of all platform notifications.
+
+## Metrics Tracked
+- **Sent**: Notifications dispatched by the backend.
+- **Delivered**: Notifications successfully received by the client/WebSocket.
+- **Read**: Notifications marked as read by the user.
+- **Clicked**: User clicked/interacted with the notification action URL.
+- **Failed**: Delivery attempts that failed.
+
+## API Endpoints
+- `GET /api/notifications/analytics/delivery` - Returns aggregate metrics and rates for dashboard rendering.
+- `POST /api/notifications/{notification_id}/delivered` - Marks notification as delivered with timestamp.
+- `POST /api/notifications/{notification_id}/click` - Marks notification as clicked with timestamp.


### PR DESCRIPTION
Closes #611

## Summary
Built end-to-end notification delivery tracking and interaction analytics to measure system effectiveness.

## Metrics Tracked
- **Sent**: Dispatched notifications.
- **Delivered**: Notifications confirmed delivered to client (`delivered_at`).
- **Read**: Notifications marked as read (`read_at`).
- **Clicked**: User clicked notification action link (`clicked_at`).
- **Failed**: Delivery attempts that failed.

## Deliverables
- **Database Schema**: Added `delivered_at` and `clicked_at` timestamp columns to `Notification` model.
- **Analytics API**:
  - `GET /api/notifications/analytics/delivery` (returns metrics & rates ready for dashboard visualization)
  - `POST /api/notifications/{id}/delivered`
  - `POST /api/notifications/{id}/click`
- **Documentation**: `docs/notification_analytics.md`
- **Automated Tests**: `backend/tests/test_notification_analytics.py`