### PR TITLE
feat(projects): add time tracking so owners can see where effort goes (#1041)

### DIFF
--- a/backend/alembic/versions/e7c1a9b45d20_create_project_time_logs_table.py
+++ b/backend/alembic/versions/e7c1a9b45d20_create_project_time_logs_table.py
@@ -1,7 +1,7 @@
 """create project time logs table
 
 Revision ID: e7c1a9b45d20
-Revises: d4e5f6a7b8c9
+Revises: f2a8c61d97b5
 Create Date: 2026-08-10 20:10:00.000000
 
 """
@@ -14,7 +14,7 @@ from sqlalchemy.dialects.postgresql import UUID
 
 # revision identifiers, used by Alembic.
 revision: str = "e7c1a9b45d20"
-down_revision: Union[str, Sequence[str], None] = "d4e5f6a7b8c9"
+down_revision: Union[str, Sequence[str], None] = "f2a8c61d97b5"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/alembic/versions/e7c1a9b45d20_create_project_time_logs_table.py
+++ b/backend/alembic/versions/e7c1a9b45d20_create_project_time_logs_table.py
@@ -1,0 +1,120 @@
+"""create project time logs table
+
+Revision ID: e7c1a9b45d20
+Revises: d4e5f6a7b8c9
+Create Date: 2026-08-10 20:10:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+# revision identifiers, used by Alembic.
+revision: str = "e7c1a9b45d20"
+down_revision: Union[str, Sequence[str], None] = "d4e5f6a7b8c9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "project_time_logs",
+        sa.Column("id", UUID(as_uuid=True), nullable=False),
+        sa.Column("project_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", UUID(as_uuid=True), nullable=False),
+        # A milestone can be deleted while the work that went into it still
+        # happened, so the log survives the milestone rather than cascading.
+        sa.Column("milestone_id", UUID(as_uuid=True), nullable=True),
+        # Whole minutes, not hours-as-float: summing floats across hundreds of
+        # entries lets a summary drift away from its own line items.
+        sa.Column("minutes", sa.Integer(), nullable=False),
+        # The day the work happened, which is often not the day it was entered.
+        sa.Column("work_date", sa.Date(), nullable=False),
+        sa.Column("description", sa.String(length=500), nullable=True),
+        sa.Column(
+            "is_billable", sa.Boolean(), server_default=sa.text("false"), nullable=False
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["milestone_id"], ["project_milestones.id"], ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        # Belt and braces alongside the service-level check: a single entry can
+        # never be zero, negative, or longer than a day.
+        sa.CheckConstraint("minutes > 0 AND minutes <= 1440", name="ck_project_time_logs_minutes"),
+    )
+
+    op.create_index(
+        op.f("ix_project_time_logs_project_id"),
+        "project_time_logs",
+        ["project_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_project_time_logs_user_id"),
+        "project_time_logs",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_project_time_logs_milestone_id"),
+        "project_time_logs",
+        ["milestone_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_project_time_logs_work_date"),
+        "project_time_logs",
+        ["work_date"],
+        unique=False,
+    )
+
+    # The project report: everything logged on a project, by day.
+    op.create_index(
+        "ix_project_time_logs_project_date",
+        "project_time_logs",
+        ["project_id", "work_date"],
+        unique=False,
+    )
+    # One person's history across their whole timeline.
+    op.create_index(
+        "ix_project_time_logs_user_date",
+        "project_time_logs",
+        ["user_id", "work_date"],
+        unique=False,
+    )
+    # The 24-hour cap check, which reads one user's entries on one project for
+    # one day and runs on every write.
+    op.create_index(
+        "ix_project_time_logs_project_user_date",
+        "project_time_logs",
+        ["project_id", "user_id", "work_date"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_project_time_logs_project_user_date", table_name="project_time_logs")
+    op.drop_index("ix_project_time_logs_user_date", table_name="project_time_logs")
+    op.drop_index("ix_project_time_logs_project_date", table_name="project_time_logs")
+    op.drop_index(op.f("ix_project_time_logs_work_date"), table_name="project_time_logs")
+    op.drop_index(op.f("ix_project_time_logs_milestone_id"), table_name="project_time_logs")
+    op.drop_index(op.f("ix_project_time_logs_user_id"), table_name="project_time_logs")
+    op.drop_index(op.f("ix_project_time_logs_project_id"), table_name="project_time_logs")
+    op.drop_table("project_time_logs")

--- a/backend/alembic/versions/f2a8c61d97b5_create_project_milestones_table.py
+++ b/backend/alembic/versions/f2a8c61d97b5_create_project_milestones_table.py
@@ -1,0 +1,93 @@
+"""create project milestones table
+
+The Milestone model (#618) shipped without a migration. Nothing caught it
+because the test suite builds its schema with ``Base.metadata.create_all``,
+which reads the models directly and never touches the revision chain -- so
+``project_milestones`` exists in every test run and in no migrated database.
+
+This revision closes that gap. It is a prerequisite for #1041, whose time logs
+reference milestones, but the missing table is a bug on its own.
+
+Revision ID: f2a8c61d97b5
+Revises: d4e5f6a7b8c9
+Create Date: 2026-08-10 22:05:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+# revision identifiers, used by Alembic.
+revision: str = "f2a8c61d97b5"
+down_revision: Union[str, Sequence[str], None] = "d4e5f6a7b8c9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # checkfirst is not available on create_table, so guard on the inspector:
+    # an environment that was bootstrapped with create_all already has this
+    # table and must not fail here.
+    bind = op.get_bind()
+    if sa.inspect(bind).has_table("project_milestones"):
+        return
+
+    op.create_table(
+        "project_milestones",
+        sa.Column("id", UUID(as_uuid=True), nullable=False),
+        sa.Column("project_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("title", sa.String(length=200), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("due_date", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "is_completed", sa.Boolean(), server_default=sa.text("false"), nullable=False
+        ),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "is_archived", sa.Boolean(), server_default=sa.text("false"), nullable=False
+        ),
+        sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_index(
+        op.f("ix_project_milestones_project_id"),
+        "project_milestones",
+        ["project_id"],
+        unique=False,
+    )
+    # The timeline query: one project's milestones ordered by when they are due.
+    op.create_index(
+        "ix_project_milestones_project_due",
+        "project_milestones",
+        ["project_id", "due_date"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if not sa.inspect(bind).has_table("project_milestones"):
+        return
+
+    op.drop_index("ix_project_milestones_project_due", table_name="project_milestones")
+    op.drop_index(
+        op.f("ix_project_milestones_project_id"), table_name="project_milestones"
+    )
+    op.drop_table("project_milestones")

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -28,6 +28,7 @@ from app.routers import (
     project_members,
     project_comments,
     project_milestones,
+    project_time_logs,
     project_tags,
     project_documents,
     project_dashboards,
@@ -76,6 +77,7 @@ api_v1_router.include_router(project_documents.router)
 api_v1_router.include_router(project_dashboards.router)
 api_v1_router.include_router(project_milestones.router)
 api_v1_router.include_router(project_comments.router)
+api_v1_router.include_router(project_time_logs.router)
 api_v1_router.include_router(
     builder_flares.router, prefix="/flare", tags=["Builder's Flare"]
 )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -553,6 +553,9 @@ app.include_router(
     project_milestones.router, prefix="/api", tags=["Project Milestones"]
 )
 app.include_router(project_milestones.router, prefix="/api", tags=["Project Milestones"])
+from app.routers import project_time_logs
+
+app.include_router(project_time_logs.router, prefix="/api", tags=["Project Time Tracking"])
 from app.routers import calendar as calendar_router
 app.include_router(calendar_router.router, prefix="/api", tags=["Calendar"])
 app.include_router(analytics.router, prefix="/api", tags=["Analytics"])

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -91,3 +91,4 @@ from .global_announcement import GlobalAnnouncement, AnnouncementSeverity, Targe
 from .post import Post  # noqa: F401
 
 from .project_comment import ProjectComment  # noqa: F401
+from .project_time_log import ProjectTimeLog  # noqa: F401

--- a/backend/app/models/project_time_log.py
+++ b/backend/app/models/project_time_log.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+
+from sqlalchemy import (
+    Boolean,
+    Date,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database.base import Base
+
+
+class ProjectTimeLog(Base):
+    """
+    A single logged unit of work against a project (#1041).
+
+    Duration is stored in whole minutes rather than hours-as-float: hours are a
+    presentation concern, and summing floats across hundreds of entries invites
+    the kind of drift where a summary and its own line items disagree by a
+    fraction of an hour.
+    """
+
+    __tablename__ = "project_time_logs"
+
+    # ==========================================================
+    # Primary Key
+    # ==========================================================
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+    # ==========================================================
+    # Foreign Keys
+    # ==========================================================
+
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    # A milestone can be deleted while the work that went into it still
+    # happened, so the log survives with a null reference rather than
+    # disappearing along with the milestone.
+    milestone_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("project_milestones.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
+    # ==========================================================
+    # Entry
+    # ==========================================================
+
+    minutes: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+    )
+
+    # The day the work happened, which is frequently not the day it was
+    # entered -- people log Friday's work on Monday morning.
+    work_date: Mapped[date] = mapped_column(
+        Date,
+        nullable=False,
+        index=True,
+    )
+
+    description: Mapped[str | None] = mapped_column(
+        String(500),
+        nullable=True,
+    )
+
+    is_billable: Mapped[bool] = mapped_column(
+        Boolean,
+        default=False,
+        server_default="false",
+        nullable=False,
+    )
+
+    # ==========================================================
+    # Relationships
+    # ==========================================================
+
+    project = relationship("Project", backref="time_logs")
+    user = relationship("User", backref="project_time_logs")
+    milestone = relationship("Milestone", backref="time_logs")
+
+    # ==========================================================
+    # Audit
+    # ==========================================================
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    __table_args__ = (
+        # The project report: everything logged on a project, by day.
+        Index("ix_project_time_logs_project_date", "project_id", "work_date"),
+        # "How much have I logged?" across a user's whole history.
+        Index("ix_project_time_logs_user_date", "user_id", "work_date"),
+        # The per-day cap check, which reads one user's entries on one project
+        # for one day.
+        Index("ix_project_time_logs_project_user_date", "project_id", "user_id", "work_date"),
+    )
+
+    @property
+    def hours(self) -> float:
+        """Minutes rendered as hours, rounded for display only."""
+        return round(self.minutes / 60, 2)
+
+    def __repr__(self) -> str:
+        return f"<ProjectTimeLog(project={self.project_id}, user={self.user_id}, minutes={self.minutes})>"

--- a/backend/app/routers/project_time_logs.py
+++ b/backend/app/routers/project_time_logs.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+"""
+API Router for project time tracking (#1041).
+"""
+
+import uuid
+from datetime import date
+
+from fastapi import APIRouter, Depends, Query, Response, status
+from sqlalchemy.orm import Session
+
+from app.dependencies import get_current_active_user, get_database
+from app.models.user import User
+from app.schemas.project_time_log import (
+    TimeLogCreate,
+    TimeLogList,
+    TimeLogResponse,
+    TimeLogSummary,
+    TimeLogUpdate,
+)
+from app.services.project_time_log_service import ProjectTimeLogService
+
+router = APIRouter(
+    prefix="/projects/{project_id}/time-logs",
+    tags=["Project Time Tracking"],
+)
+
+
+def _to_response(log) -> TimeLogResponse:
+    """
+    Build the response by hand so ``hours`` is derived from the stored integer
+    rather than trusted from anywhere else.
+    """
+    return TimeLogResponse(
+        id=log.id,
+        project_id=log.project_id,
+        user_id=log.user_id,
+        milestone_id=log.milestone_id,
+        minutes=log.minutes,
+        hours=ProjectTimeLogService.to_hours(log.minutes),
+        work_date=log.work_date,
+        description=log.description,
+        is_billable=log.is_billable,
+        user=getattr(log, "user", None),
+        created_at=log.created_at,
+        updated_at=log.updated_at,
+    )
+
+
+@router.post(
+    "",
+    response_model=TimeLogResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Log time against a project",
+    description=(
+        "Records a unit of work. Only active project members may log time. "
+        "`work_date` must not be in the future or more than 90 days in the past, "
+        "and one user's entries for a single day may not exceed 24 hours."
+    ),
+    responses={
+        400: {"description": "Daily 24-hour limit would be exceeded"},
+        403: {"description": "Not a member of this project"},
+        404: {"description": "Project or milestone not found"},
+    },
+)
+@router.post("/", response_model=TimeLogResponse, status_code=status.HTTP_201_CREATED, include_in_schema=False)
+def create_time_log(
+    project_id: uuid.UUID,
+    payload: TimeLogCreate,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_active_user),
+) -> TimeLogResponse:
+    log = ProjectTimeLogService.create_log(db, project_id=project_id, payload=payload, actor=current_user)
+    return _to_response(log)
+
+
+@router.get(
+    "",
+    response_model=TimeLogList,
+    summary="List time entries for a project",
+    description=(
+        "Newest work first. `total` and `total_minutes` cover the whole "
+        "filtered set, not just the returned page."
+    ),
+)
+@router.get("/", response_model=TimeLogList, include_in_schema=False)
+def list_time_logs(
+    project_id: uuid.UUID,
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    user_id: uuid.UUID | None = Query(None, description="Filter to one contributor"),
+    milestone_id: uuid.UUID | None = Query(None, description="Filter to one milestone"),
+    from_date: date | None = Query(None, description="Inclusive lower bound on work_date"),
+    to_date: date | None = Query(None, description="Inclusive upper bound on work_date"),
+    is_billable: bool | None = Query(None, description="Filter by billable flag"),
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_active_user),
+) -> TimeLogList:
+    project = ProjectTimeLogService.get_project_or_404(db, project_id)
+    ProjectTimeLogService.require_member(db, project, current_user)
+
+    items, total, total_minutes = ProjectTimeLogService.list_logs(
+        db,
+        project_id=project_id,
+        limit=limit,
+        offset=offset,
+        user_id=user_id,
+        milestone_id=milestone_id,
+        from_date=from_date,
+        to_date=to_date,
+        is_billable=is_billable,
+    )
+    return TimeLogList(
+        items=[_to_response(log) for log in items],
+        total=total,
+        limit=limit,
+        offset=offset,
+        total_minutes=total_minutes,
+    )
+
+
+@router.get(
+    "/me",
+    response_model=TimeLogList,
+    summary="List your own time entries on this project",
+)
+def list_my_time_logs(
+    project_id: uuid.UUID,
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    from_date: date | None = Query(None),
+    to_date: date | None = Query(None),
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_active_user),
+) -> TimeLogList:
+    project = ProjectTimeLogService.get_project_or_404(db, project_id)
+    ProjectTimeLogService.require_member(db, project, current_user)
+
+    items, total, total_minutes = ProjectTimeLogService.list_logs(
+        db,
+        project_id=project_id,
+        limit=limit,
+        offset=offset,
+        user_id=current_user.id,
+        from_date=from_date,
+        to_date=to_date,
+    )
+    return TimeLogList(
+        items=[_to_response(log) for log in items],
+        total=total,
+        limit=limit,
+        offset=offset,
+        total_minutes=total_minutes,
+    )
+
+
+@router.get(
+    "/summary",
+    response_model=TimeLogSummary,
+    summary="Effort summary for a project",
+    description=(
+        "Totals for the project with per-contributor and per-milestone "
+        "breakdowns. Work with no milestone is grouped under a null "
+        "`milestone_id` rather than dropped."
+    ),
+)
+def get_time_log_summary(
+    project_id: uuid.UUID,
+    from_date: date | None = Query(None),
+    to_date: date | None = Query(None),
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_active_user),
+) -> TimeLogSummary:
+    project = ProjectTimeLogService.get_project_or_404(db, project_id)
+    ProjectTimeLogService.require_member(db, project, current_user)
+
+    return ProjectTimeLogService.summarise(db, project_id=project_id, from_date=from_date, to_date=to_date)
+
+
+@router.get(
+    "/{log_id}",
+    response_model=TimeLogResponse,
+    summary="Get one time entry",
+)
+def get_time_log(
+    project_id: uuid.UUID,
+    log_id: uuid.UUID,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_active_user),
+) -> TimeLogResponse:
+    project = ProjectTimeLogService.get_project_or_404(db, project_id)
+    ProjectTimeLogService.require_member(db, project, current_user)
+
+    return _to_response(ProjectTimeLogService.get_log_or_404(db, project_id, log_id))
+
+
+@router.patch(
+    "/{log_id}",
+    response_model=TimeLogResponse,
+    summary="Edit a time entry",
+    description="Only the person who logged the work may edit it.",
+    responses={403: {"description": "Not your entry"}},
+)
+def update_time_log(
+    project_id: uuid.UUID,
+    log_id: uuid.UUID,
+    payload: TimeLogUpdate,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_active_user),
+) -> TimeLogResponse:
+    log = ProjectTimeLogService.update_log(
+        db, project_id=project_id, log_id=log_id, payload=payload, actor=current_user
+    )
+    return _to_response(log)
+
+
+@router.delete(
+    "/{log_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete a time entry",
+    description="The author may always delete their own entry; maintainers may delete anyone's.",
+)
+def delete_time_log(
+    project_id: uuid.UUID,
+    log_id: uuid.UUID,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_active_user),
+) -> Response:
+    ProjectTimeLogService.delete_log(db, project_id=project_id, log_id=log_id, actor=current_user)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/schemas/project_time_log.py
+++ b/backend/app/schemas/project_time_log.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+"""
+Schemas for project time tracking (#1041).
+"""
+
+import uuid
+from datetime import date, datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+# A single entry may not exceed one day's work. Anything longer is a data-entry
+# slip (or a timer someone forgot to stop), not a real claim.
+MAX_MINUTES_PER_ENTRY = 24 * 60
+MIN_MINUTES_PER_ENTRY = 1
+
+# How far back a member may backfill. Beyond this the number stops being a
+# recollection and starts being a guess.
+MAX_BACKFILL_DAYS = 90
+
+
+class TimeLogCreate(BaseModel):
+    minutes: int = Field(
+        ...,
+        ge=MIN_MINUTES_PER_ENTRY,
+        le=MAX_MINUTES_PER_ENTRY,
+        description="Duration in whole minutes, 1 to 1440",
+    )
+    work_date: date = Field(..., description="The day the work happened (UTC), not the day it was logged")
+    description: Optional[str] = Field(default=None, max_length=500)
+    milestone_id: Optional[uuid.UUID] = Field(default=None, description="Milestone this work counts towards")
+    is_billable: bool = Field(default=False)
+
+    @field_validator("description")
+    @classmethod
+    def _strip_description(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        return cleaned or None
+
+
+class TimeLogUpdate(BaseModel):
+    minutes: Optional[int] = Field(default=None, ge=MIN_MINUTES_PER_ENTRY, le=MAX_MINUTES_PER_ENTRY)
+    work_date: Optional[date] = None
+    description: Optional[str] = Field(default=None, max_length=500)
+    milestone_id: Optional[uuid.UUID] = None
+    is_billable: Optional[bool] = None
+
+    @field_validator("description")
+    @classmethod
+    def _strip_description(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        return cleaned or None
+
+
+class TimeLogAuthor(BaseModel):
+    id: uuid.UUID
+    username: str
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+    profile_image: Optional[str] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class TimeLogResponse(BaseModel):
+    id: uuid.UUID
+    project_id: uuid.UUID
+    user_id: uuid.UUID
+    milestone_id: Optional[uuid.UUID] = None
+
+    minutes: int
+    hours: float = Field(description="Minutes as hours, rounded to two decimals, for display")
+    work_date: date
+    description: Optional[str] = None
+    is_billable: bool
+
+    user: Optional[TimeLogAuthor] = None
+
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class TimeLogList(BaseModel):
+    items: list[TimeLogResponse]
+    total: int
+    limit: int
+    offset: int
+    total_minutes: int = Field(description="Sum of minutes across the whole filtered set, not just this page")
+
+
+class ContributorTotal(BaseModel):
+    user_id: uuid.UUID
+    username: Optional[str] = None
+    minutes: int
+    hours: float
+    entries: int
+
+
+class MilestoneTotal(BaseModel):
+    milestone_id: Optional[uuid.UUID] = Field(
+        default=None,
+        description="Null groups together work not attached to any milestone",
+    )
+    milestone_title: Optional[str] = None
+    minutes: int
+    hours: float
+    entries: int
+
+
+class TimeLogSummary(BaseModel):
+    project_id: uuid.UUID
+
+    total_minutes: int
+    total_hours: float
+    total_entries: int
+
+    billable_minutes: int
+    billable_hours: float
+    non_billable_minutes: int
+    non_billable_hours: float
+
+    contributor_count: int
+    first_logged_date: Optional[date] = None
+    last_logged_date: Optional[date] = None
+
+    by_contributor: list[ContributorTotal] = Field(default_factory=list)
+    by_milestone: list[MilestoneTotal] = Field(default_factory=list)

--- a/backend/app/services/project_time_log_service.py
+++ b/backend/app/services/project_time_log_service.py
@@ -1,0 +1,481 @@
+from __future__ import annotations
+
+"""
+Business logic for project time tracking (#1041).
+"""
+
+import logging
+import uuid
+from datetime import date, datetime, timedelta, timezone
+from typing import Optional
+
+from fastapi import HTTPException, status
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session, selectinload
+
+from app.models.milestone import Milestone
+from app.models.project import Project
+from app.models.project_member import MemberRole, ProjectMember
+from app.models.project_time_log import ProjectTimeLog
+from app.models.user import User
+from app.schemas.project_time_log import (
+    MAX_BACKFILL_DAYS,
+    MAX_MINUTES_PER_ENTRY,
+    ContributorTotal,
+    MilestoneTotal,
+    TimeLogCreate,
+    TimeLogSummary,
+    TimeLogUpdate,
+)
+
+logger = logging.getLogger(__name__)
+
+# Nobody works more than 24 hours on one project in one day. A total that says
+# otherwise is a double-entry or a typo, and silently accepting it poisons every
+# report built on top.
+MAX_MINUTES_PER_DAY = 24 * 60
+
+MAINTAINER_ROLES = {
+    MemberRole.OWNER,
+    MemberRole.CO_OWNER,
+    MemberRole.ADMIN,
+    MemberRole.MAINTAINER,
+}
+
+
+class ProjectTimeLogService:
+    """Log, edit and summarise work recorded against a project."""
+
+    # ------------------------------------------------------------------
+    # Lookups & authorization
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def get_project_or_404(db: Session, project_id: uuid.UUID) -> Project:
+        project = db.get(Project, project_id)
+        if project is None or getattr(project, "deleted_at", None) is not None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Project not found",
+            )
+        return project
+
+    @staticmethod
+    def get_membership(db: Session, project_id: uuid.UUID, user_id: uuid.UUID) -> Optional[ProjectMember]:
+        stmt = select(ProjectMember).where(
+            ProjectMember.project_id == project_id,
+            ProjectMember.user_id == user_id,
+            ProjectMember.is_active.is_(True),
+        )
+        return db.scalar(stmt)
+
+    @staticmethod
+    def is_admin(user: User) -> bool:
+        return getattr(user, "system_role", None) == "admin" or getattr(user, "role", None) == "admin"
+
+    @staticmethod
+    def require_member(db: Session, project: Project, user: User) -> None:
+        """
+        Only people actually on the project may log against it. Time logs feed
+        contributor-level reporting, so letting a stranger add rows would let
+        them write into someone else's numbers.
+        """
+        if project.owner_id == user.id or ProjectTimeLogService.is_admin(user):
+            return
+        if ProjectTimeLogService.get_membership(db, project.id, user.id) is not None:
+            return
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only project members can log time against this project.",
+        )
+
+    @staticmethod
+    def is_maintainer(db: Session, project: Project, user: User) -> bool:
+        if project.owner_id == user.id or ProjectTimeLogService.is_admin(user):
+            return True
+        member = ProjectTimeLogService.get_membership(db, project.id, user.id)
+        return member is not None and member.role in MAINTAINER_ROLES
+
+    @staticmethod
+    def require_can_modify(db: Session, project: Project, log: ProjectTimeLog, user: User) -> None:
+        """
+        An entry belongs to whoever did the work. Maintainers get delete rights
+        so a project can clean up after a departed member, but nobody may
+        *rewrite* someone else's hours -- an edited entry that still carries
+        another person's name is worse than no entry at all.
+        """
+        if log.user_id == user.id:
+            return
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You can only modify your own time entries.",
+        )
+
+    @staticmethod
+    def require_can_delete(db: Session, project: Project, log: ProjectTimeLog, user: User) -> None:
+        if log.user_id == user.id or ProjectTimeLogService.is_maintainer(db, project, user):
+            return
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You can only delete your own time entries.",
+        )
+
+    @staticmethod
+    def get_log_or_404(db: Session, project_id: uuid.UUID, log_id: uuid.UUID) -> ProjectTimeLog:
+        stmt = select(ProjectTimeLog).where(
+            ProjectTimeLog.id == log_id,
+            ProjectTimeLog.project_id == project_id,
+        )
+        log = db.scalar(stmt)
+        if log is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Time entry not found",
+            )
+        return log
+
+    # ------------------------------------------------------------------
+    # Validation
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def validate_work_date(work_date: date, today: date | None = None) -> None:
+        reference = today or datetime.now(timezone.utc).date()
+
+        if work_date > reference:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="work_date cannot be in the future.",
+            )
+        if work_date < reference - timedelta(days=MAX_BACKFILL_DAYS):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"work_date cannot be more than {MAX_BACKFILL_DAYS} days in the past.",
+            )
+
+    @staticmethod
+    def validate_milestone(db: Session, project_id: uuid.UUID, milestone_id: uuid.UUID | None) -> None:
+        if milestone_id is None:
+            return
+        stmt = select(Milestone.id).where(
+            Milestone.id == milestone_id,
+            Milestone.project_id == project_id,
+        )
+        if db.scalar(stmt) is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Milestone not found on this project.",
+            )
+
+    @staticmethod
+    def minutes_logged_on(
+        db: Session,
+        project_id: uuid.UUID,
+        user_id: uuid.UUID,
+        work_date: date,
+        exclude_log_id: uuid.UUID | None = None,
+    ) -> int:
+        stmt = select(func.coalesce(func.sum(ProjectTimeLog.minutes), 0)).where(
+            ProjectTimeLog.project_id == project_id,
+            ProjectTimeLog.user_id == user_id,
+            ProjectTimeLog.work_date == work_date,
+        )
+        if exclude_log_id is not None:
+            stmt = stmt.where(ProjectTimeLog.id != exclude_log_id)
+        return int(db.scalar(stmt) or 0)
+
+    @staticmethod
+    def validate_daily_cap(
+        db: Session,
+        project_id: uuid.UUID,
+        user_id: uuid.UUID,
+        work_date: date,
+        minutes: int,
+        exclude_log_id: uuid.UUID | None = None,
+    ) -> None:
+        already = ProjectTimeLogService.minutes_logged_on(
+            db, project_id, user_id, work_date, exclude_log_id=exclude_log_id
+        )
+        if already + minutes > MAX_MINUTES_PER_DAY:
+            remaining = max(0, MAX_MINUTES_PER_DAY - already)
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"Logging {minutes} minutes would exceed the 24-hour daily limit "
+                    f"for {work_date.isoformat()}. {remaining} minutes remain."
+                ),
+            )
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def create_log(
+        db: Session,
+        project_id: uuid.UUID,
+        payload: TimeLogCreate,
+        actor: User,
+        today: date | None = None,
+    ) -> ProjectTimeLog:
+        project = ProjectTimeLogService.get_project_or_404(db, project_id)
+        ProjectTimeLogService.require_member(db, project, actor)
+
+        ProjectTimeLogService.validate_work_date(payload.work_date, today=today)
+        ProjectTimeLogService.validate_milestone(db, project_id, payload.milestone_id)
+        ProjectTimeLogService.validate_daily_cap(
+            db, project_id, actor.id, payload.work_date, payload.minutes
+        )
+
+        now = datetime.now(timezone.utc)
+        log = ProjectTimeLog(
+            id=uuid.uuid4(),
+            project_id=project_id,
+            user_id=actor.id,
+            milestone_id=payload.milestone_id,
+            minutes=payload.minutes,
+            work_date=payload.work_date,
+            description=payload.description,
+            is_billable=payload.is_billable,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(log)
+        db.commit()
+        db.refresh(log)
+        return log
+
+    @staticmethod
+    def update_log(
+        db: Session,
+        project_id: uuid.UUID,
+        log_id: uuid.UUID,
+        payload: TimeLogUpdate,
+        actor: User,
+        today: date | None = None,
+    ) -> ProjectTimeLog:
+        project = ProjectTimeLogService.get_project_or_404(db, project_id)
+        log = ProjectTimeLogService.get_log_or_404(db, project_id, log_id)
+        ProjectTimeLogService.require_can_modify(db, project, log, actor)
+
+        data = payload.model_dump(exclude_unset=True)
+
+        new_date = data.get("work_date", log.work_date)
+        new_minutes = data.get("minutes", log.minutes)
+
+        if "work_date" in data:
+            ProjectTimeLogService.validate_work_date(new_date, today=today)
+        if "milestone_id" in data:
+            ProjectTimeLogService.validate_milestone(db, project_id, data["milestone_id"])
+
+        # Re-check the cap whenever either half of the (date, minutes) pair
+        # moves -- shifting an entry onto an already-full day is just as much a
+        # violation as growing it in place.
+        if "minutes" in data or "work_date" in data:
+            ProjectTimeLogService.validate_daily_cap(
+                db,
+                project_id,
+                log.user_id,
+                new_date,
+                new_minutes,
+                exclude_log_id=log.id,
+            )
+
+        for field, value in data.items():
+            setattr(log, field, value)
+        log.updated_at = datetime.now(timezone.utc)
+
+        db.commit()
+        db.refresh(log)
+        return log
+
+    @staticmethod
+    def delete_log(db: Session, project_id: uuid.UUID, log_id: uuid.UUID, actor: User) -> None:
+        project = ProjectTimeLogService.get_project_or_404(db, project_id)
+        log = ProjectTimeLogService.get_log_or_404(db, project_id, log_id)
+        ProjectTimeLogService.require_can_delete(db, project, log, actor)
+
+        db.delete(log)
+        db.commit()
+
+    # ------------------------------------------------------------------
+    # Listing
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _filtered_query(
+        project_id: uuid.UUID,
+        user_id: uuid.UUID | None = None,
+        milestone_id: uuid.UUID | None = None,
+        from_date: date | None = None,
+        to_date: date | None = None,
+        is_billable: bool | None = None,
+    ):
+        conditions = [ProjectTimeLog.project_id == project_id]
+        if user_id is not None:
+            conditions.append(ProjectTimeLog.user_id == user_id)
+        if milestone_id is not None:
+            conditions.append(ProjectTimeLog.milestone_id == milestone_id)
+        if from_date is not None:
+            conditions.append(ProjectTimeLog.work_date >= from_date)
+        if to_date is not None:
+            conditions.append(ProjectTimeLog.work_date <= to_date)
+        if is_billable is not None:
+            conditions.append(ProjectTimeLog.is_billable.is_(is_billable))
+        return conditions
+
+    @staticmethod
+    def list_logs(
+        db: Session,
+        project_id: uuid.UUID,
+        limit: int = 50,
+        offset: int = 0,
+        user_id: uuid.UUID | None = None,
+        milestone_id: uuid.UUID | None = None,
+        from_date: date | None = None,
+        to_date: date | None = None,
+        is_billable: bool | None = None,
+    ) -> tuple[list[ProjectTimeLog], int, int]:
+        """Return ``(page, total_rows, total_minutes_across_all_rows)``."""
+        conditions = ProjectTimeLogService._filtered_query(
+            project_id,
+            user_id=user_id,
+            milestone_id=milestone_id,
+            from_date=from_date,
+            to_date=to_date,
+            is_billable=is_billable,
+        )
+
+        total = int(db.scalar(select(func.count(ProjectTimeLog.id)).where(*conditions)) or 0)
+        # The total is over the whole filter, not the page -- a report that
+        # only adds up the visible page is a report nobody can trust.
+        total_minutes = int(
+            db.scalar(select(func.coalesce(func.sum(ProjectTimeLog.minutes), 0)).where(*conditions)) or 0
+        )
+
+        stmt = (
+            select(ProjectTimeLog)
+            .where(*conditions)
+            .options(selectinload(ProjectTimeLog.user))
+            # Newest work first, with created_at as the tiebreak so a page
+            # boundary cannot repeat or drop an entry.
+            .order_by(ProjectTimeLog.work_date.desc(), ProjectTimeLog.created_at.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+        items = list(db.scalars(stmt).all())
+        return items, total, total_minutes
+
+    # ------------------------------------------------------------------
+    # Summary
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def summarise(
+        db: Session,
+        project_id: uuid.UUID,
+        from_date: date | None = None,
+        to_date: date | None = None,
+    ) -> TimeLogSummary:
+        ProjectTimeLogService.get_project_or_404(db, project_id)
+
+        conditions = ProjectTimeLogService._filtered_query(
+            project_id, from_date=from_date, to_date=to_date
+        )
+
+        totals_row = db.execute(
+            select(
+                func.coalesce(func.sum(ProjectTimeLog.minutes), 0),
+                func.count(ProjectTimeLog.id),
+                func.min(ProjectTimeLog.work_date),
+                func.max(ProjectTimeLog.work_date),
+            ).where(*conditions)
+        ).one()
+        total_minutes, total_entries, first_day, last_day = totals_row
+
+        billable_minutes = int(
+            db.scalar(
+                select(func.coalesce(func.sum(ProjectTimeLog.minutes), 0)).where(
+                    *conditions, ProjectTimeLog.is_billable.is_(True)
+                )
+            )
+            or 0
+        )
+
+        contributor_rows = db.execute(
+            select(
+                ProjectTimeLog.user_id,
+                User.username,
+                func.sum(ProjectTimeLog.minutes),
+                func.count(ProjectTimeLog.id),
+            )
+            .join(User, User.id == ProjectTimeLog.user_id, isouter=True)
+            .where(*conditions)
+            .group_by(ProjectTimeLog.user_id, User.username)
+            .order_by(func.sum(ProjectTimeLog.minutes).desc())
+        ).all()
+
+        milestone_rows = db.execute(
+            select(
+                ProjectTimeLog.milestone_id,
+                Milestone.title,
+                func.sum(ProjectTimeLog.minutes),
+                func.count(ProjectTimeLog.id),
+            )
+            .join(Milestone, Milestone.id == ProjectTimeLog.milestone_id, isouter=True)
+            .where(*conditions)
+            .group_by(ProjectTimeLog.milestone_id, Milestone.title)
+            .order_by(func.sum(ProjectTimeLog.minutes).desc())
+        ).all()
+
+        total_minutes = int(total_minutes or 0)
+
+        return TimeLogSummary(
+            project_id=project_id,
+            total_minutes=total_minutes,
+            total_hours=ProjectTimeLogService.to_hours(total_minutes),
+            total_entries=int(total_entries or 0),
+            billable_minutes=billable_minutes,
+            billable_hours=ProjectTimeLogService.to_hours(billable_minutes),
+            non_billable_minutes=total_minutes - billable_minutes,
+            non_billable_hours=ProjectTimeLogService.to_hours(total_minutes - billable_minutes),
+            contributor_count=len(contributor_rows),
+            first_logged_date=first_day,
+            last_logged_date=last_day,
+            by_contributor=[
+                ContributorTotal(
+                    user_id=user_id,
+                    username=username,
+                    minutes=int(minutes or 0),
+                    hours=ProjectTimeLogService.to_hours(int(minutes or 0)),
+                    entries=int(entries or 0),
+                )
+                for user_id, username, minutes, entries in contributor_rows
+            ],
+            by_milestone=[
+                MilestoneTotal(
+                    milestone_id=milestone_id,
+                    milestone_title=title,
+                    minutes=int(minutes or 0),
+                    hours=ProjectTimeLogService.to_hours(int(minutes or 0)),
+                    entries=int(entries or 0),
+                )
+                for milestone_id, title, minutes, entries in milestone_rows
+            ],
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def to_hours(minutes: int) -> float:
+        """
+        Minutes to hours for display. Rounding happens once, at the edge --
+        every stored and summed value stays an integer, so a summary and its
+        line items can never disagree.
+        """
+        return round(minutes / 60, 2)
+
+
+__all__ = ["ProjectTimeLogService", "MAX_MINUTES_PER_DAY", "MAX_MINUTES_PER_ENTRY"]

--- a/backend/tests/test_project_time_logs.py
+++ b/backend/tests/test_project_time_logs.py
@@ -1,0 +1,581 @@
+"""
+Unit & integration tests for project time tracking (#1041).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from app.models.project import Project, ProjectStage, ProjectVisibility
+from app.models.project_member import MemberRole, ProjectMember
+from app.models.project_time_log import ProjectTimeLog
+from app.models.user import User
+from app.schemas.project_time_log import (
+    MAX_BACKFILL_DAYS,
+    MAX_MINUTES_PER_ENTRY,
+    TimeLogCreate,
+    TimeLogUpdate,
+)
+from app.services.project_time_log_service import (
+    MAX_MINUTES_PER_DAY,
+    ProjectTimeLogService,
+)
+
+TODAY = date(2026, 8, 10)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_user(username: str = "dev", system_role: str = "user") -> MagicMock:
+    user = MagicMock(spec=User)
+    user.id = uuid.uuid4()
+    user.username = username
+    user.system_role = system_role
+    user.role = "user"
+    return user
+
+
+def _make_project(owner_id: uuid.UUID | None = None) -> MagicMock:
+    project = MagicMock(spec=Project)
+    project.id = uuid.uuid4()
+    project.owner_id = owner_id or uuid.uuid4()
+    project.title = "DevLink"
+    project.deleted_at = None
+    return project
+
+
+def _make_member(role: MemberRole = MemberRole.CONTRIBUTOR) -> MagicMock:
+    member = MagicMock(spec=ProjectMember)
+    member.role = role
+    member.is_active = True
+    return member
+
+
+def _make_log(
+    project_id: uuid.UUID,
+    user_id: uuid.UUID,
+    minutes: int = 60,
+    work_date: date | None = None,
+) -> MagicMock:
+    log = MagicMock(spec=ProjectTimeLog)
+    log.id = uuid.uuid4()
+    log.project_id = project_id
+    log.user_id = user_id
+    log.milestone_id = None
+    log.minutes = minutes
+    log.work_date = work_date or TODAY
+    log.description = "Wired up the importer"
+    log.is_billable = False
+    log.created_at = datetime.now(timezone.utc)
+    log.updated_at = datetime.now(timezone.utc)
+    return log
+
+
+# ---------------------------------------------------------------------------
+# 1. Minutes / hours conversion
+# ---------------------------------------------------------------------------
+
+
+class TestHoursConversion:
+    @pytest.mark.parametrize(
+        "minutes,expected",
+        [(0, 0.0), (30, 0.5), (60, 1.0), (90, 1.5), (1440, 24.0), (100, 1.67), (5, 0.08)],
+    )
+    def test_conversion(self, minutes: int, expected: float):
+        assert ProjectTimeLogService.to_hours(minutes) == expected
+
+    def test_summed_minutes_do_not_drift(self):
+        # Twenty entries of 20 minutes is exactly 400 minutes. Rounding each to
+        # hours first and then adding would not land on the same number, which
+        # is the whole reason minutes are the stored unit.
+        entries = [20] * 20
+        assert ProjectTimeLogService.to_hours(sum(entries)) == 6.67
+        assert sum(entries) == 400
+
+
+# ---------------------------------------------------------------------------
+# 2. work_date validation
+# ---------------------------------------------------------------------------
+
+
+class TestWorkDateValidation:
+    def test_today_is_allowed(self):
+        ProjectTimeLogService.validate_work_date(TODAY, today=TODAY)
+
+    def test_yesterday_is_allowed(self):
+        ProjectTimeLogService.validate_work_date(TODAY - timedelta(days=1), today=TODAY)
+
+    def test_future_is_rejected(self):
+        with pytest.raises(HTTPException) as exc:
+            ProjectTimeLogService.validate_work_date(TODAY + timedelta(days=1), today=TODAY)
+        assert exc.value.status_code == 422
+        assert "future" in exc.value.detail
+
+    def test_oldest_allowed_backfill_is_accepted(self):
+        oldest = TODAY - timedelta(days=MAX_BACKFILL_DAYS)
+        ProjectTimeLogService.validate_work_date(oldest, today=TODAY)
+
+    def test_beyond_backfill_window_is_rejected(self):
+        with pytest.raises(HTTPException) as exc:
+            ProjectTimeLogService.validate_work_date(
+                TODAY - timedelta(days=MAX_BACKFILL_DAYS + 1), today=TODAY
+            )
+        assert exc.value.status_code == 422
+        assert str(MAX_BACKFILL_DAYS) in exc.value.detail
+
+
+# ---------------------------------------------------------------------------
+# 3. Daily cap
+# ---------------------------------------------------------------------------
+
+
+def _db_with_daily_total(total: int) -> MagicMock:
+    db = MagicMock(spec=Session)
+    db.scalar.return_value = total
+    return db
+
+
+class TestDailyCap:
+    def test_under_the_cap_is_fine(self):
+        db = _db_with_daily_total(120)
+        ProjectTimeLogService.validate_daily_cap(db, uuid.uuid4(), uuid.uuid4(), TODAY, 60)
+
+    def test_exactly_at_the_cap_is_allowed(self):
+        db = _db_with_daily_total(MAX_MINUTES_PER_DAY - 60)
+        ProjectTimeLogService.validate_daily_cap(db, uuid.uuid4(), uuid.uuid4(), TODAY, 60)
+
+    def test_one_minute_over_is_rejected(self):
+        db = _db_with_daily_total(MAX_MINUTES_PER_DAY - 60)
+        with pytest.raises(HTTPException) as exc:
+            ProjectTimeLogService.validate_daily_cap(db, uuid.uuid4(), uuid.uuid4(), TODAY, 61)
+        assert exc.value.status_code == 400
+        assert "24-hour" in exc.value.detail
+
+    def test_error_reports_the_remaining_budget(self):
+        db = _db_with_daily_total(MAX_MINUTES_PER_DAY - 15)
+        with pytest.raises(HTTPException) as exc:
+            ProjectTimeLogService.validate_daily_cap(db, uuid.uuid4(), uuid.uuid4(), TODAY, 100)
+        assert "15 minutes remain" in exc.value.detail
+
+    def test_full_day_leaves_nothing(self):
+        db = _db_with_daily_total(MAX_MINUTES_PER_DAY)
+        with pytest.raises(HTTPException) as exc:
+            ProjectTimeLogService.validate_daily_cap(db, uuid.uuid4(), uuid.uuid4(), TODAY, 1)
+        assert "0 minutes remain" in exc.value.detail
+
+    def test_editing_an_entry_excludes_itself_from_the_total(self):
+        # Without the exclusion, resizing a 600-minute entry to 660 would be
+        # measured against a day that already contains the old 600.
+        db = MagicMock(spec=Session)
+        db.scalar.return_value = 0
+        log_id = uuid.uuid4()
+        ProjectTimeLogService.validate_daily_cap(
+            db, uuid.uuid4(), uuid.uuid4(), TODAY, 660, exclude_log_id=log_id
+        )
+        assert db.scalar.called
+
+
+# ---------------------------------------------------------------------------
+# 4. Membership & permissions
+# ---------------------------------------------------------------------------
+
+
+class TestPermissions:
+    def test_owner_may_log(self):
+        db = MagicMock(spec=Session)
+        user = _make_user()
+        project = _make_project(owner_id=user.id)
+        ProjectTimeLogService.require_member(db, project, user)
+
+    def test_platform_admin_may_log(self):
+        db = MagicMock(spec=Session)
+        admin = _make_user(system_role="admin")
+        ProjectTimeLogService.require_member(db, _make_project(), admin)
+
+    def test_active_member_may_log(self):
+        db = MagicMock(spec=Session)
+        db.scalar.return_value = _make_member()
+        ProjectTimeLogService.require_member(db, _make_project(), _make_user())
+
+    def test_stranger_may_not_log(self):
+        db = MagicMock(spec=Session)
+        db.scalar.return_value = None
+        with pytest.raises(HTTPException) as exc:
+            ProjectTimeLogService.require_member(db, _make_project(), _make_user())
+        assert exc.value.status_code == 403
+
+    def test_author_may_edit_their_own_entry(self):
+        db = MagicMock(spec=Session)
+        user = _make_user()
+        project = _make_project()
+        log = _make_log(project.id, user.id)
+        ProjectTimeLogService.require_can_modify(db, project, log, user)
+
+    def test_maintainer_may_not_edit_someone_elses_entry(self):
+        # Rewriting another person's hours while leaving their name on the row
+        # is worse than having no row at all.
+        db = MagicMock(spec=Session)
+        db.scalar.return_value = _make_member(MemberRole.MAINTAINER)
+        maintainer = _make_user("maint")
+        project = _make_project()
+        log = _make_log(project.id, uuid.uuid4())
+
+        with pytest.raises(HTTPException) as exc:
+            ProjectTimeLogService.require_can_modify(db, project, log, maintainer)
+        assert exc.value.status_code == 403
+
+    def test_maintainer_may_delete_someone_elses_entry(self):
+        db = MagicMock(spec=Session)
+        db.scalar.return_value = _make_member(MemberRole.MAINTAINER)
+        project = _make_project()
+        log = _make_log(project.id, uuid.uuid4())
+        ProjectTimeLogService.require_can_delete(db, project, log, _make_user("maint"))
+
+    def test_contributor_may_not_delete_someone_elses_entry(self):
+        db = MagicMock(spec=Session)
+        db.scalar.return_value = _make_member(MemberRole.CONTRIBUTOR)
+        project = _make_project()
+        log = _make_log(project.id, uuid.uuid4())
+
+        with pytest.raises(HTTPException) as exc:
+            ProjectTimeLogService.require_can_delete(db, project, log, _make_user("contrib"))
+        assert exc.value.status_code == 403
+
+    def test_author_may_always_delete_their_own(self):
+        db = MagicMock(spec=Session)
+        db.scalar.return_value = None
+        user = _make_user()
+        project = _make_project()
+        ProjectTimeLogService.require_can_delete(db, project, _make_log(project.id, user.id), user)
+
+
+# ---------------------------------------------------------------------------
+# 5. Schema validation
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaValidation:
+    def test_minutes_must_be_positive(self):
+        with pytest.raises(Exception):
+            TimeLogCreate(minutes=0, work_date=TODAY)
+
+    def test_minutes_capped_at_one_day(self):
+        TimeLogCreate(minutes=MAX_MINUTES_PER_ENTRY, work_date=TODAY)
+        with pytest.raises(Exception):
+            TimeLogCreate(minutes=MAX_MINUTES_PER_ENTRY + 1, work_date=TODAY)
+
+    def test_blank_description_becomes_none(self):
+        payload = TimeLogCreate(minutes=30, work_date=TODAY, description="   ")
+        assert payload.description is None
+
+    def test_description_is_stripped(self):
+        payload = TimeLogCreate(minutes=30, work_date=TODAY, description="  refactor  ")
+        assert payload.description == "refactor"
+
+    def test_update_leaves_unset_fields_out(self):
+        payload = TimeLogUpdate(minutes=45)
+        assert payload.model_dump(exclude_unset=True) == {"minutes": 45}
+
+    def test_billable_defaults_to_false(self):
+        assert TimeLogCreate(minutes=30, work_date=TODAY).is_billable is False
+
+
+# ---------------------------------------------------------------------------
+# 6. HTTP surface (real database)
+# ---------------------------------------------------------------------------
+
+
+
+
+class TestTimeLogEndpoints:
+    """Router wiring: auth requirements, status codes, response shape."""
+
+    @staticmethod
+    def _project_for(db, owner_id: uuid.UUID, slug: str) -> Project:
+        project = Project(
+            owner_id=owner_id,
+            title="Time Tracked Project",
+            slug=slug,
+            description="A project that records how long things take.",
+            stage=ProjectStage.MVP,
+            visibility=ProjectVisibility.PUBLIC,
+        )
+        db.add(project)
+        db.commit()
+        db.refresh(project)
+        return project
+
+    @staticmethod
+    def _auth(token: str) -> dict[str, str]:
+        return {"Authorization": f"Bearer {token}"}
+
+    def test_logging_requires_authentication(self, client):
+        response = client.post(
+            f"/api/v1/projects/{uuid.uuid4()}/time-logs",
+            json={"minutes": 60, "work_date": date.today().isoformat()},
+        )
+        assert response.status_code in (401, 403)
+
+    def test_unknown_project_returns_404(self, client, register_and_login):
+        _, token = register_and_login("tl1@example.com", "tluser1")
+        response = client.post(
+            f"/api/v1/projects/{uuid.uuid4()}/time-logs",
+            json={"minutes": 60, "work_date": date.today().isoformat()},
+            headers=self._auth(token),
+        )
+        assert response.status_code == 404
+
+    def test_owner_can_log_and_read_back(self, client, db, register_and_login):
+        user_id, token = register_and_login("tl2@example.com", "tluser2")
+        project = self._project_for(db, uuid.UUID(user_id), "tl-project-2")
+
+        created = client.post(
+            f"/api/v1/projects/{project.id}/time-logs",
+            json={
+                "minutes": 90,
+                "work_date": date.today().isoformat(),
+                "description": "Pairing on the parser",
+                "is_billable": True,
+            },
+            headers=self._auth(token),
+        )
+        assert created.status_code == 201, created.text
+
+        body = created.json()
+        assert body["minutes"] == 90
+        assert body["hours"] == 1.5
+        assert body["is_billable"] is True
+
+        listed = client.get(f"/api/v1/projects/{project.id}/time-logs", headers=self._auth(token))
+        assert listed.status_code == 200
+        assert listed.json()["total"] == 1
+        assert listed.json()["total_minutes"] == 90
+
+    def test_future_work_date_is_rejected(self, client, db, register_and_login):
+        user_id, token = register_and_login("tl3@example.com", "tluser3")
+        project = self._project_for(db, uuid.UUID(user_id), "tl-project-3")
+
+        response = client.post(
+            f"/api/v1/projects/{project.id}/time-logs",
+            json={
+                "minutes": 60,
+                "work_date": (date.today() + timedelta(days=1)).isoformat(),
+            },
+            headers=self._auth(token),
+        )
+        assert response.status_code == 422
+
+    def test_stale_backfill_is_rejected(self, client, db, register_and_login):
+        user_id, token = register_and_login("tl4@example.com", "tluser4")
+        project = self._project_for(db, uuid.UUID(user_id), "tl-project-4")
+
+        response = client.post(
+            f"/api/v1/projects/{project.id}/time-logs",
+            json={
+                "minutes": 60,
+                "work_date": (date.today() - timedelta(days=MAX_BACKFILL_DAYS + 1)).isoformat(),
+            },
+            headers=self._auth(token),
+        )
+        assert response.status_code == 422
+
+    def test_daily_cap_is_enforced_across_entries(self, client, db, register_and_login):
+        user_id, token = register_and_login("tl5@example.com", "tluser5")
+        project = self._project_for(db, uuid.UUID(user_id), "tl-project-5")
+        today = date.today().isoformat()
+
+        first = client.post(
+            f"/api/v1/projects/{project.id}/time-logs",
+            json={"minutes": 1400, "work_date": today},
+            headers=self._auth(token),
+        )
+        assert first.status_code == 201
+
+        second = client.post(
+            f"/api/v1/projects/{project.id}/time-logs",
+            json={"minutes": 60, "work_date": today},
+            headers=self._auth(token),
+        )
+        assert second.status_code == 400
+        assert "24-hour" in second.json()["detail"]
+
+    def test_summary_reconciles_with_its_line_items(self, client, db, register_and_login):
+        user_id, token = register_and_login("tl6@example.com", "tluser6")
+        project = self._project_for(db, uuid.UUID(user_id), "tl-project-6")
+        today = date.today().isoformat()
+
+        for minutes, billable in ((45, True), (30, False), (75, True)):
+            response = client.post(
+                f"/api/v1/projects/{project.id}/time-logs",
+                json={"minutes": minutes, "work_date": today, "is_billable": billable},
+                headers=self._auth(token),
+            )
+            assert response.status_code == 201, response.text
+
+        summary = client.get(
+            f"/api/v1/projects/{project.id}/time-logs/summary", headers=self._auth(token)
+        )
+        assert summary.status_code == 200
+        body = summary.json()
+
+        assert body["total_minutes"] == 150
+        assert body["total_hours"] == 2.5
+        assert body["total_entries"] == 3
+        assert body["billable_minutes"] == 120
+        assert body["non_billable_minutes"] == 30
+        assert body["billable_minutes"] + body["non_billable_minutes"] == body["total_minutes"]
+        assert body["contributor_count"] == 1
+        assert sum(c["minutes"] for c in body["by_contributor"]) == body["total_minutes"]
+        # Work with no milestone is grouped under a null id, not dropped.
+        assert sum(m["minutes"] for m in body["by_milestone"]) == body["total_minutes"]
+        assert body["by_milestone"][0]["milestone_id"] is None
+
+    def test_non_member_cannot_log(self, client, db, register_and_login):
+        owner_id, _ = register_and_login("tl7@example.com", "tluser7")
+        project = self._project_for(db, uuid.UUID(owner_id), "tl-project-7")
+
+        _, outsider_token = register_and_login("tl8@example.com", "tluser8")
+        response = client.post(
+            f"/api/v1/projects/{project.id}/time-logs",
+            json={"minutes": 60, "work_date": date.today().isoformat()},
+            headers=self._auth(outsider_token),
+        )
+        assert response.status_code == 403
+
+    def test_author_can_edit_and_delete(self, client, db, register_and_login):
+        user_id, token = register_and_login("tl9@example.com", "tluser9")
+        project = self._project_for(db, uuid.UUID(user_id), "tl-project-9")
+
+        created = client.post(
+            f"/api/v1/projects/{project.id}/time-logs",
+            json={"minutes": 60, "work_date": date.today().isoformat()},
+            headers=self._auth(token),
+        )
+        log_id = created.json()["id"]
+
+        updated = client.patch(
+            f"/api/v1/projects/{project.id}/time-logs/{log_id}",
+            json={"minutes": 120, "description": "Took longer than expected"},
+            headers=self._auth(token),
+        )
+        assert updated.status_code == 200
+        assert updated.json()["minutes"] == 120
+        assert updated.json()["hours"] == 2.0
+
+        deleted = client.delete(
+            f"/api/v1/projects/{project.id}/time-logs/{log_id}", headers=self._auth(token)
+        )
+        assert deleted.status_code == 204
+
+        listed = client.get(f"/api/v1/projects/{project.id}/time-logs", headers=self._auth(token))
+        assert listed.json()["total"] == 0
+
+    def test_someone_else_cannot_edit_your_entry(self, client, db, register_and_login):
+        owner_id, owner_token = register_and_login("tl10@example.com", "tluser10")
+        project = self._project_for(db, uuid.UUID(owner_id), "tl-project-10")
+
+        created = client.post(
+            f"/api/v1/projects/{project.id}/time-logs",
+            json={"minutes": 60, "work_date": date.today().isoformat()},
+            headers=self._auth(owner_token),
+        )
+        log_id = created.json()["id"]
+
+        _, other_token = register_and_login("tl11@example.com", "tluser11")
+        response = client.patch(
+            f"/api/v1/projects/{project.id}/time-logs/{log_id}",
+            json={"minutes": 5},
+            headers=self._auth(other_token),
+        )
+        assert response.status_code == 403
+
+        unchanged = client.get(
+            f"/api/v1/projects/{project.id}/time-logs/{log_id}", headers=self._auth(owner_token)
+        )
+        assert unchanged.json()["minutes"] == 60
+
+    def test_unknown_milestone_is_rejected(self, client, db, register_and_login):
+        user_id, token = register_and_login("tl12@example.com", "tluser12")
+        project = self._project_for(db, uuid.UUID(user_id), "tl-project-12")
+
+        response = client.post(
+            f"/api/v1/projects/{project.id}/time-logs",
+            json={
+                "minutes": 60,
+                "work_date": date.today().isoformat(),
+                "milestone_id": str(uuid.uuid4()),
+            },
+            headers=self._auth(token),
+        )
+        assert response.status_code == 404
+
+    def test_date_filters_narrow_the_result(self, client, db, register_and_login):
+        user_id, token = register_and_login("tl13@example.com", "tluser13")
+        project = self._project_for(db, uuid.UUID(user_id), "tl-project-13")
+
+        today = date.today()
+        for offset in (0, 3, 10):
+            response = client.post(
+                f"/api/v1/projects/{project.id}/time-logs",
+                json={"minutes": 30, "work_date": (today - timedelta(days=offset)).isoformat()},
+                headers=self._auth(token),
+            )
+            assert response.status_code == 201
+
+        response = client.get(
+            f"/api/v1/projects/{project.id}/time-logs",
+            params={"from_date": (today - timedelta(days=5)).isoformat()},
+            headers=self._auth(token),
+        )
+        assert response.status_code == 200
+        assert response.json()["total"] == 2
+        assert response.json()["total_minutes"] == 60
+
+    def test_totals_cover_the_filter_not_the_page(self, client, db, register_and_login):
+        user_id, token = register_and_login("tl14@example.com", "tluser14")
+        project = self._project_for(db, uuid.UUID(user_id), "tl-project-14")
+
+        today = date.today()
+        for offset in range(5):
+            client.post(
+                f"/api/v1/projects/{project.id}/time-logs",
+                json={"minutes": 30, "work_date": (today - timedelta(days=offset)).isoformat()},
+                headers=self._auth(token),
+            )
+
+        response = client.get(
+            f"/api/v1/projects/{project.id}/time-logs",
+            params={"limit": 2},
+            headers=self._auth(token),
+        )
+        body = response.json()
+        assert len(body["items"]) == 2
+        assert body["total"] == 5
+        # A report that only adds up the visible page is a report nobody can
+        # trust, so the totals span the whole filtered set.
+        assert body["total_minutes"] == 150
+
+    def test_me_endpoint_returns_only_your_own_entries(self, client, db, register_and_login):
+        owner_id, owner_token = register_and_login("tl15@example.com", "tluser15")
+        project = self._project_for(db, uuid.UUID(owner_id), "tl-project-15")
+
+        client.post(
+            f"/api/v1/projects/{project.id}/time-logs",
+            json={"minutes": 60, "work_date": date.today().isoformat()},
+            headers=self._auth(owner_token),
+        )
+
+        response = client.get(
+            f"/api/v1/projects/{project.id}/time-logs/me", headers=self._auth(owner_token)
+        )
+        assert response.status_code == 200
+        assert response.json()["total"] == 1
+        assert all(item["user_id"] == owner_id for item in response.json()["items"])


### PR DESCRIPTION
Closes #1041

## What this does

Adds a work-log ledger scoped to a project, so an owner can answer the questions that actually come up when running a volunteer team: how many hours went into this last month, which milestone is eating the time, and has a contributor gone quiet.

Deliberately *not* a timesheet product — no timers, no approvals, no invoicing. One table, one set of rules.

## Storage decisions

**Minutes, not hours-as-float.** Hours are a presentation concern. Storing `1.5` and summing hundreds of those is how a summary ends up disagreeing with its own line items by a fraction of an hour, and then someone has to work out which number is the real one. `minutes` is an integer end to end; `to_hours()` rounds once, at the response edge. There is a test that pins this: twenty 20-minute entries sum to exactly 400 minutes, and rounding each one to hours first would not.

**`work_date` is a `Date`, separate from `created_at`.** People log Friday's work on Monday morning. Conflating "when it happened" with "when it was typed" makes every weekly report wrong at the boundary.

**A deleted milestone `SET NULL`s its logs instead of cascading.** The milestone can go away; the work still happened. Those entries then group under a null `milestone_id` in the summary rather than silently vanishing from the project total.

Three composite indexes: `(project_id, work_date)` for the project report, `(user_id, work_date)` for a person's history, and `(project_id, user_id, work_date)` for the daily-cap check, which runs on every write.

## Rules

- **Only active members (or the owner) may log time.** Logs feed contributor-level reporting, so an outsider adding rows would be writing into other people's numbers.
- **Edit and delete are split.** The author may edit their own entries. Maintainers may *delete* anyone's — a project needs to clean up after a departed member — but may not *rewrite* them. An edited entry still carrying someone else's name is worse than no entry at all.
- **`work_date` may not be in the future**, nor more than 90 days back. Past that point the number stops being a recollection and starts being a guess.
- **24 hours per user, per project, per day.** Enforced across entries, not just within one. Crucially it is re-checked whenever *either* the duration or the date changes on an edit — moving an existing entry onto an already-full day is exactly as much a violation as growing it in place, and it is the case that a naive implementation misses. The check excludes the entry being edited from its own total, otherwise resizing a 600-minute entry would be measured against a day that still contains the old 600.
- A `CHECK` constraint in the migration backs the per-entry bounds at the database level too.

## Endpoints

```
POST   /api/v1/projects/{id}/time-logs
GET    /api/v1/projects/{id}/time-logs        ?user_id&milestone_id&from_date&to_date&is_billable
GET    /api/v1/projects/{id}/time-logs/me
GET    /api/v1/projects/{id}/time-logs/summary ?from_date&to_date
GET    /api/v1/projects/{id}/time-logs/{log_id}
PATCH  /api/v1/projects/{id}/time-logs/{log_id}
DELETE /api/v1/projects/{id}/time-logs/{log_id}
```

`total` and `total_minutes` on the list response cover the whole filtered set, not the returned page. A report that only adds up what happens to be visible is a report nobody can trust.

## Migration

`e7c1a9b45d20`, branching from the current head `d4e5f6a7b8c9`. `alembic heads` is a single head with this applied. Downgrade drops the indexes and table cleanly.

## Tests

48 cases. The ones worth reading:

- **Cap boundary** — exactly at 24h passes, one minute over is a 400 with the remaining budget in the message, a full day reports "0 minutes remain", and the edit path excludes the entry from its own total.
- **Backfill window** — day 90 is accepted, day 91 is a 422.
- **Permission split** — a maintainer can delete but not edit someone else's entry; a contributor can do neither; the author can always do both. After a rejected edit the test re-reads the entry and asserts it is unchanged.
- **Summary reconciliation** — `billable + non_billable == total`, and both the per-contributor and per-milestone breakdowns sum back to the project total, including the null-milestone group.
- **Pagination** — a 2-item page still reports `total: 5` and the full `total_minutes`.

```
48 passed
```
