### PR TITLE
fix(frontend): repair the type errors blocking every open PR

### DIFF
--- a/frontend/src/components/layout/UserProfile.tsx
+++ b/frontend/src/components/layout/UserProfile.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import { LogOut, BadgeCheck } from "lucide-react";
 import { Avatar } from "@/components/shared/primitives";
+import { cn } from "@/lib/utils";
 import { currentUser } from "@/mocks/seed";
 import { useSidebar } from "@/hooks/useSidebar";
 

--- a/frontend/src/mocks/seed.ts
+++ b/frontend/src/mocks/seed.ts
@@ -39,6 +39,7 @@ export interface Builder {
   lastActiveAt: string | null;
   publicEmail?: string;
   verified?: boolean;
+  premium?: boolean;
   pinnedProjects?: string[];
   contributions?: number;
   followers?: number;

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as AppSettingsRouteImport } from './routes/_app.settings'
 import { Route as AppSearchRouteImport } from './routes/_app.search'
 import { Route as AppRepositoryQualityRouteImport } from './routes/_app.repository-quality'
 import { Route as AppProjectsRouteImport } from './routes/_app.projects'
+import { Route as AppProfileAnalyticsRouteImport } from './routes/_app.profile-analytics'
 import { Route as AppOrganizationsRouteImport } from './routes/_app.organizations'
 import { Route as AppNotificationsRouteImport } from './routes/_app.notifications'
 import { Route as AppMessagesRouteImport } from './routes/_app.messages'
@@ -108,6 +109,11 @@ const AppRepositoryQualityRoute = AppRepositoryQualityRouteImport.update({
 const AppProjectsRoute = AppProjectsRouteImport.update({
   id: '/projects',
   path: '/projects',
+  getParentRoute: () => AppRoute,
+} as any)
+const AppProfileAnalyticsRoute = AppProfileAnalyticsRouteImport.update({
+  id: '/profile-analytics',
+  path: '/profile-analytics',
   getParentRoute: () => AppRoute,
 } as any)
 const AppOrganizationsRoute = AppOrganizationsRouteImport.update({
@@ -281,6 +287,7 @@ export interface FileRoutesByFullPath {
   '/messages': typeof AppMessagesRouteWithChildren
   '/notifications': typeof AppNotificationsRoute
   '/organizations': typeof AppOrganizationsRouteWithChildren
+  '/profile-analytics': typeof AppProfileAnalyticsRoute
   '/projects': typeof AppProjectsRouteWithChildren
   '/repository-quality': typeof AppRepositoryQualityRoute
   '/search': typeof AppSearchRoute
@@ -322,6 +329,7 @@ export interface FileRoutesByTo {
   '/hackathons': typeof AppHackathonsRouteWithChildren
   '/messages': typeof AppMessagesRouteWithChildren
   '/notifications': typeof AppNotificationsRoute
+  '/profile-analytics': typeof AppProfileAnalyticsRoute
   '/projects': typeof AppProjectsRouteWithChildren
   '/repository-quality': typeof AppRepositoryQualityRoute
   '/search': typeof AppSearchRoute
@@ -366,6 +374,7 @@ export interface FileRoutesById {
   '/_app/messages': typeof AppMessagesRouteWithChildren
   '/_app/notifications': typeof AppNotificationsRoute
   '/_app/organizations': typeof AppOrganizationsRouteWithChildren
+  '/_app/profile-analytics': typeof AppProfileAnalyticsRoute
   '/_app/projects': typeof AppProjectsRouteWithChildren
   '/_app/repository-quality': typeof AppRepositoryQualityRoute
   '/_app/search': typeof AppSearchRoute
@@ -410,6 +419,7 @@ export interface FileRouteTypes {
     | '/messages'
     | '/notifications'
     | '/organizations'
+    | '/profile-analytics'
     | '/projects'
     | '/repository-quality'
     | '/search'
@@ -451,6 +461,7 @@ export interface FileRouteTypes {
     | '/hackathons'
     | '/messages'
     | '/notifications'
+    | '/profile-analytics'
     | '/projects'
     | '/repository-quality'
     | '/search'
@@ -494,6 +505,7 @@ export interface FileRouteTypes {
     | '/_app/messages'
     | '/_app/notifications'
     | '/_app/organizations'
+    | '/_app/profile-analytics'
     | '/_app/projects'
     | '/_app/repository-quality'
     | '/_app/search'
@@ -612,6 +624,13 @@ declare module '@tanstack/react-router' {
       path: '/projects'
       fullPath: '/projects'
       preLoaderRoute: typeof AppProjectsRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/_app/profile-analytics': {
+      id: '/_app/profile-analytics'
+      path: '/profile-analytics'
+      fullPath: '/profile-analytics'
+      preLoaderRoute: typeof AppProfileAnalyticsRouteImport
       parentRoute: typeof AppRoute
     }
     '/_app/organizations': {
@@ -942,6 +961,7 @@ interface AppRouteChildren {
   AppMessagesRoute: typeof AppMessagesRouteWithChildren
   AppNotificationsRoute: typeof AppNotificationsRoute
   AppOrganizationsRoute: typeof AppOrganizationsRouteWithChildren
+  AppProfileAnalyticsRoute: typeof AppProfileAnalyticsRoute
   AppProjectsRoute: typeof AppProjectsRouteWithChildren
   AppRepositoryQualityRoute: typeof AppRepositoryQualityRoute
   AppSearchRoute: typeof AppSearchRoute
@@ -963,6 +983,7 @@ const AppRouteChildren: AppRouteChildren = {
   AppMessagesRoute: AppMessagesRouteWithChildren,
   AppNotificationsRoute: AppNotificationsRoute,
   AppOrganizationsRoute: AppOrganizationsRouteWithChildren,
+  AppProfileAnalyticsRoute: AppProfileAnalyticsRoute,
   AppProjectsRoute: AppProjectsRouteWithChildren,
   AppRepositoryQualityRoute: AppRepositoryQualityRoute,
   AppSearchRoute: AppSearchRoute,

--- a/frontend/src/routes/_app.profile.$username.tsx
+++ b/frontend/src/routes/_app.profile.$username.tsx
@@ -240,7 +240,7 @@ function ProfilePage() {
         <ProfileCompletionChecklist
           userProfile={{
             avatar: avatarUrl,
-            banner: bannerUrl,
+            banner: bannerUrl ?? undefined,
             bio: b.bio,
             skills: b.profileSkills?.map((s) => s.name) ?? b.skills,
             experience: b.experienceLevel || b.role || b.company,

--- a/frontend/src/routes/portfolio.$username.tsx
+++ b/frontend/src/routes/portfolio.$username.tsx
@@ -26,7 +26,13 @@ import {
   LayoutGrid,
 } from "lucide-react";
 import { toast } from "sonner";
-import { builders, currentUser, projects as allProjects, flares as allFlares } from "@/mocks/seed";
+import {
+  builders,
+  currentUser,
+  projects as allProjects,
+  flares as allFlares,
+  type Builder,
+} from "@/mocks/seed";
 
 export const Route = createFileRoute("/portfolio/$username")({
   head: ({ params }) => ({
@@ -107,7 +113,7 @@ function PortfolioPage() {
   const me = username === currentUser.handle;
 
   // Find builder details
-  const b =
+  const b: Builder | null =
     builders.find((x) => x.handle === username) ||
     (me
       ? {
@@ -120,6 +126,9 @@ function PortfolioPage() {
           yearsExp: 3,
           matchScore: 96,
           skills: ["React", "Next.js", "TypeScript", "Node.js", "Python", "TailwindCSS"],
+          badges: [],
+          interests: [],
+          lastActiveAt: null,
           online: true,
           bio: "Product engineer. Ships fast, sleeps sometimes. Love crafting delightful UX.",
         }

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -32,7 +32,7 @@ import type {
   IssueUpdateInput,
   TechStackResponse,
 } from "@/api";
-import type { Hackathon, Flare } from "@/mocks/seed";
+import type { Hackathon, Flare, Message } from "@/mocks/seed";
 
 const delay = 120;
 const mock = <T>(v: T): Promise<T> => new Promise((r) => setTimeout(() => r(v), delay));
@@ -210,7 +210,7 @@ export const messagesService = {
     return withFallback(
       async () => {
         const msgs = await messagesApi.thread(id);
-        return msgs.map((m: any) => ({
+        return msgs.map((m: any): Message => ({
           id: m.id,
           from: m.sender_id === currentUser?.id ? "me" : m.sender_id,
           text: m.content ?? "",


### PR DESCRIPTION
## What

`frontend-ci` has been red on `main` since ebcdef32. `npm run typecheck` is the gating step in that workflow and it reports **15 errors**, so every open PR that merges `main` inherits a failing `build` job through no fault of its own.

This fixes all 15 at the source so the branch protection unblocks for everyone.

## The errors, and why each is what it is

| Fix | Detail |
|---|---|
| `routeTree.gen.ts` regenerated | Never regenerated after `_app.profile-analytics.tsx` landed, so the route is absent from `FileRoutesByPath`. Both the route's own `getRouteApi` call and the `Link` to it failed to resolve. The diff is 21 added lines, all registering that one route. |
| `UserProfile.tsx` | Calls `cn()` without importing it. |
| `Builder.premium` declared | The premium-badge work reads `.premium` in three files but the interface never declared it. It is a real column (`User.premium`, default `false`) and `seed.ts` already sets it — so the field is declared optional to match the backend, rather than changing the call sites. |
| `portfolio.$username.tsx` | The `me` fallback is an untyped object literal omitting `badges`, `interests` and `lastActiveAt`. That widened `b` into a union whose second arm has no `githubUrl`. Annotated `Builder \| null` and filled in the three missing fields. |
| `_app.profile.$username.tsx` | `ProfileCompletionChecklist` takes `banner?: string`; `bannerUrl` is `string \| null`. Both mean "no banner" to the consumer, which does `banner?.trim()`. |
| `services/index.ts` | `messagesService.thread` maps to a shape where `type` and the attachment fields are inferred *required*, which the `Message[]` fallback does not satisfy. Annotating the mapper pins the generic to the type the seed already uses. |

## Verification

- `npm run typecheck` — clean (was 15 errors)
- `npm run build` — passes
- `npm run test` — 455 unit tests pass
- `npm run lint` — unchanged at 231 pre-existing problems (that step is `continue-on-error: true`)

No behaviour changes; this is types and one missing import.

### Out of scope
The 4 failing test *files* are Playwright e2e specs that vitest picks up and cannot run. Pre-existing config issue, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)