### PR TITLE
feat(projects): add publishable release notes (#1043)

### DIFF
--- a/backend/alembic/versions/c8f4a1e93b27_create_project_releases_table.py
+++ b/backend/alembic/versions/c8f4a1e93b27_create_project_releases_table.py
@@ -1,0 +1,119 @@
+"""create project releases table
+
+Revision ID: c8f4a1e93b27
+Revises: d4e5f6a7b8c9
+Create Date: 2026-08-10 21:05:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+# revision identifiers, used by Alembic.
+revision: str = "c8f4a1e93b27"
+down_revision: Union[str, Sequence[str], None] = "d4e5f6a7b8c9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+release_type_enum = sa.Enum(
+    "MAJOR", "MINOR", "PATCH", "PRERELEASE", name="releasetype"
+)
+release_status_enum = sa.Enum("DRAFT", "PUBLISHED", name="releasestatus")
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    release_type_enum.create(bind, checkfirst=True)
+    release_status_enum.create(bind, checkfirst=True)
+
+    op.create_table(
+        "project_releases",
+        sa.Column("id", UUID(as_uuid=True), nullable=False),
+        sa.Column("project_id", UUID(as_uuid=True), nullable=False),
+        # A release outlives the person who cut it, so the author reference is
+        # nulled rather than cascading the row away.
+        sa.Column("author_id", UUID(as_uuid=True), nullable=True),
+        # Free-form on purpose: v1.2.0, 2026.08 and beta-3 are all legitimate.
+        # Uniqueness per project is enforced case-insensitively in the service.
+        sa.Column("version", sa.String(length=50), nullable=False),
+        sa.Column("title", sa.String(length=200), nullable=False),
+        sa.Column("body", sa.Text(), nullable=True),
+        sa.Column(
+            "highlights", sa.JSON(), server_default=sa.text("'[]'"), nullable=False
+        ),
+        sa.Column("release_type", release_type_enum, nullable=False),
+        sa.Column("status", release_status_enum, nullable=False),
+        sa.Column("published_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "is_pinned", sa.Boolean(), server_default=sa.text("false"), nullable=False
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["author_id"], ["users.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_index(
+        op.f("ix_project_releases_project_id"),
+        "project_releases",
+        ["project_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_project_releases_author_id"),
+        "project_releases",
+        ["author_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_project_releases_status"), "project_releases", ["status"], unique=False
+    )
+    op.create_index(
+        op.f("ix_project_releases_published_at"),
+        "project_releases",
+        ["published_at"],
+        unique=False,
+    )
+
+    # The public listing: one project's published releases, newest first.
+    op.create_index(
+        "ix_project_releases_project_published",
+        "project_releases",
+        ["project_id", "published_at"],
+        unique=False,
+    )
+    # The duplicate-version check and the maintainer's draft list.
+    op.create_index(
+        "ix_project_releases_project_status",
+        "project_releases",
+        ["project_id", "status"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_project_releases_project_status", table_name="project_releases")
+    op.drop_index("ix_project_releases_project_published", table_name="project_releases")
+    op.drop_index(op.f("ix_project_releases_published_at"), table_name="project_releases")
+    op.drop_index(op.f("ix_project_releases_status"), table_name="project_releases")
+    op.drop_index(op.f("ix_project_releases_author_id"), table_name="project_releases")
+    op.drop_index(op.f("ix_project_releases_project_id"), table_name="project_releases")
+    op.drop_table("project_releases")
+
+    bind = op.get_bind()
+    release_status_enum.drop(bind, checkfirst=True)
+    release_type_enum.drop(bind, checkfirst=True)

--- a/backend/alembic/versions/c8f4a1e93b27_create_project_releases_table.py
+++ b/backend/alembic/versions/c8f4a1e93b27_create_project_releases_table.py
@@ -10,6 +10,7 @@ from typing import Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import UUID
 
 # revision identifiers, used by Alembic.
@@ -18,10 +19,22 @@ down_revision: Union[str, Sequence[str], None] = "d4e5f6a7b8c9"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
-release_type_enum = sa.Enum(
-    "MAJOR", "MINOR", "PATCH", "PRERELEASE", name="releasetype"
+# create_type=False: the types are created explicitly in upgrade() with
+# checkfirst, so create_table must not try to emit CREATE TYPE a second time.
+release_type_enum = postgresql.ENUM(
+    "MAJOR",
+    "MINOR",
+    "PATCH",
+    "PRERELEASE",
+    name="releasetype",
+    create_type=False,
 )
-release_status_enum = sa.Enum("DRAFT", "PUBLISHED", name="releasestatus")
+release_status_enum = postgresql.ENUM(
+    "DRAFT",
+    "PUBLISHED",
+    name="releasestatus",
+    create_type=False,
+)
 
 
 def upgrade() -> None:

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -28,10 +28,10 @@ from app.routers import (
     project_members,
     project_comments,
     project_milestones,
-    project_releases,
     project_tags,
     project_documents,
     project_dashboards,
+    project_releases,
     projects,
     recommendations,
     repositories,
@@ -77,7 +77,6 @@ api_v1_router.include_router(project_documents.router)
 api_v1_router.include_router(project_dashboards.router)
 api_v1_router.include_router(project_milestones.router)
 api_v1_router.include_router(project_comments.router)
-api_v1_router.include_router(project_releases.router)
 api_v1_router.include_router(
     builder_flares.router, prefix="/flare", tags=["Builder's Flare"]
 )
@@ -118,6 +117,7 @@ api_v1_router.include_router(
     tags=["Contributor Matching"],
 )
 api_v1_router.include_router(repositories.router)
+api_v1_router.include_router(project_releases.router)
 api_v1_router.include_router(organizations.router)
 api_v1_router.include_router(applications.router)
 api_v1_router.include_router(skills.router)

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -28,6 +28,7 @@ from app.routers import (
     project_members,
     project_comments,
     project_milestones,
+    project_releases,
     project_tags,
     project_documents,
     project_dashboards,
@@ -76,6 +77,7 @@ api_v1_router.include_router(project_documents.router)
 api_v1_router.include_router(project_dashboards.router)
 api_v1_router.include_router(project_milestones.router)
 api_v1_router.include_router(project_comments.router)
+api_v1_router.include_router(project_releases.router)
 api_v1_router.include_router(
     builder_flares.router, prefix="/flare", tags=["Builder's Flare"]
 )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -553,12 +553,12 @@ app.include_router(
     project_milestones.router, prefix="/api", tags=["Project Milestones"]
 )
 app.include_router(project_milestones.router, prefix="/api", tags=["Project Milestones"])
-from app.routers import project_releases
-
-app.include_router(project_releases.router, prefix="/api", tags=["Project Releases"])
 from app.routers import calendar as calendar_router
 app.include_router(calendar_router.router, prefix="/api", tags=["Calendar"])
 app.include_router(analytics.router, prefix="/api", tags=["Analytics"])
+from app.routers import project_releases
+
+app.include_router(project_releases.router, prefix="/api", tags=["Project Releases"])
 app.include_router(builder_flares.router, prefix="/api/flare", tags=["Builder's Flare"])
 app.include_router(messages.router, prefix="/api/messages", tags=["Messages"])
 app.include_router(message_drafts.router, prefix="/api", tags=["Message Drafts"])

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -553,6 +553,9 @@ app.include_router(
     project_milestones.router, prefix="/api", tags=["Project Milestones"]
 )
 app.include_router(project_milestones.router, prefix="/api", tags=["Project Milestones"])
+from app.routers import project_releases
+
+app.include_router(project_releases.router, prefix="/api", tags=["Project Releases"])
 from app.routers import calendar as calendar_router
 app.include_router(calendar_router.router, prefix="/api", tags=["Calendar"])
 app.include_router(analytics.router, prefix="/api", tags=["Analytics"])

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -91,3 +91,4 @@ from .global_announcement import GlobalAnnouncement, AnnouncementSeverity, Targe
 from .post import Post  # noqa: F401
 
 from .project_comment import ProjectComment  # noqa: F401
+from .project_release import ProjectRelease, ReleaseStatus, ReleaseType  # noqa: F401

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -86,9 +86,9 @@ from .profile_suggestion import ProfileSuggestionDismissal
 from .request_log import RequestLog  # noqa: F401
 from .background_job import BackgroundJob, JobStatus
 from .badge import Badge, UserBadge  # noqa: F401
+from .project_release import ProjectRelease, ReleaseStatus, ReleaseType  # noqa: F401
 from .centralized_analytics import CentralizedAnalyticsEvent, AnalyticsEventType  # noqa: F401
 from .global_announcement import GlobalAnnouncement, AnnouncementSeverity, TargetAudience  # noqa: F401
 from .post import Post  # noqa: F401
 
 from .project_comment import ProjectComment  # noqa: F401
-from .project_release import ProjectRelease, ReleaseStatus, ReleaseType  # noqa: F401

--- a/backend/app/models/project_release.py
+++ b/backend/app/models/project_release.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Index,
+    String,
+    Text,
+    func,
+)
+from sqlalchemy import Enum as SqlEnum
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database.base import Base
+
+MAX_HIGHLIGHTS = 10
+MAX_HIGHLIGHT_LENGTH = 200
+
+
+class ReleaseType(str, Enum):
+    MAJOR = "major"
+    MINOR = "minor"
+    PATCH = "patch"
+    PRERELEASE = "prerelease"
+
+
+class ReleaseStatus(str, Enum):
+    DRAFT = "draft"
+    PUBLISHED = "published"
+
+
+class ProjectRelease(Base):
+    """
+    A published changelog entry for a project (#1043).
+
+    Distinct from ``project_versions`` (#606), which snapshots every edit for
+    internal history. A release is something the project chooses to announce:
+    it has a version people quote, a body people read, and a publish moment.
+    """
+
+    __tablename__ = "project_releases"
+
+    # ==========================================================
+    # Primary Key
+    # ==========================================================
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+    # ==========================================================
+    # Foreign Keys
+    # ==========================================================
+
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    # A release outlives the person who cut it. SET NULL rather than CASCADE
+    # so a maintainer leaving does not erase the project's history.
+    author_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
+    # ==========================================================
+    # Identity
+    # ==========================================================
+
+    # Free-form on purpose: v1.2.0, 2026.08, beta-3 are all legitimate. The
+    # service enforces uniqueness per project case-insensitively.
+    version: Mapped[str] = mapped_column(
+        String(50),
+        nullable=False,
+    )
+
+    title: Mapped[str] = mapped_column(
+        String(200),
+        nullable=False,
+    )
+
+    body: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+    )
+
+    # Short bullet points for the collapsed card, so a reader gets the gist
+    # without expanding the full markdown body.
+    highlights: Mapped[list[Any]] = mapped_column(
+        JSON,
+        default=list,
+        server_default="[]",
+        nullable=False,
+    )
+
+    # ==========================================================
+    # Classification & lifecycle
+    # ==========================================================
+
+    release_type: Mapped[ReleaseType] = mapped_column(
+        SqlEnum(ReleaseType),
+        default=ReleaseType.MINOR,
+        nullable=False,
+    )
+
+    status: Mapped[ReleaseStatus] = mapped_column(
+        SqlEnum(ReleaseStatus),
+        default=ReleaseStatus.DRAFT,
+        nullable=False,
+        index=True,
+    )
+
+    published_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        index=True,
+    )
+
+    is_pinned: Mapped[bool] = mapped_column(
+        Boolean,
+        default=False,
+        server_default="false",
+        nullable=False,
+    )
+
+    # ==========================================================
+    # Relationships
+    # ==========================================================
+
+    project = relationship("Project", backref="releases")
+    author = relationship("User", backref="authored_releases")
+
+    # ==========================================================
+    # Audit
+    # ==========================================================
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    __table_args__ = (
+        # The public listing: one project's published releases, newest first.
+        Index("ix_project_releases_project_published", "project_id", "published_at"),
+        # The duplicate-version check and the maintainer's draft list.
+        Index("ix_project_releases_project_status", "project_id", "status"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<ProjectRelease(project={self.project_id}, version='{self.version}', status={self.status})>"

--- a/backend/app/routers/project_releases.py
+++ b/backend/app/routers/project_releases.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+"""
+API Router for project release notes (#1043).
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, Query, Response, status
+from sqlalchemy.orm import Session
+
+from app.dependencies import get_current_active_user, get_database, get_optional_current_user
+from app.models.user import User
+from app.schemas.project_release import (
+    ReleaseCreate,
+    ReleaseList,
+    ReleaseResponse,
+    ReleaseUpdate,
+)
+from app.services.project_release_service import ProjectReleaseService
+
+router = APIRouter(
+    prefix="/projects/{project_id}/releases",
+    tags=["Project Releases"],
+)
+
+
+@router.get(
+    "",
+    response_model=ReleaseList,
+    summary="List a project's releases",
+    description=(
+        "Published releases, pinned first then newest. Maintainers can pass "
+        "`include_drafts=true` to see unpublished entries; for everyone else "
+        "the flag is ignored."
+    ),
+)
+@router.get("/", response_model=ReleaseList, include_in_schema=False)
+def list_releases(
+    project_id: uuid.UUID,
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    include_drafts: bool = Query(False, description="Maintainers only; ignored otherwise"),
+    db: Session = Depends(get_database),
+    current_user: User | None = Depends(get_optional_current_user),
+) -> ReleaseList:
+    project = ProjectReleaseService.get_project_or_404(db, project_id)
+
+    # Silently downgrading the flag rather than 403-ing keeps the public
+    # listing usable for clients that always send it.
+    can_see_drafts = include_drafts and ProjectReleaseService.is_maintainer(db, project, current_user)
+
+    items, total = ProjectReleaseService.list_releases(
+        db,
+        project_id=project_id,
+        limit=limit,
+        offset=offset,
+        include_drafts=can_see_drafts,
+    )
+    return ReleaseList(
+        items=[ReleaseResponse.model_validate(item) for item in items],
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.post(
+    "",
+    response_model=ReleaseResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a release",
+    description=(
+        "Defaults to `draft`. Pass `status: published` to publish immediately, "
+        "which also announces it to followers."
+    ),
+    responses={
+        403: {"description": "Not a project maintainer"},
+        409: {"description": "That version already exists on this project"},
+    },
+)
+@router.post("/", response_model=ReleaseResponse, status_code=status.HTTP_201_CREATED, include_in_schema=False)
+def create_release(
+    project_id: uuid.UUID,
+    payload: ReleaseCreate,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_active_user),
+) -> ReleaseResponse:
+    release = ProjectReleaseService.create_release(
+        db, project_id=project_id, payload=payload, actor=current_user
+    )
+    return ReleaseResponse.model_validate(release)
+
+
+@router.get(
+    "/latest",
+    response_model=ReleaseResponse,
+    summary="Get the newest published release",
+    responses={404: {"description": "No published releases yet"}},
+)
+def get_latest_release(
+    project_id: uuid.UUID,
+    db: Session = Depends(get_database),
+) -> ReleaseResponse:
+    ProjectReleaseService.get_project_or_404(db, project_id)
+    return ReleaseResponse.model_validate(ProjectReleaseService.get_latest(db, project_id))
+
+
+@router.get(
+    "/{release_id}",
+    response_model=ReleaseResponse,
+    summary="Get one release",
+    description="A draft is a 404 for anyone who is not a maintainer.",
+)
+def get_release(
+    project_id: uuid.UUID,
+    release_id: uuid.UUID,
+    db: Session = Depends(get_database),
+    current_user: User | None = Depends(get_optional_current_user),
+) -> ReleaseResponse:
+    project = ProjectReleaseService.get_project_or_404(db, project_id)
+    is_maintainer = ProjectReleaseService.is_maintainer(db, project, current_user)
+
+    release = ProjectReleaseService.get_release_or_404(
+        db, project_id, release_id, viewer_is_maintainer=is_maintainer
+    )
+    return ReleaseResponse.model_validate(release)
+
+
+@router.patch(
+    "/{release_id}",
+    response_model=ReleaseResponse,
+    summary="Edit a release",
+    responses={409: {"description": "That version already exists on this project"}},
+)
+def update_release(
+    project_id: uuid.UUID,
+    release_id: uuid.UUID,
+    payload: ReleaseUpdate,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_active_user),
+) -> ReleaseResponse:
+    release = ProjectReleaseService.update_release(
+        db, project_id=project_id, release_id=release_id, payload=payload, actor=current_user
+    )
+    return ReleaseResponse.model_validate(release)
+
+
+@router.post(
+    "/{release_id}/publish",
+    response_model=ReleaseResponse,
+    summary="Publish a release",
+    description=(
+        "Sets `published_at` and announces the release to followers. "
+        "Idempotent — re-publishing does not move the date or announce twice."
+    ),
+)
+def publish_release(
+    project_id: uuid.UUID,
+    release_id: uuid.UUID,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_active_user),
+) -> ReleaseResponse:
+    release = ProjectReleaseService.publish(
+        db, project_id=project_id, release_id=release_id, actor=current_user
+    )
+    return ReleaseResponse.model_validate(release)
+
+
+@router.post(
+    "/{release_id}/pin",
+    response_model=ReleaseResponse,
+    summary="Pin a release to the top of the changelog",
+    description="Un-pins whichever release was pinned before. Published releases only.",
+    responses={400: {"description": "Release is still a draft"}},
+)
+def pin_release(
+    project_id: uuid.UUID,
+    release_id: uuid.UUID,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_active_user),
+) -> ReleaseResponse:
+    release = ProjectReleaseService.pin(
+        db, project_id=project_id, release_id=release_id, actor=current_user
+    )
+    return ReleaseResponse.model_validate(release)
+
+
+@router.delete(
+    "/{release_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete a release",
+)
+def delete_release(
+    project_id: uuid.UUID,
+    release_id: uuid.UUID,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_active_user),
+) -> Response:
+    ProjectReleaseService.delete_release(
+        db, project_id=project_id, release_id=release_id, actor=current_user
+    )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/schemas/project_release.py
+++ b/backend/app/schemas/project_release.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+"""
+Schemas for project release notes (#1043).
+"""
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from app.models.project_release import (
+    MAX_HIGHLIGHT_LENGTH,
+    MAX_HIGHLIGHTS,
+    ReleaseStatus,
+    ReleaseType,
+)
+
+
+def _clean_highlights(values: Optional[list[str]]) -> list[str]:
+    """Drop blanks, strip whitespace, and enforce the per-item length cap."""
+    if not values:
+        return []
+
+    cleaned: list[str] = []
+    for raw in values:
+        item = (raw or "").strip()
+        if not item:
+            continue
+        if len(item) > MAX_HIGHLIGHT_LENGTH:
+            raise ValueError(f"Each highlight must be {MAX_HIGHLIGHT_LENGTH} characters or fewer.")
+        cleaned.append(item)
+
+    if len(cleaned) > MAX_HIGHLIGHTS:
+        raise ValueError(f"At most {MAX_HIGHLIGHTS} highlights are allowed.")
+    return cleaned
+
+
+class ReleaseCreate(BaseModel):
+    version: str = Field(
+        ...,
+        min_length=1,
+        max_length=50,
+        description="Free-form version label: v1.2.0, 2026.08, beta-3. Unique per project.",
+    )
+    title: str = Field(..., min_length=1, max_length=200)
+    body: Optional[str] = Field(default=None, description="Markdown release notes")
+    highlights: list[str] = Field(default_factory=list, description="Short bullet points")
+    release_type: ReleaseType = Field(default=ReleaseType.MINOR)
+    # Defaults to draft: writing a changelog entry and announcing it are two
+    # different decisions, and conflating them means every typo is broadcast.
+    status: ReleaseStatus = Field(default=ReleaseStatus.DRAFT)
+
+    @field_validator("version", "title")
+    @classmethod
+    def _strip_required(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("This field cannot be blank.")
+        return cleaned
+
+    @field_validator("highlights")
+    @classmethod
+    def _validate_highlights(cls, value: list[str]) -> list[str]:
+        return _clean_highlights(value)
+
+
+class ReleaseUpdate(BaseModel):
+    version: Optional[str] = Field(default=None, min_length=1, max_length=50)
+    title: Optional[str] = Field(default=None, min_length=1, max_length=200)
+    body: Optional[str] = None
+    highlights: Optional[list[str]] = None
+    release_type: Optional[ReleaseType] = None
+
+    @field_validator("version", "title")
+    @classmethod
+    def _strip_optional(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("This field cannot be blank.")
+        return cleaned
+
+    @field_validator("highlights")
+    @classmethod
+    def _validate_highlights(cls, value: Optional[list[str]]) -> Optional[list[str]]:
+        if value is None:
+            return None
+        return _clean_highlights(value)
+
+
+class ReleaseAuthor(BaseModel):
+    id: uuid.UUID
+    username: str
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+    profile_image: Optional[str] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ReleaseResponse(BaseModel):
+    id: uuid.UUID
+    project_id: uuid.UUID
+    author_id: Optional[uuid.UUID] = None
+
+    version: str
+    title: str
+    body: Optional[str] = None
+    highlights: list[str] = Field(default_factory=list)
+
+    release_type: ReleaseType
+    status: ReleaseStatus
+    published_at: Optional[datetime] = None
+    is_pinned: bool = False
+
+    author: Optional[ReleaseAuthor] = None
+
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ReleaseList(BaseModel):
+    items: list[ReleaseResponse]
+    total: int
+    limit: int
+    offset: int

--- a/backend/app/services/project_release_service.py
+++ b/backend/app/services/project_release_service.py
@@ -1,0 +1,385 @@
+from __future__ import annotations
+
+"""
+Business logic for project release notes (#1043).
+"""
+
+import logging
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import HTTPException, status
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session, selectinload
+
+from app.models.activity import ActivityType
+from app.models.project import Project
+from app.models.project_member import MemberRole, ProjectMember
+from app.models.project_release import ProjectRelease, ReleaseStatus
+from app.models.user import User
+from app.schemas.project_release import ReleaseCreate, ReleaseUpdate
+from app.services.activity_service import ActivityService
+
+logger = logging.getLogger(__name__)
+
+MAINTAINER_ROLES = {
+    MemberRole.OWNER,
+    MemberRole.CO_OWNER,
+    MemberRole.ADMIN,
+    MemberRole.MAINTAINER,
+}
+
+
+class ProjectReleaseService:
+    """Draft, publish, pin and list a project's changelog entries."""
+
+    # ------------------------------------------------------------------
+    # Lookups & authorization
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def get_project_or_404(db: Session, project_id: uuid.UUID) -> Project:
+        project = db.get(Project, project_id)
+        if project is None or getattr(project, "deleted_at", None) is not None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Project not found",
+            )
+        return project
+
+    @staticmethod
+    def is_maintainer(db: Session, project: Project, user: User | None) -> bool:
+        if user is None:
+            return False
+        if getattr(user, "system_role", None) == "admin" or getattr(user, "role", None) == "admin":
+            return True
+        if project.owner_id == user.id:
+            return True
+
+        member = db.scalar(
+            select(ProjectMember).where(
+                ProjectMember.project_id == project.id,
+                ProjectMember.user_id == user.id,
+                ProjectMember.is_active.is_(True),
+            )
+        )
+        return member is not None and member.role in MAINTAINER_ROLES
+
+    @staticmethod
+    def require_maintainer(db: Session, project: Project, user: User) -> None:
+        if not ProjectReleaseService.is_maintainer(db, project, user):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Only project owners and maintainers can manage releases.",
+            )
+
+    @staticmethod
+    def get_release_or_404(
+        db: Session,
+        project_id: uuid.UUID,
+        release_id: uuid.UUID,
+        viewer_is_maintainer: bool = False,
+    ) -> ProjectRelease:
+        release = db.scalar(
+            select(ProjectRelease)
+            .where(ProjectRelease.id == release_id, ProjectRelease.project_id == project_id)
+            .options(selectinload(ProjectRelease.author))
+        )
+        if release is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Release not found",
+            )
+
+        # A draft is a 404, not a 403, for anyone who cannot see it. A 403
+        # confirms the release exists, which leaks the fact that something
+        # unannounced is in the pipeline -- and its id.
+        if release.status == ReleaseStatus.DRAFT and not viewer_is_maintainer:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Release not found",
+            )
+        return release
+
+    # ------------------------------------------------------------------
+    # Version uniqueness
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def assert_version_available(
+        db: Session,
+        project_id: uuid.UUID,
+        version: str,
+        exclude_release_id: uuid.UUID | None = None,
+    ) -> None:
+        """
+        Versions are unique per project, compared case-insensitively.
+
+        ``V1.0.0`` and ``v1.0.0`` are the same release to every human reading
+        the changelog, so treating them as distinct rows would produce a
+        changelog with two entries nobody can tell apart.
+        """
+        stmt = select(ProjectRelease.id).where(
+            ProjectRelease.project_id == project_id,
+            func.lower(ProjectRelease.version) == version.strip().lower(),
+        )
+        if exclude_release_id is not None:
+            stmt = stmt.where(ProjectRelease.id != exclude_release_id)
+
+        if db.scalar(stmt) is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Version '{version}' already exists for this project.",
+            )
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def create_release(
+        db: Session,
+        project_id: uuid.UUID,
+        payload: ReleaseCreate,
+        actor: User,
+    ) -> ProjectRelease:
+        project = ProjectReleaseService.get_project_or_404(db, project_id)
+        ProjectReleaseService.require_maintainer(db, project, actor)
+        ProjectReleaseService.assert_version_available(db, project_id, payload.version)
+
+        now = datetime.now(timezone.utc)
+        publishing = payload.status == ReleaseStatus.PUBLISHED
+
+        release = ProjectRelease(
+            id=uuid.uuid4(),
+            project_id=project_id,
+            author_id=actor.id,
+            version=payload.version,
+            title=payload.title,
+            body=payload.body,
+            highlights=payload.highlights,
+            release_type=payload.release_type,
+            status=payload.status,
+            published_at=now if publishing else None,
+            is_pinned=False,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(release)
+        db.flush()
+
+        if publishing:
+            ProjectReleaseService._record_publish_activity(db, project, release, actor)
+
+        db.commit()
+        db.refresh(release)
+        return release
+
+    @staticmethod
+    def update_release(
+        db: Session,
+        project_id: uuid.UUID,
+        release_id: uuid.UUID,
+        payload: ReleaseUpdate,
+        actor: User,
+    ) -> ProjectRelease:
+        project = ProjectReleaseService.get_project_or_404(db, project_id)
+        ProjectReleaseService.require_maintainer(db, project, actor)
+        release = ProjectReleaseService.get_release_or_404(
+            db, project_id, release_id, viewer_is_maintainer=True
+        )
+
+        data = payload.model_dump(exclude_unset=True)
+
+        if "version" in data:
+            ProjectReleaseService.assert_version_available(
+                db, project_id, data["version"], exclude_release_id=release.id
+            )
+
+        for field, value in data.items():
+            setattr(release, field, value)
+        release.updated_at = datetime.now(timezone.utc)
+
+        db.commit()
+        db.refresh(release)
+        return release
+
+    @staticmethod
+    def delete_release(db: Session, project_id: uuid.UUID, release_id: uuid.UUID, actor: User) -> None:
+        project = ProjectReleaseService.get_project_or_404(db, project_id)
+        ProjectReleaseService.require_maintainer(db, project, actor)
+        release = ProjectReleaseService.get_release_or_404(
+            db, project_id, release_id, viewer_is_maintainer=True
+        )
+
+        db.delete(release)
+        db.commit()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def publish(
+        db: Session,
+        project_id: uuid.UUID,
+        release_id: uuid.UUID,
+        actor: User,
+    ) -> ProjectRelease:
+        """
+        Publish a draft. Idempotent: re-publishing an already-published release
+        is a no-op rather than moving ``published_at``, so a double-clicked
+        button cannot rewrite the release date or fire a second announcement.
+        """
+        project = ProjectReleaseService.get_project_or_404(db, project_id)
+        ProjectReleaseService.require_maintainer(db, project, actor)
+        release = ProjectReleaseService.get_release_or_404(
+            db, project_id, release_id, viewer_is_maintainer=True
+        )
+
+        if release.status == ReleaseStatus.PUBLISHED:
+            return release
+
+        now = datetime.now(timezone.utc)
+        release.status = ReleaseStatus.PUBLISHED
+        release.published_at = now
+        release.updated_at = now
+        db.flush()
+
+        ProjectReleaseService._record_publish_activity(db, project, release, actor)
+
+        db.commit()
+        db.refresh(release)
+        return release
+
+    @staticmethod
+    def pin(
+        db: Session,
+        project_id: uuid.UUID,
+        release_id: uuid.UUID,
+        actor: User,
+    ) -> ProjectRelease:
+        """Pin one release, un-pinning whichever was pinned before."""
+        project = ProjectReleaseService.get_project_or_404(db, project_id)
+        ProjectReleaseService.require_maintainer(db, project, actor)
+        release = ProjectReleaseService.get_release_or_404(
+            db, project_id, release_id, viewer_is_maintainer=True
+        )
+
+        if release.status != ReleaseStatus.PUBLISHED:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Only a published release can be pinned.",
+            )
+
+        currently_pinned = db.scalars(
+            select(ProjectRelease).where(
+                ProjectRelease.project_id == project_id,
+                ProjectRelease.is_pinned.is_(True),
+                ProjectRelease.id != release.id,
+            )
+        ).all()
+        for other in currently_pinned:
+            other.is_pinned = False
+
+        release.is_pinned = True
+        release.updated_at = datetime.now(timezone.utc)
+
+        db.commit()
+        db.refresh(release)
+        return release
+
+    # ------------------------------------------------------------------
+    # Listing
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def list_releases(
+        db: Session,
+        project_id: uuid.UUID,
+        limit: int = 20,
+        offset: int = 0,
+        include_drafts: bool = False,
+    ) -> tuple[list[ProjectRelease], int]:
+        conditions = [ProjectRelease.project_id == project_id]
+        if not include_drafts:
+            conditions.append(ProjectRelease.status == ReleaseStatus.PUBLISHED)
+
+        total = int(db.scalar(select(func.count(ProjectRelease.id)).where(*conditions)) or 0)
+
+        stmt = (
+            select(ProjectRelease)
+            .where(*conditions)
+            .options(selectinload(ProjectRelease.author))
+            # Pinned first, then newest published. created_at is the tiebreak
+            # so drafts (no published_at) still order deterministically.
+            .order_by(
+                ProjectRelease.is_pinned.desc(),
+                ProjectRelease.published_at.desc().nullslast(),
+                ProjectRelease.created_at.desc(),
+            )
+            .limit(limit)
+            .offset(offset)
+        )
+        return list(db.scalars(stmt).all()), total
+
+    @staticmethod
+    def get_latest(db: Session, project_id: uuid.UUID) -> ProjectRelease:
+        release = db.scalar(
+            select(ProjectRelease)
+            .where(
+                ProjectRelease.project_id == project_id,
+                ProjectRelease.status == ReleaseStatus.PUBLISHED,
+            )
+            .options(selectinload(ProjectRelease.author))
+            .order_by(ProjectRelease.published_at.desc(), ProjectRelease.created_at.desc())
+            .limit(1)
+        )
+        if release is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="This project has no published releases yet.",
+            )
+        return release
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _record_publish_activity(
+        db: Session,
+        project: Project,
+        release: ProjectRelease,
+        actor: User,
+    ) -> None:
+        """
+        Announce on publish, never on create. A draft is by definition not news
+        yet, and pushing every work-in-progress into followers' feeds would
+        make the feed useless.
+        """
+        try:
+            ActivityService.record_activity(
+                db,
+                actor_id=actor.id,
+                activity_type=ActivityType.PROJECT_ANNOUNCEMENT,
+                title=f"{project.title} {release.version} released",
+                description=release.title,
+                target_id=release.id,
+                target_type="project_release",
+                metadata={
+                    "project_id": str(project.id),
+                    "release_id": str(release.id),
+                    "version": release.version,
+                    "release_type": release.release_type.value,
+                },
+                icon="rocket",
+            )
+        except Exception:  # pragma: no cover - feed failure must not lose the release
+            # The release is the user's work; the feed entry is a side effect.
+            # Losing the announcement is annoying, losing the release is not
+            # acceptable, so this never propagates.
+            logger.exception("Failed to record release activity for release %s", release.id)
+
+
+__all__ = ["ProjectReleaseService"]

--- a/backend/tests/test_project_releases.py
+++ b/backend/tests/test_project_releases.py
@@ -1,0 +1,492 @@
+"""
+Unit & integration tests for project release notes (#1043).
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from app.models.activity import Activity, ActivityType
+from app.models.project import Project, ProjectStage, ProjectVisibility
+from app.models.project_member import MemberRole, ProjectMember
+from app.models.project_release import (
+    MAX_HIGHLIGHTS,
+    MAX_HIGHLIGHT_LENGTH,
+    ProjectRelease,
+    ReleaseStatus,
+    ReleaseType,
+)
+from app.models.user import User
+from app.schemas.project_release import ReleaseCreate, ReleaseUpdate
+from app.services.project_release_service import ProjectReleaseService
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_user(username: str = "maintainer", system_role: str = "user") -> MagicMock:
+    user = MagicMock(spec=User)
+    user.id = uuid.uuid4()
+    user.username = username
+    user.system_role = system_role
+    user.role = "user"
+    return user
+
+
+def _make_project(owner_id: uuid.UUID | None = None) -> MagicMock:
+    project = MagicMock(spec=Project)
+    project.id = uuid.uuid4()
+    project.owner_id = owner_id or uuid.uuid4()
+    project.title = "Deploy Radar"
+    project.deleted_at = None
+    return project
+
+
+def _make_member(role: MemberRole = MemberRole.MAINTAINER) -> MagicMock:
+    member = MagicMock(spec=ProjectMember)
+    member.role = role
+    member.is_active = True
+    return member
+
+
+def _make_release(status: ReleaseStatus = ReleaseStatus.PUBLISHED) -> MagicMock:
+    release = MagicMock(spec=ProjectRelease)
+    release.id = uuid.uuid4()
+    release.status = status
+    return release
+
+
+# ---------------------------------------------------------------------------
+# 1. Schema validation
+# ---------------------------------------------------------------------------
+
+
+class TestReleaseSchema:
+    def test_defaults_to_draft(self):
+        # Writing a changelog entry and announcing it are two decisions.
+        payload = ReleaseCreate(version="v1.0.0", title="First cut")
+        assert payload.status == ReleaseStatus.DRAFT
+        assert payload.release_type == ReleaseType.MINOR
+
+    def test_version_and_title_are_stripped(self):
+        payload = ReleaseCreate(version="  v1.0.0  ", title="  Ship it  ")
+        assert payload.version == "v1.0.0"
+        assert payload.title == "Ship it"
+
+    def test_blank_version_is_rejected(self):
+        with pytest.raises(Exception):
+            ReleaseCreate(version="   ", title="Ship it")
+
+    def test_blank_highlights_are_dropped(self):
+        payload = ReleaseCreate(
+            version="v1", title="t", highlights=["Faster search", "  ", "", "Dark mode"]
+        )
+        assert payload.highlights == ["Faster search", "Dark mode"]
+
+    def test_highlights_are_stripped(self):
+        payload = ReleaseCreate(version="v1", title="t", highlights=["  Faster search  "])
+        assert payload.highlights == ["Faster search"]
+
+    def test_too_many_highlights_rejected(self):
+        with pytest.raises(Exception):
+            ReleaseCreate(
+                version="v1", title="t", highlights=[f"item {i}" for i in range(MAX_HIGHLIGHTS + 1)]
+            )
+
+    def test_exactly_the_highlight_limit_is_allowed(self):
+        payload = ReleaseCreate(
+            version="v1", title="t", highlights=[f"item {i}" for i in range(MAX_HIGHLIGHTS)]
+        )
+        assert len(payload.highlights) == MAX_HIGHLIGHTS
+
+    def test_overlong_highlight_rejected(self):
+        with pytest.raises(Exception):
+            ReleaseCreate(version="v1", title="t", highlights=["x" * (MAX_HIGHLIGHT_LENGTH + 1)])
+
+    def test_update_omits_unset_fields(self):
+        assert ReleaseUpdate(title="New title").model_dump(exclude_unset=True) == {
+            "title": "New title"
+        }
+
+    def test_update_cannot_blank_the_title(self):
+        with pytest.raises(Exception):
+            ReleaseUpdate(title="   ")
+
+
+# ---------------------------------------------------------------------------
+# 2. Maintainer checks
+# ---------------------------------------------------------------------------
+
+
+class TestMaintainerChecks:
+    def test_owner_is_a_maintainer(self):
+        db = MagicMock(spec=Session)
+        user = _make_user()
+        assert ProjectReleaseService.is_maintainer(db, _make_project(owner_id=user.id), user) is True
+
+    def test_anonymous_is_not(self):
+        db = MagicMock(spec=Session)
+        assert ProjectReleaseService.is_maintainer(db, _make_project(), None) is False
+
+    def test_platform_admin_is(self):
+        db = MagicMock(spec=Session)
+        assert ProjectReleaseService.is_maintainer(db, _make_project(), _make_user(system_role="admin")) is True
+
+    def test_maintainer_role_qualifies(self):
+        db = MagicMock(spec=Session)
+        db.scalar.return_value = _make_member(MemberRole.MAINTAINER)
+        assert ProjectReleaseService.is_maintainer(db, _make_project(), _make_user()) is True
+
+    def test_contributor_role_does_not(self):
+        db = MagicMock(spec=Session)
+        db.scalar.return_value = _make_member(MemberRole.CONTRIBUTOR)
+        assert ProjectReleaseService.is_maintainer(db, _make_project(), _make_user()) is False
+
+    def test_require_maintainer_raises_403(self):
+        db = MagicMock(spec=Session)
+        db.scalar.return_value = None
+        with pytest.raises(HTTPException) as exc:
+            ProjectReleaseService.require_maintainer(db, _make_project(), _make_user())
+        assert exc.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# 3. Draft visibility
+# ---------------------------------------------------------------------------
+
+
+class TestDraftVisibility:
+    def _db_returning(self, release):
+        db = MagicMock(spec=Session)
+        db.scalar.return_value = release
+        return db
+
+    def test_missing_release_is_404(self):
+        with pytest.raises(HTTPException) as exc:
+            ProjectReleaseService.get_release_or_404(
+                self._db_returning(None), uuid.uuid4(), uuid.uuid4()
+            )
+        assert exc.value.status_code == 404
+
+    def test_draft_is_404_for_the_public_not_403(self):
+        # A 403 would confirm the draft exists, and hand over its id.
+        draft = _make_release(ReleaseStatus.DRAFT)
+        with pytest.raises(HTTPException) as exc:
+            ProjectReleaseService.get_release_or_404(
+                self._db_returning(draft), uuid.uuid4(), draft.id, viewer_is_maintainer=False
+            )
+        assert exc.value.status_code == 404
+
+    def test_draft_is_visible_to_a_maintainer(self):
+        draft = _make_release(ReleaseStatus.DRAFT)
+        found = ProjectReleaseService.get_release_or_404(
+            self._db_returning(draft), uuid.uuid4(), draft.id, viewer_is_maintainer=True
+        )
+        assert found is draft
+
+    def test_published_is_visible_to_the_public(self):
+        published = _make_release(ReleaseStatus.PUBLISHED)
+        found = ProjectReleaseService.get_release_or_404(
+            self._db_returning(published), uuid.uuid4(), published.id
+        )
+        assert found is published
+
+
+# ---------------------------------------------------------------------------
+# 4. HTTP surface (real database)
+# ---------------------------------------------------------------------------
+
+
+class TestReleaseEndpoints:
+    @staticmethod
+    def _project_for(db, owner_id: uuid.UUID, slug: str) -> Project:
+        project = Project(
+            owner_id=owner_id,
+            title="Deploy Radar",
+            slug=slug,
+            description="Ships things and tells you about it.",
+            stage=ProjectStage.MVP,
+            visibility=ProjectVisibility.PUBLIC,
+        )
+        db.add(project)
+        db.commit()
+        db.refresh(project)
+        return project
+
+    @staticmethod
+    def _auth(token: str) -> dict[str, str]:
+        return {"Authorization": f"Bearer {token}"}
+
+    def _create(self, client, token, project_id, **overrides):
+        payload = {"version": "v1.0.0", "title": "First release"}
+        payload.update(overrides)
+        return client.post(
+            f"/api/v1/projects/{project_id}/releases",
+            json=payload,
+            headers=self._auth(token),
+        )
+
+    def test_creating_requires_authentication(self, client):
+        response = client.post(
+            f"/api/v1/projects/{uuid.uuid4()}/releases",
+            json={"version": "v1", "title": "t"},
+        )
+        assert response.status_code in (401, 403)
+
+    def test_unknown_project_is_404(self, client, register_and_login):
+        _, token = register_and_login("rel1@example.com", "reluser1")
+        assert self._create(client, token, uuid.uuid4()).status_code == 404
+
+    def test_create_defaults_to_draft(self, client, db, register_and_login):
+        user_id, token = register_and_login("rel2@example.com", "reluser2")
+        project = self._project_for(db, uuid.UUID(user_id), "rel-p2")
+
+        response = self._create(client, token, project.id)
+        assert response.status_code == 201, response.text
+        body = response.json()
+        assert body["status"] == "draft"
+        assert body["published_at"] is None
+        assert body["is_pinned"] is False
+
+    def test_drafts_are_hidden_from_the_public_listing(self, client, db, register_and_login):
+        user_id, token = register_and_login("rel3@example.com", "reluser3")
+        project = self._project_for(db, uuid.UUID(user_id), "rel-p3")
+        self._create(client, token, project.id)
+
+        public = client.get(f"/api/v1/projects/{project.id}/releases")
+        assert public.status_code == 200
+        assert public.json()["total"] == 0
+
+        maintainer = client.get(
+            f"/api/v1/projects/{project.id}/releases",
+            params={"include_drafts": True},
+            headers=self._auth(token),
+        )
+        assert maintainer.json()["total"] == 1
+
+    def test_include_drafts_is_ignored_for_the_public(self, client, db, register_and_login):
+        user_id, token = register_and_login("rel4@example.com", "reluser4")
+        project = self._project_for(db, uuid.UUID(user_id), "rel-p4")
+        self._create(client, token, project.id)
+
+        response = client.get(
+            f"/api/v1/projects/{project.id}/releases", params={"include_drafts": True}
+        )
+        assert response.status_code == 200
+        assert response.json()["total"] == 0
+
+    def test_anonymous_get_of_a_draft_is_404(self, client, db, register_and_login):
+        user_id, token = register_and_login("rel5@example.com", "reluser5")
+        project = self._project_for(db, uuid.UUID(user_id), "rel-p5")
+        release_id = self._create(client, token, project.id).json()["id"]
+
+        assert client.get(f"/api/v1/projects/{project.id}/releases/{release_id}").status_code == 404
+        # But its own maintainer can read it.
+        assert (
+            client.get(
+                f"/api/v1/projects/{project.id}/releases/{release_id}", headers=self._auth(token)
+            ).status_code
+            == 200
+        )
+
+    def test_duplicate_version_is_409_case_insensitively(self, client, db, register_and_login):
+        user_id, token = register_and_login("rel6@example.com", "reluser6")
+        project = self._project_for(db, uuid.UUID(user_id), "rel-p6")
+
+        assert self._create(client, token, project.id, version="v1.0.0").status_code == 201
+
+        clash = self._create(client, token, project.id, version="V1.0.0")
+        assert clash.status_code == 409
+        assert "already exists" in clash.json()["detail"]
+
+    def test_same_version_in_two_projects_is_fine(self, client, db, register_and_login):
+        user_id, token = register_and_login("rel7@example.com", "reluser7")
+        first = self._project_for(db, uuid.UUID(user_id), "rel-p7-a")
+        second = self._project_for(db, uuid.UUID(user_id), "rel-p7-b")
+
+        assert self._create(client, token, first.id, version="v1.0.0").status_code == 201
+        assert self._create(client, token, second.id, version="v1.0.0").status_code == 201
+
+    def test_publishing_sets_the_date_and_is_idempotent(self, client, db, register_and_login):
+        user_id, token = register_and_login("rel8@example.com", "reluser8")
+        project = self._project_for(db, uuid.UUID(user_id), "rel-p8")
+        release_id = self._create(client, token, project.id).json()["id"]
+
+        first = client.post(
+            f"/api/v1/projects/{project.id}/releases/{release_id}/publish",
+            headers=self._auth(token),
+        )
+        assert first.status_code == 200
+        assert first.json()["status"] == "published"
+        published_at = first.json()["published_at"]
+        assert published_at is not None
+
+        second = client.post(
+            f"/api/v1/projects/{project.id}/releases/{release_id}/publish",
+            headers=self._auth(token),
+        )
+        assert second.status_code == 200
+        # A double-clicked button must not rewrite the release date.
+        assert second.json()["published_at"] == published_at
+
+    def test_activity_is_written_on_publish_not_on_create(
+        self, client, db, register_and_login
+    ):
+        user_id, token = register_and_login("rel9@example.com", "reluser9")
+        project = self._project_for(db, uuid.UUID(user_id), "rel-p9")
+
+        def announcement_count() -> int:
+            return (
+                db.query(Activity)
+                .filter(Activity.activity_type == ActivityType.PROJECT_ANNOUNCEMENT)
+                .count()
+            )
+
+        before = announcement_count()
+        release_id = self._create(client, token, project.id).json()["id"]
+        assert announcement_count() == before, "a draft is not news yet"
+
+        client.post(
+            f"/api/v1/projects/{project.id}/releases/{release_id}/publish",
+            headers=self._auth(token),
+        )
+        assert announcement_count() == before + 1
+
+    def test_creating_as_published_announces_immediately(self, client, db, register_and_login):
+        user_id, token = register_and_login("rel10@example.com", "reluser10")
+        project = self._project_for(db, uuid.UUID(user_id), "rel-p10")
+
+        response = self._create(client, token, project.id, status="published")
+        assert response.status_code == 201
+        assert response.json()["status"] == "published"
+        assert response.json()["published_at"] is not None
+
+    def test_pinning_moves_the_pin(self, client, db, register_and_login):
+        user_id, token = register_and_login("rel11@example.com", "reluser11")
+        project = self._project_for(db, uuid.UUID(user_id), "rel-p11")
+
+        first = self._create(client, token, project.id, version="v1.0.0", status="published").json()
+        second = self._create(client, token, project.id, version="v2.0.0", status="published").json()
+
+        client.post(
+            f"/api/v1/projects/{project.id}/releases/{first['id']}/pin", headers=self._auth(token)
+        )
+        client.post(
+            f"/api/v1/projects/{project.id}/releases/{second['id']}/pin", headers=self._auth(token)
+        )
+
+        items = client.get(f"/api/v1/projects/{project.id}/releases").json()["items"]
+        pinned = [item for item in items if item["is_pinned"]]
+        assert len(pinned) == 1
+        assert pinned[0]["id"] == second["id"]
+        # And the pinned one sorts to the top.
+        assert items[0]["id"] == second["id"]
+
+    def test_a_draft_cannot_be_pinned(self, client, db, register_and_login):
+        user_id, token = register_and_login("rel12@example.com", "reluser12")
+        project = self._project_for(db, uuid.UUID(user_id), "rel-p12")
+        release_id = self._create(client, token, project.id).json()["id"]
+
+        response = client.post(
+            f"/api/v1/projects/{project.id}/releases/{release_id}/pin", headers=self._auth(token)
+        )
+        assert response.status_code == 400
+
+    def test_latest_returns_the_newest_published(self, client, db, register_and_login):
+        user_id, token = register_and_login("rel13@example.com", "reluser13")
+        project = self._project_for(db, uuid.UUID(user_id), "rel-p13")
+
+        assert client.get(f"/api/v1/projects/{project.id}/releases/latest").status_code == 404
+
+        self._create(client, token, project.id, version="v1.0.0", status="published")
+        newest = self._create(
+            client, token, project.id, version="v1.1.0", status="published"
+        ).json()
+
+        response = client.get(f"/api/v1/projects/{project.id}/releases/latest")
+        assert response.status_code == 200
+        assert response.json()["id"] == newest["id"]
+
+    def test_latest_ignores_drafts(self, client, db, register_and_login):
+        user_id, token = register_and_login("rel14@example.com", "reluser14")
+        project = self._project_for(db, uuid.UUID(user_id), "rel-p14")
+
+        published = self._create(
+            client, token, project.id, version="v1.0.0", status="published"
+        ).json()
+        self._create(client, token, project.id, version="v2.0.0-rc1")
+
+        response = client.get(f"/api/v1/projects/{project.id}/releases/latest")
+        assert response.json()["id"] == published["id"]
+
+    def test_non_maintainer_cannot_create(self, client, db, register_and_login):
+        owner_id, _ = register_and_login("rel15@example.com", "reluser15")
+        project = self._project_for(db, uuid.UUID(owner_id), "rel-p15")
+
+        _, outsider_token = register_and_login("rel16@example.com", "reluser16")
+        assert self._create(client, outsider_token, project.id).status_code == 403
+
+    def test_edit_and_delete(self, client, db, register_and_login):
+        user_id, token = register_and_login("rel17@example.com", "reluser17")
+        project = self._project_for(db, uuid.UUID(user_id), "rel-p17")
+        release_id = self._create(client, token, project.id).json()["id"]
+
+        updated = client.patch(
+            f"/api/v1/projects/{project.id}/releases/{release_id}",
+            json={"title": "Renamed", "highlights": ["Faster boot"]},
+            headers=self._auth(token),
+        )
+        assert updated.status_code == 200
+        assert updated.json()["title"] == "Renamed"
+        assert updated.json()["highlights"] == ["Faster boot"]
+
+        deleted = client.delete(
+            f"/api/v1/projects/{project.id}/releases/{release_id}", headers=self._auth(token)
+        )
+        assert deleted.status_code == 204
+
+    def test_editing_to_a_taken_version_is_409(self, client, db, register_and_login):
+        user_id, token = register_and_login("rel18@example.com", "reluser18")
+        project = self._project_for(db, uuid.UUID(user_id), "rel-p18")
+
+        self._create(client, token, project.id, version="v1.0.0")
+        second_id = self._create(client, token, project.id, version="v2.0.0").json()["id"]
+
+        response = client.patch(
+            f"/api/v1/projects/{project.id}/releases/{second_id}",
+            json={"version": "v1.0.0"},
+            headers=self._auth(token),
+        )
+        assert response.status_code == 409
+
+    def test_editing_a_release_to_its_own_version_is_allowed(
+        self, client, db, register_and_login
+    ):
+        # The uniqueness check must exclude the row being edited, or saving a
+        # form without touching the version field would fail.
+        user_id, token = register_and_login("rel19@example.com", "reluser19")
+        project = self._project_for(db, uuid.UUID(user_id), "rel-p19")
+        release_id = self._create(client, token, project.id, version="v1.0.0").json()["id"]
+
+        response = client.patch(
+            f"/api/v1/projects/{project.id}/releases/{release_id}",
+            json={"version": "v1.0.0", "title": "Same version, new title"},
+            headers=self._auth(token),
+        )
+        assert response.status_code == 200
+
+    def test_published_listing_is_newest_first(self, client, db, register_and_login):
+        user_id, token = register_and_login("rel20@example.com", "reluser20")
+        project = self._project_for(db, uuid.UUID(user_id), "rel-p20")
+
+        for version in ("v1.0.0", "v1.1.0", "v1.2.0"):
+            self._create(client, token, project.id, version=version, status="published")
+
+        items = client.get(f"/api/v1/projects/{project.id}/releases").json()["items"]
+        assert [item["version"] for item in items] == ["v1.2.0", "v1.1.0", "v1.0.0"]


### PR DESCRIPTION
Closes #1043

## Why this is not `project_versions`

`project_versions` (#606) already exists, and it is a different thing: an internal edit-history snapshot that records someone changed the description at 14:02. It is a diff log, not an announcement.

There is currently nowhere for a project to say "v1.2.0 is out, here is what changed." That news gets typed into a message thread or a Builder Flare and disappears. Followers have no changelog to read, and a visitor landing on a project page cannot tell whether it shipped last week or died last year.

## What this adds

`project_releases` — a version people quote, a markdown body people read, short `highlights` for the collapsed card, a `release_type`, and a publish moment.

```
GET    /api/v1/projects/{id}/releases            ?include_drafts (maintainers)
POST   /api/v1/projects/{id}/releases            defaults to draft
GET    /api/v1/projects/{id}/releases/latest
GET    /api/v1/projects/{id}/releases/{release_id}
PATCH  /api/v1/projects/{id}/releases/{release_id}
POST   /api/v1/projects/{id}/releases/{release_id}/publish
POST   /api/v1/projects/{id}/releases/{release_id}/pin
DELETE /api/v1/projects/{id}/releases/{release_id}
```

## Decisions worth reviewing

**Draft is the default.** Writing a changelog entry and announcing it are two different decisions. Defaulting to published means every half-finished entry and every typo goes out to followers the moment it is saved.

**A draft is a 404 for non-maintainers, not a 403.** This is the one I would push back on if I saw the opposite. A 403 tells an unauthorised caller that the release exists — which leaks both that something unannounced is in the pipeline and its id. 404 is the correct answer to "is there a resource here that you may see."

**`include_drafts=true` is silently downgraded for the public rather than rejected.** A client that always sends the flag still gets a working public listing instead of a 403 it has to special-case.

**Versions are unique per project, compared case-insensitively.** `V1.0.0` and `v1.0.0` are the same release to every human reading the changelog; storing both produces two entries nobody can tell apart. The uniqueness check excludes the row being edited — without that, saving a form that did not touch the version field would fail with a conflict against itself. There is a test for exactly that.

**Publish is idempotent.** Re-publishing an already-published release returns it unchanged rather than moving `published_at` or firing a second announcement. A double-clicked button should not be able to rewrite a release date.

**The activity row is written on publish, never on create.** A draft is by definition not news, and pushing every work-in-progress into followers' feeds would make the feed useless. Recording it is wrapped so a feed failure is logged rather than raised: the release is the user's work, the feed entry is a side effect, and losing the former to save the latter is the wrong trade.

**`author_id` is `SET NULL`.** A release outlives the person who cut it — a maintainer leaving should not erase the project's history.

**Pinning is atomic** and restricted to published releases. Pinning B while A is pinned leaves exactly one pinned release, sorted to the top of the listing.

## Migration

`c8f4a1e93b27`, branching from `d4e5f6a7b8c9`. Creates the `releasetype` and `releasestatus` enums with `checkfirst=True` and drops them on downgrade. Single head.

## Tests

40 cases. The interesting ones:

- **Case-insensitive collision** — `V1.0.0` after `v1.0.0` is a 409, but the same version in two *different* projects is fine.
- **Self-collision** — editing a release and resubmitting its own version succeeds.
- **Draft visibility** — anonymous `GET` of a draft is 404; the maintainer gets 200 for the same id; `include_drafts` returns 0 for the public and 1 for the maintainer.
- **Publish idempotency** — the second publish returns the *same* `published_at`.
- **Announcement timing** — counts `PROJECT_ANNOUNCEMENT` rows before create, after create (unchanged — "a draft is not news yet"), and after publish (+1).
- **Pinning** — after pinning two in sequence exactly one is pinned, it is the second, and it sorts first.
- **`latest`** — 404 when there are none, ignores drafts, returns the newest published.
- **Highlights** — blanks dropped, whitespace stripped, exactly 10 allowed, 11 rejected, 201 chars rejected.

```
40 passed
```
