### PR TITLE
feat(profile): back pinned projects with a real API (#1042)

### DIFF
--- a/backend/alembic/versions/b6d3f2a71c48_create_pinned_projects_table.py
+++ b/backend/alembic/versions/b6d3f2a71c48_create_pinned_projects_table.py
@@ -1,0 +1,64 @@
+"""create pinned projects table
+
+Revision ID: b6d3f2a71c48
+Revises: d4e5f6a7b8c9
+Create Date: 2026-08-10 20:40:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+# revision identifiers, used by Alembic.
+revision: str = "b6d3f2a71c48"
+down_revision: Union[str, Sequence[str], None] = "d4e5f6a7b8c9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "pinned_projects",
+        sa.Column("id", UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("project_id", UUID(as_uuid=True), nullable=False),
+        # 0-based and contiguous, compacted by the service on every removal.
+        sa.Column("position", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        # One pin per project per user. Unlike position this never
+        # legitimately collides, so it is safe to enforce here.
+        sa.UniqueConstraint("user_id", "project_id", name="uq_pinned_projects_user_project"),
+        sa.CheckConstraint("position >= 0", name="ck_pinned_projects_position"),
+    )
+
+    op.create_index(
+        op.f("ix_pinned_projects_user_id"), "pinned_projects", ["user_id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_pinned_projects_project_id"), "pinned_projects", ["project_id"], unique=False
+    )
+    # The read path: one user's pins in display order.
+    op.create_index(
+        "ix_pinned_projects_user_position",
+        "pinned_projects",
+        ["user_id", "position"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_pinned_projects_user_position", table_name="pinned_projects")
+    op.drop_index(op.f("ix_pinned_projects_project_id"), table_name="pinned_projects")
+    op.drop_index(op.f("ix_pinned_projects_user_id"), table_name="pinned_projects")
+    op.drop_table("pinned_projects")

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -22,6 +22,7 @@ from app.routers import (
     oauth_linking,
     org_audit_logs,
     organizations,
+    pinned_projects,
     plugins,
     profile_summary,
     profile_suggestions,
@@ -69,6 +70,7 @@ api_v1_router.include_router(oauth_linking.router)
 api_v1_router.include_router(users.router, prefix="/users", tags=["Users"])
 api_v1_router.include_router(blocks.router, prefix="/blocks", tags=["User Blocks"])
 api_v1_router.include_router(export.router, prefix="/users", tags=["Export"])
+api_v1_router.include_router(pinned_projects.router)
 api_v1_router.include_router(backup.router)
 api_v1_router.include_router(projects.router, prefix="/projects", tags=["Projects"])
 api_v1_router.include_router(project_members.router)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -537,6 +537,9 @@ app.include_router(global_announcements.router, prefix="/api", tags=["Global Ann
 app.include_router(users.router, prefix="/api/users", tags=["Users"])
 app.include_router(blocks.router, prefix="/api/blocks", tags=["User Blocks"])
 app.include_router(export.router, prefix="/api/users", tags=["Export"])
+from app.routers import pinned_projects
+
+app.include_router(pinned_projects.router, prefix="/api", tags=["Pinned Projects"])
 from app.routers import feedback
 
 app.include_router(feedback.router, prefix="/api/feedback", tags=["Feedback"])

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -89,6 +89,6 @@ from .badge import Badge, UserBadge  # noqa: F401
 from .centralized_analytics import CentralizedAnalyticsEvent, AnalyticsEventType  # noqa: F401
 from .global_announcement import GlobalAnnouncement, AnnouncementSeverity, TargetAudience  # noqa: F401
 from .post import Post  # noqa: F401
+from .pinned_project import PinnedProject  # noqa: F401
 
 from .project_comment import ProjectComment  # noqa: F401
-from .pinned_project import PinnedProject  # noqa: F401

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -91,3 +91,4 @@ from .global_announcement import GlobalAnnouncement, AnnouncementSeverity, Targe
 from .post import Post  # noqa: F401
 
 from .project_comment import ProjectComment  # noqa: F401
+from .pinned_project import PinnedProject  # noqa: F401

--- a/backend/app/models/pinned_project.py
+++ b/backend/app/models/pinned_project.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database.base import Base
+
+# A profile shop-window, not a project list. Six is enough to show range and
+# few enough that a visitor reads all of them.
+MAX_PINNED_PROJECTS = 6
+
+
+class PinnedProject(Base):
+    """
+    A project a user has chosen to feature on their profile (#1042).
+    """
+
+    __tablename__ = "pinned_projects"
+
+    # ==========================================================
+    # Primary Key
+    # ==========================================================
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+    # ==========================================================
+    # Foreign Keys
+    # ==========================================================
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    # ==========================================================
+    # Ordering
+    # ==========================================================
+
+    # 0-based, contiguous. There is deliberately no unique constraint on
+    # (user_id, position): a reorder has to pass through states where two rows
+    # briefly share a slot, and a non-deferrable unique index would reject the
+    # write halfway. The service owns compaction instead.
+    position: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=0,
+    )
+
+    # ==========================================================
+    # Relationships
+    # ==========================================================
+
+    user = relationship("User", backref="pinned_projects")
+    project = relationship("Project", backref="pinned_by")
+
+    # ==========================================================
+    # Audit
+    # ==========================================================
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    __table_args__ = (
+        # One pin per project per user. This *is* safe to enforce in the
+        # database -- unlike position, it never legitimately collides.
+        UniqueConstraint("user_id", "project_id", name="uq_pinned_projects_user_project"),
+        # The read path: one user's pins in display order.
+        Index("ix_pinned_projects_user_position", "user_id", "position"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<PinnedProject(user={self.user_id}, project={self.project_id}, position={self.position})>"

--- a/backend/app/routers/pinned_projects.py
+++ b/backend/app/routers/pinned_projects.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+"""
+API Router for pinned profile projects (#1042).
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy.orm import Session
+
+from app.dependencies import get_current_active_user, get_database, get_optional_current_user
+from app.models.pinned_project import MAX_PINNED_PROJECTS
+from app.models.user import User
+from app.schemas.pinned_project import (
+    PinnedProjectCreate,
+    PinnedProjectList,
+    PinnedProjectReorder,
+    PinnedProjectResponse,
+)
+from app.services.pinned_project_service import PinnedProjectService
+
+router = APIRouter(
+    prefix="/users",
+    tags=["Pinned Projects"],
+)
+
+
+def _as_list(pins) -> PinnedProjectList:
+    return PinnedProjectList(
+        items=[PinnedProjectResponse.model_validate(pin) for pin in pins],
+        total=len(pins),
+        max_pins=MAX_PINNED_PROJECTS,
+    )
+
+
+@router.get(
+    "/me/pinned-projects",
+    response_model=PinnedProjectList,
+    summary="List your pinned projects",
+)
+def list_my_pinned_projects(
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_active_user),
+) -> PinnedProjectList:
+    return _as_list(PinnedProjectService.list_pins(db, current_user.id))
+
+
+@router.post(
+    "/me/pinned-projects",
+    response_model=PinnedProjectResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Pin a project to your profile",
+    description=(
+        f"Appends the project after any existing pins, up to {MAX_PINNED_PROJECTS}. "
+        "You may only pin a public, non-archived project you own or are a member of."
+    ),
+    responses={
+        400: {"description": "Pin limit reached, or the project is private or archived"},
+        403: {"description": "Not your project"},
+        404: {"description": "Project not found"},
+        409: {"description": "Already pinned"},
+    },
+)
+def pin_project(
+    payload: PinnedProjectCreate,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_active_user),
+) -> PinnedProjectResponse:
+    pin = PinnedProjectService.pin(db, user=current_user, project_id=payload.project_id)
+    return PinnedProjectResponse.model_validate(pin)
+
+
+@router.put(
+    "/me/pinned-projects",
+    response_model=PinnedProjectList,
+    summary="Replace the whole pinned set",
+    description=(
+        "Sets the complete list of pins, in display order — what a drag-and-drop "
+        "UI wants. The batch is validated in full before anything is written, so "
+        "one ineligible project rejects the whole request rather than leaving a "
+        "half-applied order."
+    ),
+    responses={400: {"description": "Too many pins, a duplicate, or an ineligible project"}},
+)
+def replace_pinned_projects(
+    payload: PinnedProjectReorder,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_active_user),
+) -> PinnedProjectList:
+    pins = PinnedProjectService.replace(db, user=current_user, project_ids=payload.project_ids)
+    return _as_list(pins)
+
+
+@router.delete(
+    "/me/pinned-projects/{project_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Unpin a project",
+    description="Remaining pins are renumbered so positions stay contiguous.",
+)
+def unpin_project(
+    project_id: uuid.UUID,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_active_user),
+) -> Response:
+    PinnedProjectService.unpin(db, user=current_user, project_id=project_id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get(
+    "/{username}/pinned-projects",
+    response_model=PinnedProjectList,
+    summary="List a builder's pinned projects",
+    description="Public, ordered by position. Private profiles are visible to their owner only.",
+    responses={
+        403: {"description": "Profile is private"},
+        404: {"description": "User not found"},
+    },
+)
+def list_pinned_projects(
+    username: str,
+    db: Session = Depends(get_database),
+    current_user: User | None = Depends(get_optional_current_user),
+) -> PinnedProjectList:
+    subject = PinnedProjectService.get_user_or_404(db, username)
+
+    if subject.is_private and (current_user is None or current_user.id != subject.id):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have permission to view this private profile.",
+        )
+
+    return _as_list(PinnedProjectService.list_pins(db, subject.id))

--- a/backend/app/schemas/pinned_project.py
+++ b/backend/app/schemas/pinned_project.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+"""
+Schemas for pinned profile projects (#1042).
+"""
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.models.pinned_project import MAX_PINNED_PROJECTS
+
+
+class PinnedProjectCreate(BaseModel):
+    project_id: uuid.UUID = Field(..., description="Project to pin; appended after any existing pins")
+
+
+class PinnedProjectReorder(BaseModel):
+    project_ids: list[uuid.UUID] = Field(
+        ...,
+        max_length=MAX_PINNED_PROJECTS,
+        description=(
+            "The complete pinned set, in display order. Replaces whatever was "
+            "pinned before. An empty list clears all pins."
+        ),
+    )
+
+
+class PinnedProjectSummary(BaseModel):
+    """The slice of a project a profile card needs. Not the full project."""
+
+    id: uuid.UUID
+    title: str
+    slug: str
+    tagline: Optional[str] = None
+    stage: Optional[str] = None
+    tech_stack: Optional[str] = None
+    tags: Optional[list] = None
+    logo_url: Optional[str] = None
+    banner_url: Optional[str] = None
+    stars: int = 0
+    views: int = 0
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PinnedProjectResponse(BaseModel):
+    id: uuid.UUID
+    user_id: uuid.UUID
+    project_id: uuid.UUID
+    position: int
+    project: Optional[PinnedProjectSummary] = None
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PinnedProjectList(BaseModel):
+    items: list[PinnedProjectResponse]
+    total: int
+    max_pins: int = Field(default=MAX_PINNED_PROJECTS, description="Server-enforced cap")

--- a/backend/app/services/pinned_project_service.py
+++ b/backend/app/services/pinned_project_service.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+"""
+Business logic for pinned profile projects (#1042).
+"""
+
+import logging
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import HTTPException, status
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session, selectinload
+
+from app.models.pinned_project import MAX_PINNED_PROJECTS, PinnedProject
+from app.models.project import Project, ProjectVisibility
+from app.models.project_member import ProjectMember
+from app.models.user import User
+
+logger = logging.getLogger(__name__)
+
+
+class PinnedProjectService:
+    """Pin, unpin and reorder the projects featured on a profile."""
+
+    # ------------------------------------------------------------------
+    # Lookups
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def get_user_or_404(db: Session, username: str) -> User:
+        user = db.scalar(select(User).where(User.username == username))
+        if user is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="User not found",
+            )
+        return user
+
+    @staticmethod
+    def get_project_or_404(db: Session, project_id: uuid.UUID) -> Project:
+        project = db.get(Project, project_id)
+        if project is None or getattr(project, "deleted_at", None) is not None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Project not found",
+            )
+        return project
+
+    # ------------------------------------------------------------------
+    # Eligibility
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def is_associated(db: Session, project: Project, user: User) -> bool:
+        """Owner or active member. You cannot pin a project you had no part in."""
+        if project.owner_id == user.id:
+            return True
+        member = db.scalar(
+            select(ProjectMember).where(
+                ProjectMember.project_id == project.id,
+                ProjectMember.user_id == user.id,
+                ProjectMember.is_active.is_(True),
+            )
+        )
+        return member is not None
+
+    @staticmethod
+    def require_pinnable(db: Session, project: Project, user: User) -> None:
+        """
+        A pin is a public shop-window. The rules follow from that: the visitor
+        who clicks one has to be able to open it, and the person pinning has to
+        have actually been involved.
+        """
+        if not PinnedProjectService.is_associated(db, project, user):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You can only pin projects you own or are a member of.",
+            )
+
+        if getattr(project, "is_archived", False):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Archived projects cannot be pinned.",
+            )
+
+        # A private project pinned by its owner is a dead link for everyone
+        # else, so it does not belong in a shop-window at all.
+        if project.visibility == ProjectVisibility.PRIVATE:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Private projects cannot be pinned to a public profile.",
+            )
+
+    # ------------------------------------------------------------------
+    # Reads
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def list_pins(db: Session, user_id: uuid.UUID) -> list[PinnedProject]:
+        stmt = (
+            select(PinnedProject)
+            .where(PinnedProject.user_id == user_id)
+            .options(selectinload(PinnedProject.project))
+            .order_by(PinnedProject.position.asc())
+        )
+        return list(db.scalars(stmt).all())
+
+    @staticmethod
+    def count_pins(db: Session, user_id: uuid.UUID) -> int:
+        return int(
+            db.scalar(select(func.count(PinnedProject.id)).where(PinnedProject.user_id == user_id)) or 0
+        )
+
+    # ------------------------------------------------------------------
+    # Writes
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def pin(db: Session, user: User, project_id: uuid.UUID) -> PinnedProject:
+        project = PinnedProjectService.get_project_or_404(db, project_id)
+        PinnedProjectService.require_pinnable(db, project, user)
+
+        existing = db.scalar(
+            select(PinnedProject).where(
+                PinnedProject.user_id == user.id,
+                PinnedProject.project_id == project_id,
+            )
+        )
+        if existing is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="This project is already pinned.",
+            )
+
+        current = PinnedProjectService.count_pins(db, user.id)
+        if current >= MAX_PINNED_PROJECTS:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"You can pin at most {MAX_PINNED_PROJECTS} projects. Unpin one first.",
+            )
+
+        pin = PinnedProject(
+            id=uuid.uuid4(),
+            user_id=user.id,
+            project_id=project_id,
+            position=current,
+            created_at=datetime.now(timezone.utc),
+        )
+        db.add(pin)
+        db.commit()
+        db.refresh(pin)
+        return pin
+
+    @staticmethod
+    def unpin(db: Session, user: User, project_id: uuid.UUID) -> None:
+        pin = db.scalar(
+            select(PinnedProject).where(
+                PinnedProject.user_id == user.id,
+                PinnedProject.project_id == project_id,
+            )
+        )
+        if pin is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="This project is not pinned.",
+            )
+
+        db.delete(pin)
+        db.flush()
+        # Close the gap so positions stay 0..n-1. A sparse sequence would leak
+        # out through the API and force every client to renumber for itself.
+        PinnedProjectService._compact_positions(db, user.id)
+        db.commit()
+
+    @staticmethod
+    def replace(db: Session, user: User, project_ids: list[uuid.UUID]) -> list[PinnedProject]:
+        """
+        Replace the entire pinned set in the given order.
+
+        This is what a drag-and-drop UI wants: one call, one final state, no
+        intermediate ordering the client has to reconstruct if a request fails.
+        """
+        if len(project_ids) > MAX_PINNED_PROJECTS:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"You can pin at most {MAX_PINNED_PROJECTS} projects.",
+            )
+
+        seen: set[uuid.UUID] = set()
+        for project_id in project_ids:
+            if project_id in seen:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="The same project appears more than once.",
+                )
+            seen.add(project_id)
+
+        # Validate the whole batch before touching a single row. A partial
+        # write here would leave the profile in a state the user never asked
+        # for and cannot see to correct.
+        for project_id in project_ids:
+            project = PinnedProjectService.get_project_or_404(db, project_id)
+            PinnedProjectService.require_pinnable(db, project, user)
+
+        for pin in PinnedProjectService.list_pins(db, user.id):
+            db.delete(pin)
+        db.flush()
+
+        now = datetime.now(timezone.utc)
+        for position, project_id in enumerate(project_ids):
+            db.add(
+                PinnedProject(
+                    id=uuid.uuid4(),
+                    user_id=user.id,
+                    project_id=project_id,
+                    position=position,
+                    created_at=now,
+                )
+            )
+
+        db.commit()
+        return PinnedProjectService.list_pins(db, user.id)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _compact_positions(db: Session, user_id: uuid.UUID) -> None:
+        pins = list(
+            db.scalars(
+                select(PinnedProject)
+                .where(PinnedProject.user_id == user_id)
+                .order_by(PinnedProject.position.asc(), PinnedProject.created_at.asc())
+            ).all()
+        )
+        for index, pin in enumerate(pins):
+            if pin.position != index:
+                pin.position = index
+        db.flush()
+
+
+__all__ = ["PinnedProjectService", "MAX_PINNED_PROJECTS"]

--- a/backend/tests/test_pinned_projects.py
+++ b/backend/tests/test_pinned_projects.py
@@ -1,0 +1,368 @@
+"""
+Unit & integration tests for pinned profile projects (#1042).
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from app.models.pinned_project import MAX_PINNED_PROJECTS
+from app.models.project import Project, ProjectStage, ProjectVisibility
+from app.models.project_member import ProjectMember
+from app.models.user import User
+from app.schemas.pinned_project import PinnedProjectReorder
+from app.services.pinned_project_service import PinnedProjectService
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_user(username: str = "ada") -> MagicMock:
+    user = MagicMock(spec=User)
+    user.id = uuid.uuid4()
+    user.username = username
+    user.is_private = False
+    return user
+
+
+def _make_project(
+    owner_id: uuid.UUID | None = None,
+    visibility: ProjectVisibility = ProjectVisibility.PUBLIC,
+    is_archived: bool = False,
+) -> MagicMock:
+    project = MagicMock(spec=Project)
+    project.id = uuid.uuid4()
+    project.owner_id = owner_id or uuid.uuid4()
+    project.title = "Deploy Radar"
+    project.visibility = visibility
+    project.is_archived = is_archived
+    project.deleted_at = None
+    return project
+
+
+def _make_membership() -> MagicMock:
+    member = MagicMock(spec=ProjectMember)
+    member.is_active = True
+    return member
+
+
+# ---------------------------------------------------------------------------
+# 1. Eligibility rules
+# ---------------------------------------------------------------------------
+
+
+class TestPinnable:
+    def test_owner_may_pin_their_public_project(self):
+        db = MagicMock(spec=Session)
+        user = _make_user()
+        PinnedProjectService.require_pinnable(db, _make_project(owner_id=user.id), user)
+
+    def test_active_member_may_pin(self):
+        db = MagicMock(spec=Session)
+        db.scalar.return_value = _make_membership()
+        PinnedProjectService.require_pinnable(db, _make_project(), _make_user())
+
+    def test_stranger_may_not_pin(self):
+        db = MagicMock(spec=Session)
+        db.scalar.return_value = None
+        with pytest.raises(HTTPException) as exc:
+            PinnedProjectService.require_pinnable(db, _make_project(), _make_user())
+        assert exc.value.status_code == 403
+
+    def test_private_project_may_not_be_pinned_even_by_its_owner(self):
+        # A pin a visitor cannot open is a dead link, not a showcase.
+        db = MagicMock(spec=Session)
+        user = _make_user()
+        project = _make_project(owner_id=user.id, visibility=ProjectVisibility.PRIVATE)
+
+        with pytest.raises(HTTPException) as exc:
+            PinnedProjectService.require_pinnable(db, project, user)
+        assert exc.value.status_code == 400
+        assert "Private" in exc.value.detail
+
+    def test_archived_project_may_not_be_pinned(self):
+        db = MagicMock(spec=Session)
+        user = _make_user()
+        project = _make_project(owner_id=user.id, is_archived=True)
+
+        with pytest.raises(HTTPException) as exc:
+            PinnedProjectService.require_pinnable(db, project, user)
+        assert exc.value.status_code == 400
+        assert "Archived" in exc.value.detail
+
+    def test_ownership_is_checked_before_visibility(self):
+        # A stranger probing private project ids should get "not yours", not a
+        # message that confirms the project exists and is private.
+        db = MagicMock(spec=Session)
+        db.scalar.return_value = None
+        project = _make_project(visibility=ProjectVisibility.PRIVATE)
+
+        with pytest.raises(HTTPException) as exc:
+            PinnedProjectService.require_pinnable(db, project, _make_user())
+        assert exc.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# 2. Reorder payload validation
+# ---------------------------------------------------------------------------
+
+
+class TestReorderSchema:
+    def test_empty_list_is_valid(self):
+        assert PinnedProjectReorder(project_ids=[]).project_ids == []
+
+    def test_at_the_limit_is_valid(self):
+        ids = [uuid.uuid4() for _ in range(MAX_PINNED_PROJECTS)]
+        assert len(PinnedProjectReorder(project_ids=ids).project_ids) == MAX_PINNED_PROJECTS
+
+    def test_over_the_limit_is_rejected(self):
+        ids = [uuid.uuid4() for _ in range(MAX_PINNED_PROJECTS + 1)]
+        with pytest.raises(Exception):
+            PinnedProjectReorder(project_ids=ids)
+
+
+# ---------------------------------------------------------------------------
+# 3. HTTP surface (real database)
+# ---------------------------------------------------------------------------
+
+
+class TestPinnedProjectEndpoints:
+    @staticmethod
+    def _project_for(
+        db,
+        owner_id: uuid.UUID,
+        slug: str,
+        visibility: ProjectVisibility = ProjectVisibility.PUBLIC,
+        is_archived: bool = False,
+    ) -> Project:
+        project = Project(
+            owner_id=owner_id,
+            title=f"Project {slug}",
+            slug=slug,
+            description="A project worth showing off.",
+            stage=ProjectStage.MVP,
+            visibility=visibility,
+            is_archived=is_archived,
+        )
+        db.add(project)
+        db.commit()
+        db.refresh(project)
+        return project
+
+    @staticmethod
+    def _auth(token: str) -> dict[str, str]:
+        return {"Authorization": f"Bearer {token}"}
+
+    def _pin(self, client, token: str, project_id):
+        return client.post(
+            "/api/v1/users/me/pinned-projects",
+            json={"project_id": str(project_id)},
+            headers=self._auth(token),
+        )
+
+    def test_pinning_requires_authentication(self, client):
+        response = client.post(
+            "/api/v1/users/me/pinned-projects",
+            json={"project_id": str(uuid.uuid4())},
+        )
+        assert response.status_code in (401, 403)
+
+    def test_unknown_project_is_404(self, client, register_and_login):
+        _, token = register_and_login("pin1@example.com", "pinuser1")
+        assert self._pin(client, token, uuid.uuid4()).status_code == 404
+
+    def test_pin_and_read_back_publicly(self, client, db, register_and_login):
+        user_id, token = register_and_login("pin2@example.com", "pinuser2")
+        project = self._project_for(db, uuid.UUID(user_id), "pin-p2")
+
+        created = self._pin(client, token, project.id)
+        assert created.status_code == 201, created.text
+        assert created.json()["position"] == 0
+
+        public = client.get("/api/v1/users/pinuser2/pinned-projects")
+        assert public.status_code == 200
+        body = public.json()
+        assert body["total"] == 1
+        assert body["max_pins"] == MAX_PINNED_PROJECTS
+        assert body["items"][0]["project"]["slug"] == "pin-p2"
+
+    def test_unknown_username_is_404(self, client):
+        assert client.get("/api/v1/users/nobody-at-all/pinned-projects").status_code == 404
+
+    def test_pinning_twice_is_409(self, client, db, register_and_login):
+        user_id, token = register_and_login("pin3@example.com", "pinuser3")
+        project = self._project_for(db, uuid.UUID(user_id), "pin-p3")
+
+        assert self._pin(client, token, project.id).status_code == 201
+        second = self._pin(client, token, project.id)
+        assert second.status_code == 409
+
+        # And no duplicate row was created.
+        assert client.get("/api/v1/users/pinuser3/pinned-projects").json()["total"] == 1
+
+    def test_seventh_pin_is_rejected(self, client, db, register_and_login):
+        user_id, token = register_and_login("pin4@example.com", "pinuser4")
+
+        for i in range(MAX_PINNED_PROJECTS):
+            project = self._project_for(db, uuid.UUID(user_id), f"pin-p4-{i}")
+            assert self._pin(client, token, project.id).status_code == 201
+
+        one_too_many = self._project_for(db, uuid.UUID(user_id), "pin-p4-extra")
+        response = self._pin(client, token, one_too_many.id)
+        assert response.status_code == 400
+        assert str(MAX_PINNED_PROJECTS) in response.json()["detail"]
+
+    def test_positions_are_assigned_in_pin_order(self, client, db, register_and_login):
+        user_id, token = register_and_login("pin5@example.com", "pinuser5")
+
+        slugs = ["pin-p5-a", "pin-p5-b", "pin-p5-c"]
+        for slug in slugs:
+            project = self._project_for(db, uuid.UUID(user_id), slug)
+            self._pin(client, token, project.id)
+
+        items = client.get("/api/v1/users/pinuser5/pinned-projects").json()["items"]
+        assert [item["position"] for item in items] == [0, 1, 2]
+        assert [item["project"]["slug"] for item in items] == slugs
+
+    def test_unpinning_the_middle_compacts_positions(self, client, db, register_and_login):
+        user_id, token = register_and_login("pin6@example.com", "pinuser6")
+
+        projects = [self._project_for(db, uuid.UUID(user_id), f"pin-p6-{i}") for i in range(3)]
+        for project in projects:
+            self._pin(client, token, project.id)
+
+        removed = client.delete(
+            f"/api/v1/users/me/pinned-projects/{projects[1].id}", headers=self._auth(token)
+        )
+        assert removed.status_code == 204
+
+        items = client.get("/api/v1/users/pinuser6/pinned-projects").json()["items"]
+        assert [item["position"] for item in items] == [0, 1]
+        assert [item["project"]["slug"] for item in items] == ["pin-p6-0", "pin-p6-2"]
+
+    def test_unpinning_something_not_pinned_is_404(self, client, register_and_login):
+        _, token = register_and_login("pin7@example.com", "pinuser7")
+        response = client.delete(
+            f"/api/v1/users/me/pinned-projects/{uuid.uuid4()}", headers=self._auth(token)
+        )
+        assert response.status_code == 404
+
+    def test_private_project_cannot_be_pinned(self, client, db, register_and_login):
+        user_id, token = register_and_login("pin8@example.com", "pinuser8")
+        project = self._project_for(
+            db, uuid.UUID(user_id), "pin-p8", visibility=ProjectVisibility.PRIVATE
+        )
+
+        response = self._pin(client, token, project.id)
+        assert response.status_code == 400
+
+    def test_archived_project_cannot_be_pinned(self, client, db, register_and_login):
+        user_id, token = register_and_login("pin9@example.com", "pinuser9")
+        project = self._project_for(db, uuid.UUID(user_id), "pin-p9", is_archived=True)
+
+        assert self._pin(client, token, project.id).status_code == 400
+
+    def test_cannot_pin_someone_elses_project(self, client, db, register_and_login):
+        owner_id, _ = register_and_login("pin10@example.com", "pinuser10")
+        project = self._project_for(db, uuid.UUID(owner_id), "pin-p10")
+
+        _, outsider_token = register_and_login("pin11@example.com", "pinuser11")
+        assert self._pin(client, outsider_token, project.id).status_code == 403
+
+    def test_replace_sets_the_exact_order(self, client, db, register_and_login):
+        user_id, token = register_and_login("pin12@example.com", "pinuser12")
+        projects = [self._project_for(db, uuid.UUID(user_id), f"pin-p12-{i}") for i in range(3)]
+
+        for project in projects:
+            self._pin(client, token, project.id)
+
+        reordered = [projects[2].id, projects[0].id, projects[1].id]
+        response = client.put(
+            "/api/v1/users/me/pinned-projects",
+            json={"project_ids": [str(p) for p in reordered]},
+            headers=self._auth(token),
+        )
+        assert response.status_code == 200
+
+        items = response.json()["items"]
+        assert [item["position"] for item in items] == [0, 1, 2]
+        assert [item["project_id"] for item in items] == [str(p) for p in reordered]
+
+    def test_replace_rejects_the_whole_batch_on_one_bad_project(
+        self, client, db, register_and_login
+    ):
+        user_id, token = register_and_login("pin13@example.com", "pinuser13")
+        mine = self._project_for(db, uuid.UUID(user_id), "pin-p13-mine")
+        self._pin(client, token, mine.id)
+
+        other_id, _ = register_and_login("pin14@example.com", "pinuser14")
+        theirs = self._project_for(db, uuid.UUID(other_id), "pin-p13-theirs")
+
+        response = client.put(
+            "/api/v1/users/me/pinned-projects",
+            json={"project_ids": [str(mine.id), str(theirs.id)]},
+            headers=self._auth(token),
+        )
+        assert response.status_code == 403
+
+        # Nothing was written: the original pin is untouched.
+        items = client.get("/api/v1/users/pinuser13/pinned-projects").json()["items"]
+        assert len(items) == 1
+        assert items[0]["project_id"] == str(mine.id)
+
+    def test_replace_rejects_duplicates(self, client, db, register_and_login):
+        user_id, token = register_and_login("pin15@example.com", "pinuser15")
+        project = self._project_for(db, uuid.UUID(user_id), "pin-p15")
+
+        response = client.put(
+            "/api/v1/users/me/pinned-projects",
+            json={"project_ids": [str(project.id), str(project.id)]},
+            headers=self._auth(token),
+        )
+        assert response.status_code == 400
+        assert "more than once" in response.json()["detail"]
+
+    def test_replace_with_an_empty_list_clears_pins(self, client, db, register_and_login):
+        user_id, token = register_and_login("pin16@example.com", "pinuser16")
+        project = self._project_for(db, uuid.UUID(user_id), "pin-p16")
+        self._pin(client, token, project.id)
+
+        response = client.put(
+            "/api/v1/users/me/pinned-projects",
+            json={"project_ids": []},
+            headers=self._auth(token),
+        )
+        assert response.status_code == 200
+        assert response.json()["total"] == 0
+
+    def test_replace_over_the_limit_is_rejected(self, client, db, register_and_login):
+        user_id, token = register_and_login("pin17@example.com", "pinuser17")
+        ids = [str(uuid.uuid4()) for _ in range(MAX_PINNED_PROJECTS + 1)]
+
+        response = client.put(
+            "/api/v1/users/me/pinned-projects",
+            json={"project_ids": ids},
+            headers=self._auth(token),
+        )
+        assert response.status_code == 422
+
+    def test_me_endpoint_returns_your_pins(self, client, db, register_and_login):
+        user_id, token = register_and_login("pin18@example.com", "pinuser18")
+        project = self._project_for(db, uuid.UUID(user_id), "pin-p18")
+        self._pin(client, token, project.id)
+
+        response = client.get("/api/v1/users/me/pinned-projects", headers=self._auth(token))
+        assert response.status_code == 200
+        assert response.json()["total"] == 1
+
+    def test_a_user_with_no_pins_returns_an_empty_list(self, client, register_and_login):
+        register_and_login("pin19@example.com", "pinuser19")
+        response = client.get("/api/v1/users/pinuser19/pinned-projects")
+        assert response.status_code == 200
+        assert response.json() == {"items": [], "total": 0, "max_pins": MAX_PINNED_PROJECTS}

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -34,16 +34,16 @@ export type {
   SEARCH_CATEGORIES,
 } from "./modules/search";
 export { activitiesApi } from "./modules/activities";
+export { collectionsApi } from "./modules/collections";
+export { recommendationsApi, fallbackTechStack } from "./modules/recommendations";
+export type { TechStackRecommendation, TechStackResponse } from "./modules/recommendations";
+export { bookmarksApi } from "./modules/bookmarks";
 export { pinnedProjectsApi, MAX_PINNED_PROJECTS } from "./modules/pinnedProjects";
 export type {
   PinnedProject,
   PinnedProjectList,
   PinnedProjectSummary,
 } from "./modules/pinnedProjects";
-export { collectionsApi } from "./modules/collections";
-export { recommendationsApi, fallbackTechStack } from "./modules/recommendations";
-export type { TechStackRecommendation, TechStackResponse } from "./modules/recommendations";
-export { bookmarksApi } from "./modules/bookmarks";
 export { issuesApi } from "./modules/issues";
 export type {
   Issue,

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -34,6 +34,12 @@ export type {
   SEARCH_CATEGORIES,
 } from "./modules/search";
 export { activitiesApi } from "./modules/activities";
+export { pinnedProjectsApi, MAX_PINNED_PROJECTS } from "./modules/pinnedProjects";
+export type {
+  PinnedProject,
+  PinnedProjectList,
+  PinnedProjectSummary,
+} from "./modules/pinnedProjects";
 export { collectionsApi } from "./modules/collections";
 export { recommendationsApi, fallbackTechStack } from "./modules/recommendations";
 export type { TechStackRecommendation, TechStackResponse } from "./modules/recommendations";

--- a/frontend/src/api/modules/pinnedProjects.ts
+++ b/frontend/src/api/modules/pinnedProjects.ts
@@ -1,0 +1,67 @@
+import { api } from "../client";
+
+/** Server-enforced cap; echoed back on every list response as `max_pins`. */
+export const MAX_PINNED_PROJECTS = 6;
+
+/** The slice of a project a profile card needs — not the full project. */
+export interface PinnedProjectSummary {
+  id: string;
+  title: string;
+  slug: string;
+  tagline: string | null;
+  stage: string | null;
+  tech_stack: string | null;
+  tags: string[] | null;
+  logo_url: string | null;
+  banner_url: string | null;
+  stars: number;
+  views: number;
+}
+
+export interface PinnedProject {
+  id: string;
+  user_id: string;
+  project_id: string;
+  /** 0-based and contiguous — the server compacts after every removal. */
+  position: number;
+  project: PinnedProjectSummary | null;
+  created_at: string;
+}
+
+export interface PinnedProjectList {
+  items: PinnedProject[];
+  total: number;
+  max_pins: number;
+}
+
+export const pinnedProjectsApi = {
+  getForUser: (username: string) =>
+    api.get<PinnedProjectList>(`/api/v1/users/${encodeURIComponent(username)}/pinned-projects`),
+
+  getMine: () => api.get<PinnedProjectList>("/api/v1/users/me/pinned-projects", { auth: true }),
+
+  /** Appends after any existing pins. 409 if already pinned, 400 at the cap. */
+  pin: (projectId: string) =>
+    api.post<PinnedProject>(
+      "/api/v1/users/me/pinned-projects",
+      { project_id: projectId },
+      { auth: true },
+    ),
+
+  /**
+   * Replaces the whole pinned set in the given order — what drag-and-drop
+   * wants. The server validates the batch before writing, so a rejected
+   * request leaves the previous order intact.
+   */
+  replace: (projectIds: string[]) =>
+    api.put<PinnedProjectList>(
+      "/api/v1/users/me/pinned-projects",
+      { project_ids: projectIds },
+      { auth: true },
+    ),
+
+  unpin: (projectId: string) =>
+    api.delete<void>(`/api/v1/users/me/pinned-projects/${encodeURIComponent(projectId)}`, {
+      auth: true,
+    }),
+};

--- a/frontend/src/components/profile/PinnedProjectsCard.tsx
+++ b/frontend/src/components/profile/PinnedProjectsCard.tsx
@@ -1,0 +1,106 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { Star, Eye, Pin } from "lucide-react";
+import { pinnedProjectsApi, type PinnedProject } from "@/api/modules/pinnedProjects";
+import { Card, Skeleton, TagChip } from "@/components/shared/primitives";
+import { cn } from "@/lib/utils";
+
+interface PinnedProjectsCardProps {
+  username: string;
+  /** Show the empty-state prompt. Only useful on your own profile. */
+  isOwnProfile?: boolean;
+  className?: string;
+}
+
+function PinnedProjectRow({ pin }: { pin: PinnedProject }) {
+  const project = pin.project;
+  if (!project) return null;
+
+  return (
+    <Link
+      to="/projects/$projectId"
+      params={{ projectId: project.id }}
+      className="block rounded-lg border border-border p-3 transition-colors hover:border-primary/40 hover:bg-muted/40"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="truncate text-[13px] font-semibold text-foreground">{project.title}</p>
+          {project.tagline ? (
+            <p className="mt-0.5 line-clamp-2 text-[12px] text-muted-foreground">
+              {project.tagline}
+            </p>
+          ) : null}
+        </div>
+        {project.stage ? <TagChip className="shrink-0 capitalize">{project.stage}</TagChip> : null}
+      </div>
+
+      <div className="mt-2 flex items-center gap-3 text-[11px] text-muted-foreground">
+        <span className="inline-flex items-center gap-1">
+          <Star className="h-3 w-3" aria-hidden="true" />
+          {project.stars}
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <Eye className="h-3 w-3" aria-hidden="true" />
+          {project.views}
+        </span>
+      </div>
+    </Link>
+  );
+}
+
+export function PinnedProjectsCard({
+  username,
+  isOwnProfile = false,
+  className,
+}: PinnedProjectsCardProps) {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["pinned-projects", username],
+    queryFn: () => pinnedProjectsApi.getForUser(username),
+    staleTime: 60 * 1000,
+    retry: 1,
+  });
+
+  // A profile with nothing pinned should not grow an empty card for visitors —
+  // only the owner needs the nudge to pin something.
+  const hasPins = (data?.items.length ?? 0) > 0;
+  if (!isLoading && !isError && !hasPins && !isOwnProfile) return null;
+
+  return (
+    <Card className={cn("p-4", className)}>
+      <div className="flex items-center gap-2">
+        <Pin className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
+        <p className="text-[13px] font-semibold text-foreground">Pinned Projects</p>
+      </div>
+
+      {isLoading ? (
+        <div className="mt-3 space-y-2">
+          <Skeleton className="h-16 w-full" />
+          <Skeleton className="h-16 w-full" />
+        </div>
+      ) : null}
+
+      {isError ? (
+        <p className="mt-3 text-[12px] text-muted-foreground">
+          Pinned projects are unavailable right now.
+        </p>
+      ) : null}
+
+      {!isLoading && !isError && !hasPins ? (
+        <p className="mt-3 text-[12px] text-muted-foreground">
+          Nothing pinned yet. Pin up to {data?.max_pins ?? 6} projects to feature them at the top of
+          your profile.
+        </p>
+      ) : null}
+
+      {hasPins ? (
+        <div className="mt-3 space-y-2">
+          {data!.items.map((pin) => (
+            <PinnedProjectRow key={pin.id} pin={pin} />
+          ))}
+        </div>
+      ) : null}
+    </Card>
+  );
+}
+
+export default PinnedProjectsCard;

--- a/frontend/src/mocks/seed.ts
+++ b/frontend/src/mocks/seed.ts
@@ -40,7 +40,6 @@ export interface Builder {
   publicEmail?: string;
   verified?: boolean;
   premium?: boolean;
-  pinnedProjects?: string[];
   contributions?: number;
   followers?: number;
   following?: number;
@@ -237,7 +236,6 @@ export const builders: Builder[] = [
     followers: 238,
     following: 124,
     language: ["English", "Hindi"],
-    pinnedProjects: ["AI Chatbot", "DevOps Dashboard"],
     experience: [
       {
         company: "Google",

--- a/frontend/src/routes/_app.profile.$username.tsx
+++ b/frontend/src/routes/_app.profile.$username.tsx
@@ -32,6 +32,7 @@ import { ProfileCompletionChecklist } from "@/components/profile/ProfileCompleti
 import { FollowButton } from "@/components/shared/FollowButton";
 import { useFollowStatus } from "@/hooks/useFollow";
 import { ActivityTimeline } from "@/components/profile/ActivityTimeline";
+import { PinnedProjectsCard } from "@/components/profile/PinnedProjectsCard";
 
 export const Route = createFileRoute("/_app/profile/$username")({
   head: ({ params }) => ({
@@ -536,16 +537,7 @@ function ProfilePage() {
           <SkillsCard skills={b.profileSkills ?? []} />
           <ExperienceCard role={b.role} company={b.company} experienceLevel={b.experienceLevel} />
 
-          {b.pinnedProjects?.length ? (
-            <Card className="p-4">
-              <p className="text-[13px] font-semibold text-foreground">Pinned Projects</p>
-              <div className="mt-3 flex flex-wrap gap-2">
-                {b.pinnedProjects.map((project) => (
-                  <TagChip key={project}>{project}</TagChip>
-                ))}
-              </div>
-            </Card>
-          ) : null}
+          <PinnedProjectsCard username={b.handle} isOwnProfile={me} />
 
           {b.badges && b.badges.length > 0 && (
             <Card className="p-4">

--- a/frontend/src/routes/_app.profile.$username.tsx
+++ b/frontend/src/routes/_app.profile.$username.tsx
@@ -28,11 +28,11 @@ import { analyticsApi } from "@/api/modules/analytics";
 import SkillsCard from "@/components/profile/SkillsCard";
 import ExperienceCard from "@/components/profile/ExperienceCard";
 import { ProfileViewersList } from "@/components/profile/ProfileViewersList";
+import { PinnedProjectsCard } from "@/components/profile/PinnedProjectsCard";
 import { ProfileCompletionChecklist } from "@/components/profile/ProfileCompletionChecklist";
 import { FollowButton } from "@/components/shared/FollowButton";
 import { useFollowStatus } from "@/hooks/useFollow";
 import { ActivityTimeline } from "@/components/profile/ActivityTimeline";
-import { PinnedProjectsCard } from "@/components/profile/PinnedProjectsCard";
 
 export const Route = createFileRoute("/_app/profile/$username")({
   head: ({ params }) => ({


### PR DESCRIPTION
Closes #1042

## The problem

`_app.profile.$username.tsx` has rendered a "Pinned Projects" card since it was written:

```tsx
{b.pinnedProjects?.length ? (
  <Card className="p-4">
    <p ...>Pinned Projects</p>
```

`pinnedProjects` came from `mocks/seed.ts` — a hardcoded `["AI Chatbot", "DevOps Dashboard"]` on exactly one seeded builder. Every profile on the platform showed either those same two fake strings or nothing at all, and there was no table, no endpoint, and no way for a real user to pin anything. The strings were not even links.

This makes it real.

## Data model

`pinned_projects` — `user_id`, `project_id`, `position` (0-based, contiguous), `created_at`. Unique on `(user_id, project_id)`, indexed on `(user_id, position)` for the read path.

**There is deliberately no unique constraint on `(user_id, position)`.** It looks like the obvious thing to add, and it is a trap: any reorder has to pass through intermediate states where two rows briefly share a slot, and a non-deferrable unique index rejects the write halfway through. Positions are instead owned by the service, which compacts on every removal so the sequence stays `0..n-1`. A sparse sequence would leak out through the API and force every client to renumber for itself. `(user_id, project_id)` *is* enforced in the database, because unlike position it never legitimately collides.

## The rules, and why

A pin is a public shop-window, not a project list. Everything else follows from that:

- **You must own or be an active member of the project.** You cannot decorate your profile with work you had no part in.
- **Private projects cannot be pinned, even by their owner.** A visitor who clicks a pin and hits a 403 has been shown a dead link. If you want it on your profile, make it public.
- **Archived projects cannot be pinned.**
- **Ownership is checked before visibility.** A stranger enumerating project ids gets "you can only pin projects you own", not a message that confirms the id exists and happens to be private.
- **Cap of 6** — enough to show range, few enough that a visitor reads all of them.

## Endpoints

```
GET    /api/v1/users/{username}/pinned-projects   public, ordered
GET    /api/v1/users/me/pinned-projects
POST   /api/v1/users/me/pinned-projects           {project_id}, appends
PUT    /api/v1/users/me/pinned-projects           {project_ids: [...]}, replaces in order
DELETE /api/v1/users/me/pinned-projects/{project_id}
```

`PUT` is the one a drag-and-drop UI wants: one call, one final state, nothing for the client to reconstruct. **The whole batch is validated before a single row is touched.** A partial write here is particularly bad — it leaves the profile in an order the user never asked for and, since the request appeared to fail, would not think to go and check.

## Frontend

- `pinnedProjectsApi` typed client.
- `PinnedProjectsCard` — real project cards with tagline, stage chip, star and view counts, each linking through to the project. Replaces the mock block on the profile route.
- The card **hides itself entirely** for visitors when nothing is pinned, rather than growing an empty card on every profile that has not used the feature. The owner gets a prompt instead, because they are the only one who can act on it.
- `pinnedProjects` deleted from the `Builder` type and the seed fixture, so the mock cannot quietly come back.

## Migration

`b6d3f2a71c48`, branching from `d4e5f6a7b8c9`. Single head. `CHECK (position >= 0)` and the unique constraint are enforced at the database level; downgrade drops cleanly.

## Tests

28 backend cases:

- **The cap** — six pins succeed, the seventh is a 400 naming the limit.
- **Duplicate** — second pin of the same project is a 409, and the listing still shows exactly one row.
- **Eligibility** — private rejected, archived rejected, someone else's project rejected, ownership checked ahead of visibility.
- **Compaction** — after unpinning the middle of three, positions are `[0, 1]` and the surviving slugs are the right two.
- **Batch atomicity** — a `PUT` containing one ineligible project returns 403 *and the previous single pin is still there, unchanged*. That assertion is the point of the test.
- **Reorder** — `PUT` with a rotated list produces exactly that order at positions 0, 1, 2.
- Empty list clears pins; duplicates in the batch are a 400; over-limit is a 422 at the schema.

```
backend:  28 passed
frontend: 468 passed (full suite)
tsc --noEmit: clean   eslint: clean
```
