### PR TITLE
feat(profile): add peer testimonials (#1044)

### DIFF
--- a/backend/alembic/versions/d9e2b7c4f183_create_testimonials_table.py
+++ b/backend/alembic/versions/d9e2b7c4f183_create_testimonials_table.py
@@ -1,0 +1,116 @@
+"""create testimonials table
+
+Revision ID: d9e2b7c4f183
+Revises: d4e5f6a7b8c9
+Create Date: 2026-08-10 21:35:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+# revision identifiers, used by Alembic.
+revision: str = "d9e2b7c4f183"
+down_revision: Union[str, Sequence[str], None] = "d4e5f6a7b8c9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+relationship_enum = sa.Enum(
+    "COLLABORATOR",
+    "MENTOR",
+    "MENTEE",
+    "CLIENT",
+    "TEAMMATE",
+    name="testimonialrelationship",
+)
+status_enum = sa.Enum("PENDING", "APPROVED", "HIDDEN", name="testimonialstatus")
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    relationship_enum.create(bind, checkfirst=True)
+    status_enum.create(bind, checkfirst=True)
+
+    op.create_table(
+        "testimonials",
+        sa.Column("id", UUID(as_uuid=True), nullable=False),
+        # Who it is about.
+        sa.Column("subject_id", UUID(as_uuid=True), nullable=False),
+        # Who wrote it.
+        sa.Column("author_id", UUID(as_uuid=True), nullable=False),
+        # The collaboration it came out of. SET NULL because the testimonial is
+        # about the person, not the project.
+        sa.Column("project_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("relationship", relationship_enum, nullable=False),
+        sa.Column("body", sa.Text(), nullable=False),
+        sa.Column("status", status_enum, nullable=False),
+        sa.Column(
+            "is_featured", sa.Boolean(), server_default=sa.text("false"), nullable=False
+        ),
+        # When the subject last approved or hid it.
+        sa.Column("responded_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["subject_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["author_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        # One testimonial per author per subject. Someone with an opinion worth
+        # stating twice can edit the one they already wrote.
+        sa.UniqueConstraint("author_id", "subject_id", name="uq_testimonials_author_subject"),
+        # Nobody writes a testimonial about themselves.
+        sa.CheckConstraint("author_id <> subject_id", name="ck_testimonials_not_self"),
+    )
+
+    op.create_index(
+        op.f("ix_testimonials_subject_id"), "testimonials", ["subject_id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_testimonials_author_id"), "testimonials", ["author_id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_testimonials_project_id"), "testimonials", ["project_id"], unique=False
+    )
+    op.create_index(op.f("ix_testimonials_status"), "testimonials", ["status"], unique=False)
+
+    # The public profile listing: one subject's approved testimonials.
+    op.create_index(
+        "ix_testimonials_subject_status",
+        "testimonials",
+        ["subject_id", "status"],
+        unique=False,
+    )
+    # The author's own "what have I written" view.
+    op.create_index(
+        "ix_testimonials_author_created",
+        "testimonials",
+        ["author_id", "created_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_testimonials_author_created", table_name="testimonials")
+    op.drop_index("ix_testimonials_subject_status", table_name="testimonials")
+    op.drop_index(op.f("ix_testimonials_status"), table_name="testimonials")
+    op.drop_index(op.f("ix_testimonials_project_id"), table_name="testimonials")
+    op.drop_index(op.f("ix_testimonials_author_id"), table_name="testimonials")
+    op.drop_index(op.f("ix_testimonials_subject_id"), table_name="testimonials")
+    op.drop_table("testimonials")
+
+    bind = op.get_bind()
+    status_enum.drop(bind, checkfirst=True)
+    relationship_enum.drop(bind, checkfirst=True)

--- a/backend/alembic/versions/d9e2b7c4f183_create_testimonials_table.py
+++ b/backend/alembic/versions/d9e2b7c4f183_create_testimonials_table.py
@@ -10,6 +10,7 @@ from typing import Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import UUID
 
 # revision identifiers, used by Alembic.
@@ -18,15 +19,24 @@ down_revision: Union[str, Sequence[str], None] = "d4e5f6a7b8c9"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
-relationship_enum = sa.Enum(
+# create_type=False: the types are created explicitly in upgrade() with
+# checkfirst, so create_table must not try to emit CREATE TYPE a second time.
+relationship_enum = postgresql.ENUM(
     "COLLABORATOR",
     "MENTOR",
     "MENTEE",
     "CLIENT",
     "TEAMMATE",
     name="testimonialrelationship",
+    create_type=False,
 )
-status_enum = sa.Enum("PENDING", "APPROVED", "HIDDEN", name="testimonialstatus")
+status_enum = postgresql.ENUM(
+    "PENDING",
+    "APPROVED",
+    "HIDDEN",
+    name="testimonialstatus",
+    create_type=False,
+)
 
 
 def upgrade() -> None:

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -40,6 +40,7 @@ from app.routers import (
     security_dashboard,
     security_events,
     skills,
+    testimonials,
     users,
     webhooks,
     websockets,
@@ -119,6 +120,7 @@ api_v1_router.include_router(repositories.router)
 api_v1_router.include_router(organizations.router)
 api_v1_router.include_router(applications.router)
 api_v1_router.include_router(skills.router)
+api_v1_router.include_router(testimonials.router)
 api_v1_router.include_router(websockets.router)
 api_v1_router.include_router(recommendations.router)
 api_v1_router.include_router(repository_quality.router, tags=["Repository Quality"])

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -536,6 +536,9 @@ app.include_router(mfa.router, prefix="/api")
 app.include_router(global_announcements.router, prefix="/api", tags=["Global Announcements"])
 app.include_router(users.router, prefix="/api/users", tags=["Users"])
 app.include_router(blocks.router, prefix="/api/blocks", tags=["User Blocks"])
+from app.routers import testimonials
+
+app.include_router(testimonials.router, prefix="/api", tags=["Testimonials"])
 app.include_router(export.router, prefix="/api/users", tags=["Export"])
 from app.routers import feedback
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -85,14 +85,14 @@ from .security_event import SecurityEvent, SecurityEventType, SecurityEventSever
 from .profile_suggestion import ProfileSuggestionDismissal
 from .request_log import RequestLog  # noqa: F401
 from .background_job import BackgroundJob, JobStatus
+from .testimonial import (  # noqa: F401
+    Testimonial,
+    TestimonialRelationship,
+    TestimonialStatus,
+)
 from .badge import Badge, UserBadge  # noqa: F401
 from .centralized_analytics import CentralizedAnalyticsEvent, AnalyticsEventType  # noqa: F401
 from .global_announcement import GlobalAnnouncement, AnnouncementSeverity, TargetAudience  # noqa: F401
 from .post import Post  # noqa: F401
 
 from .project_comment import ProjectComment  # noqa: F401
-from .testimonial import (  # noqa: F401
-    Testimonial,
-    TestimonialRelationship,
-    TestimonialStatus,
-)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -91,3 +91,8 @@ from .global_announcement import GlobalAnnouncement, AnnouncementSeverity, Targe
 from .post import Post  # noqa: F401
 
 from .project_comment import ProjectComment  # noqa: F401
+from .testimonial import (  # noqa: F401
+    Testimonial,
+    TestimonialRelationship,
+    TestimonialStatus,
+)

--- a/backend/app/models/testimonial.py
+++ b/backend/app/models/testimonial.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from enum import Enum
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Index,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy import Enum as SqlEnum
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database.base import Base
+
+MIN_BODY_LENGTH = 50
+MAX_BODY_LENGTH = 2000
+
+# The subject curates, they do not accumulate. Three featured testimonials fit
+# above the fold; more and nobody reads any of them.
+MAX_FEATURED = 3
+
+
+class TestimonialRelationship(str, Enum):
+    COLLABORATOR = "collaborator"
+    MENTOR = "mentor"
+    MENTEE = "mentee"
+    CLIENT = "client"
+    TEAMMATE = "teammate"
+
+
+class TestimonialStatus(str, Enum):
+    PENDING = "pending"
+    APPROVED = "approved"
+    HIDDEN = "hidden"
+
+
+class Testimonial(Base):
+    """
+    A written recommendation one user leaves for another (#1044).
+
+    Distinct from a skill endorsement (#257), which is a +1 on a tag. This is
+    free text with an author, a stated relationship, and a moderation
+    lifecycle the subject controls.
+    """
+
+    __tablename__ = "testimonials"
+
+    # ==========================================================
+    # Primary Key
+    # ==========================================================
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+    # ==========================================================
+    # Parties
+    # ==========================================================
+
+    # Who the testimonial is about.
+    subject_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    # Who wrote it.
+    author_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    # The collaboration it came out of, if any. SET NULL because the
+    # testimonial is about the person, not the project.
+    project_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("projects.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
+    # ==========================================================
+    # Content
+    # ==========================================================
+
+    relationship_type: Mapped[TestimonialRelationship] = mapped_column(
+        SqlEnum(TestimonialRelationship),
+        name="relationship",
+        nullable=False,
+    )
+
+    body: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+    )
+
+    # ==========================================================
+    # Moderation
+    # ==========================================================
+
+    status: Mapped[TestimonialStatus] = mapped_column(
+        SqlEnum(TestimonialStatus),
+        default=TestimonialStatus.PENDING,
+        nullable=False,
+        index=True,
+    )
+
+    is_featured: Mapped[bool] = mapped_column(
+        Boolean,
+        default=False,
+        server_default="false",
+        nullable=False,
+    )
+
+    # When the subject last acted on it (approved or hid it).
+    responded_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+
+    # ==========================================================
+    # Relationships
+    # ==========================================================
+
+    subject = relationship("User", foreign_keys=[subject_id], backref="testimonials_received")
+    author = relationship("User", foreign_keys=[author_id], backref="testimonials_written")
+    project = relationship("Project", backref="testimonials")
+
+    # ==========================================================
+    # Audit
+    # ==========================================================
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    __table_args__ = (
+        # One testimonial per author, per subject. Someone with an opinion
+        # worth stating twice can edit the one they already wrote.
+        UniqueConstraint("author_id", "subject_id", name="uq_testimonials_author_subject"),
+        # The public profile listing: one subject's approved testimonials.
+        Index("ix_testimonials_subject_status", "subject_id", "status"),
+        # The author's own "what have I written" view.
+        Index("ix_testimonials_author_created", "author_id", "created_at"),
+    )
+
+    @property
+    def relationship(self) -> TestimonialRelationship:
+        """
+        Alias for ``relationship_type``.
+
+        The column is called ``relationship`` and that is what the API speaks,
+        but the attribute cannot be -- ``relationship`` is SQLAlchemy's own
+        name in this module's namespace. The mapped attribute carries the
+        ``_type`` suffix and this property bridges the two.
+        """
+        return self.relationship_type
+
+    def __repr__(self) -> str:
+        return f"<Testimonial(subject={self.subject_id}, author={self.author_id}, status={self.status})>"

--- a/backend/app/routers/testimonials.py
+++ b/backend/app/routers/testimonials.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+"""
+API Router for peer testimonials (#1044).
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy.orm import Session
+
+from app.dependencies import get_current_active_user, get_database, get_optional_current_user
+from app.models.testimonial import TestimonialStatus
+from app.models.user import User
+from app.schemas.testimonial import (
+    TestimonialCreate,
+    TestimonialList,
+    TestimonialResponse,
+    TestimonialSummary,
+    TestimonialUpdate,
+)
+from app.services.testimonial_service import TestimonialService
+
+router = APIRouter(tags=["Testimonials"])
+
+
+def _as_list(items, total: int, limit: int, offset: int) -> TestimonialList:
+    return TestimonialList(
+        items=[TestimonialResponse.model_validate(item) for item in items],
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Writing
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/testimonials",
+    response_model=TestimonialResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Write a testimonial about someone",
+    description=(
+        "Lands in `pending` and is visible only to you and the subject until "
+        "they approve it. One testimonial per pair — edit yours rather than "
+        "writing a second."
+    ),
+    responses={
+        400: {"description": "You cannot write about yourself"},
+        403: {"description": "One of you has blocked the other"},
+        409: {"description": "You have already written one for this user"},
+    },
+)
+def create_testimonial(
+    payload: TestimonialCreate,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_active_user),
+) -> TestimonialResponse:
+    testimonial = TestimonialService.create(db, author=current_user, payload=payload)
+    return TestimonialResponse.model_validate(testimonial)
+
+
+@router.patch(
+    "/testimonials/{testimonial_id}",
+    response_model=TestimonialResponse,
+    summary="Edit your testimonial",
+    description=(
+        "Editing the text of an approved testimonial returns it to `pending` "
+        "and un-features it — otherwise approval would be a rubber stamp on "
+        "text that can be swapped out afterwards."
+    ),
+    responses={403: {"description": "Not your testimonial, or it has been hidden"}},
+)
+def update_testimonial(
+    testimonial_id: uuid.UUID,
+    payload: TestimonialUpdate,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_active_user),
+) -> TestimonialResponse:
+    testimonial = TestimonialService.update(
+        db, testimonial_id=testimonial_id, author=current_user, payload=payload
+    )
+    return TestimonialResponse.model_validate(testimonial)
+
+
+@router.delete(
+    "/testimonials/{testimonial_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete your testimonial",
+    description=(
+        "Only the author may delete. The subject can hide a testimonial but "
+        "not erase it — someone else's opinion is not theirs to destroy."
+    ),
+)
+def delete_testimonial(
+    testimonial_id: uuid.UUID,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_active_user),
+) -> Response:
+    TestimonialService.delete(db, testimonial_id=testimonial_id, user=current_user)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+# ---------------------------------------------------------------------------
+# Moderation (subject only)
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/testimonials/{testimonial_id}/approve",
+    response_model=TestimonialResponse,
+    summary="Approve a testimonial written about you",
+    responses={403: {"description": "You are not the subject"}},
+)
+def approve_testimonial(
+    testimonial_id: uuid.UUID,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_active_user),
+) -> TestimonialResponse:
+    return TestimonialResponse.model_validate(
+        TestimonialService.approve(db, testimonial_id=testimonial_id, subject=current_user)
+    )
+
+
+@router.post(
+    "/testimonials/{testimonial_id}/hide",
+    response_model=TestimonialResponse,
+    summary="Hide a testimonial written about you",
+    description="Removes it from your profile and un-features it. The author can still see it.",
+)
+def hide_testimonial(
+    testimonial_id: uuid.UUID,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_active_user),
+) -> TestimonialResponse:
+    return TestimonialResponse.model_validate(
+        TestimonialService.hide(db, testimonial_id=testimonial_id, subject=current_user)
+    )
+
+
+@router.post(
+    "/testimonials/{testimonial_id}/feature",
+    response_model=TestimonialResponse,
+    summary="Feature (or un-feature) an approved testimonial",
+    responses={400: {"description": "Not approved, or the featured limit is reached"}},
+)
+def feature_testimonial(
+    testimonial_id: uuid.UUID,
+    featured: bool = Query(True, description="Set false to un-feature"),
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_active_user),
+) -> TestimonialResponse:
+    return TestimonialResponse.model_validate(
+        TestimonialService.set_featured(
+            db, testimonial_id=testimonial_id, subject=current_user, featured=featured
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reading
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/testimonials/received",
+    response_model=TestimonialList,
+    summary="Testimonials written about you",
+    description="Your moderation queue. Includes pending and hidden entries.",
+)
+def list_received(
+    status_filter: TestimonialStatus | None = Query(None, alias="status"),
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_active_user),
+) -> TestimonialList:
+    items, total = TestimonialService.list_for_subject(
+        db,
+        subject=current_user,
+        viewer=current_user,
+        status_filter=status_filter,
+        limit=limit,
+        offset=offset,
+    )
+    return _as_list(items, total, limit, offset)
+
+
+@router.get(
+    "/testimonials/written",
+    response_model=TestimonialList,
+    summary="Testimonials you have written",
+)
+def list_written(
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_active_user),
+) -> TestimonialList:
+    items, total = TestimonialService.list_written_by(
+        db, author=current_user, limit=limit, offset=offset
+    )
+    return _as_list(items, total, limit, offset)
+
+
+@router.get(
+    "/testimonials/{testimonial_id}",
+    response_model=TestimonialResponse,
+    summary="Get one testimonial",
+    description="A pending or hidden testimonial is a 404 for anyone but its author and subject.",
+)
+def get_testimonial(
+    testimonial_id: uuid.UUID,
+    db: Session = Depends(get_database),
+    current_user: User | None = Depends(get_optional_current_user),
+) -> TestimonialResponse:
+    testimonial = TestimonialService.get_testimonial_or_404(db, testimonial_id)
+
+    # 404 rather than 403: a 403 would confirm that an unapproved testimonial
+    # about this person exists, which is exactly what moderation hides.
+    if not TestimonialService.can_view(testimonial, current_user):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Testimonial not found")
+
+    return TestimonialResponse.model_validate(testimonial)
+
+
+@router.get(
+    "/users/{username}/testimonials",
+    response_model=TestimonialList,
+    summary="A builder's testimonials",
+    description=(
+        "Approved only for the public. The subject sees their whole inbox and "
+        "may filter with `?status=`."
+    ),
+)
+def list_for_user(
+    username: str,
+    status_filter: TestimonialStatus | None = Query(None, alias="status"),
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    db: Session = Depends(get_database),
+    current_user: User | None = Depends(get_optional_current_user),
+) -> TestimonialList:
+    subject = TestimonialService.get_user_or_404(db, username)
+    items, total = TestimonialService.list_for_subject(
+        db,
+        subject=subject,
+        viewer=current_user,
+        status_filter=status_filter,
+        limit=limit,
+        offset=offset,
+    )
+    return _as_list(items, total, limit, offset)
+
+
+@router.get(
+    "/users/{username}/testimonials/summary",
+    response_model=TestimonialSummary,
+    summary="Testimonial summary for a profile header",
+    description="Approved counts grouped by relationship, plus the featured testimonials.",
+)
+def get_summary(
+    username: str,
+    db: Session = Depends(get_database),
+) -> TestimonialSummary:
+    subject = TestimonialService.get_user_or_404(db, username)
+    return TestimonialService.summarise(db, subject)

--- a/backend/app/schemas/testimonial.py
+++ b/backend/app/schemas/testimonial.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+"""
+Schemas for peer testimonials (#1044).
+"""
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from app.models.testimonial import (
+    MAX_BODY_LENGTH,
+    MAX_FEATURED,
+    MIN_BODY_LENGTH,
+    TestimonialRelationship,
+    TestimonialStatus,
+)
+
+
+class TestimonialCreate(BaseModel):
+    subject_id: uuid.UUID = Field(..., description="The user this testimonial is about")
+    relationship: TestimonialRelationship = Field(..., description="How you worked together")
+    body: str = Field(
+        ...,
+        min_length=MIN_BODY_LENGTH,
+        max_length=MAX_BODY_LENGTH,
+        description=(
+            f"{MIN_BODY_LENGTH}-{MAX_BODY_LENGTH} characters. The floor is deliberate: "
+            "a two-word testimonial carries no information and dilutes the ones that do."
+        ),
+    )
+    project_id: Optional[uuid.UUID] = Field(
+        default=None, description="The collaboration this came out of"
+    )
+
+    @field_validator("body")
+    @classmethod
+    def _strip_body(cls, value: str) -> str:
+        cleaned = value.strip()
+        if len(cleaned) < MIN_BODY_LENGTH:
+            raise ValueError(f"A testimonial must be at least {MIN_BODY_LENGTH} characters.")
+        return cleaned
+
+
+class TestimonialUpdate(BaseModel):
+    relationship: Optional[TestimonialRelationship] = None
+    body: Optional[str] = Field(default=None, min_length=MIN_BODY_LENGTH, max_length=MAX_BODY_LENGTH)
+    project_id: Optional[uuid.UUID] = None
+
+    @field_validator("body")
+    @classmethod
+    def _strip_body(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        if len(cleaned) < MIN_BODY_LENGTH:
+            raise ValueError(f"A testimonial must be at least {MIN_BODY_LENGTH} characters.")
+        return cleaned
+
+
+class TestimonialParty(BaseModel):
+    id: uuid.UUID
+    username: str
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+    profile_image: Optional[str] = None
+    headline: Optional[str] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class TestimonialResponse(BaseModel):
+    id: uuid.UUID
+    subject_id: uuid.UUID
+    author_id: uuid.UUID
+    project_id: Optional[uuid.UUID] = None
+
+    relationship: TestimonialRelationship
+    body: str
+
+    status: TestimonialStatus
+    is_featured: bool = False
+    responded_at: Optional[datetime] = None
+
+    author: Optional[TestimonialParty] = None
+    subject: Optional[TestimonialParty] = None
+
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class TestimonialList(BaseModel):
+    items: list[TestimonialResponse]
+    total: int
+    limit: int
+    offset: int
+
+
+class RelationshipCount(BaseModel):
+    relationship: TestimonialRelationship
+    count: int
+
+
+class TestimonialSummary(BaseModel):
+    user_id: uuid.UUID
+    username: str
+
+    total_approved: int = Field(description="Approved testimonials, the only ones shown publicly")
+    featured: list[TestimonialResponse] = Field(default_factory=list)
+    by_relationship: list[RelationshipCount] = Field(default_factory=list)
+    max_featured: int = Field(default=MAX_FEATURED)

--- a/backend/app/services/testimonial_service.py
+++ b/backend/app/services/testimonial_service.py
@@ -1,0 +1,394 @@
+from __future__ import annotations
+
+"""
+Business logic for peer testimonials (#1044).
+
+The rules in here *are* the feature. A testimonial system where the subject can
+quietly rewrite what was said about them, or approve their own praise, is worth
+less than no testimonials at all -- it looks like social proof while carrying
+none.
+"""
+
+import logging
+import uuid
+from collections import Counter
+from datetime import datetime, timezone
+
+from fastapi import HTTPException, status
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session, selectinload
+
+from app.models.project import Project
+from app.models.testimonial import (
+    MAX_FEATURED,
+    Testimonial,
+    TestimonialRelationship,
+    TestimonialStatus,
+)
+from app.models.user import User
+from app.schemas.testimonial import (
+    RelationshipCount,
+    TestimonialCreate,
+    TestimonialSummary,
+    TestimonialUpdate,
+)
+from app.services.block_service import BlockService
+
+logger = logging.getLogger(__name__)
+
+
+class TestimonialService:
+    """Write, moderate and read peer testimonials."""
+
+    # ------------------------------------------------------------------
+    # Lookups
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def get_user_or_404(db: Session, username: str) -> User:
+        user = db.scalar(select(User).where(User.username == username))
+        if user is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+        return user
+
+    @staticmethod
+    def get_subject_or_404(db: Session, subject_id: uuid.UUID) -> User:
+        user = db.get(User, subject_id)
+        if user is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+        return user
+
+    @staticmethod
+    def get_testimonial_or_404(db: Session, testimonial_id: uuid.UUID) -> Testimonial:
+        testimonial = db.scalar(
+            select(Testimonial)
+            .where(Testimonial.id == testimonial_id)
+            .options(selectinload(Testimonial.author), selectinload(Testimonial.subject))
+        )
+        if testimonial is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Testimonial not found"
+            )
+        return testimonial
+
+    # ------------------------------------------------------------------
+    # Guards
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def require_writable(db: Session, author: User, subject_id: uuid.UUID) -> None:
+        if author.id == subject_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="You cannot write a testimonial about yourself.",
+            )
+
+        # is_blocked is bidirectional. Either direction is a hard no: a block
+        # means these two have opted out of each other, and a testimonial is a
+        # channel from one to the other's profile.
+        if BlockService.is_blocked(db, author.id, subject_id):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You cannot write a testimonial for this user.",
+            )
+
+    @staticmethod
+    def require_author(testimonial: Testimonial, user: User) -> None:
+        if testimonial.author_id != user.id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Only the author can edit this testimonial.",
+            )
+
+    @staticmethod
+    def require_subject(testimonial: Testimonial, user: User) -> None:
+        """
+        Moderation belongs to the subject alone. If the author could approve
+        their own testimonial, approval would mean nothing.
+        """
+        if testimonial.subject_id != user.id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Only the person a testimonial is about can moderate it.",
+            )
+
+    @staticmethod
+    def can_view(testimonial: Testimonial, viewer: User | None) -> bool:
+        if testimonial.status == TestimonialStatus.APPROVED:
+            return True
+        if viewer is None:
+            return False
+        return viewer.id in (testimonial.author_id, testimonial.subject_id)
+
+    @staticmethod
+    def validate_project(db: Session, project_id: uuid.UUID | None) -> None:
+        if project_id is None:
+            return
+        if db.scalar(select(Project.id).where(Project.id == project_id)) is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Project not found")
+
+    # ------------------------------------------------------------------
+    # Writes
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def create(db: Session, author: User, payload: TestimonialCreate) -> Testimonial:
+        TestimonialService.get_subject_or_404(db, payload.subject_id)
+        TestimonialService.require_writable(db, author, payload.subject_id)
+        TestimonialService.validate_project(db, payload.project_id)
+
+        existing = db.scalar(
+            select(Testimonial).where(
+                Testimonial.author_id == author.id,
+                Testimonial.subject_id == payload.subject_id,
+            )
+        )
+        if existing is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="You have already written a testimonial for this user. Edit it instead.",
+            )
+
+        now = datetime.now(timezone.utc)
+        testimonial = Testimonial(
+            id=uuid.uuid4(),
+            subject_id=payload.subject_id,
+            author_id=author.id,
+            project_id=payload.project_id,
+            relationship_type=payload.relationship,
+            body=payload.body,
+            status=TestimonialStatus.PENDING,
+            is_featured=False,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(testimonial)
+        db.commit()
+        db.refresh(testimonial)
+        return testimonial
+
+    @staticmethod
+    def update(
+        db: Session,
+        testimonial_id: uuid.UUID,
+        author: User,
+        payload: TestimonialUpdate,
+    ) -> Testimonial:
+        """
+        Edit an existing testimonial.
+
+        Editing an approved testimonial sends it back to ``pending`` and clears
+        the feature flag. Without that, approval would be a rubber stamp on
+        text the author can swap out afterwards -- get something bland
+        approved, then rewrite it into anything at all.
+        """
+        testimonial = TestimonialService.get_testimonial_or_404(db, testimonial_id)
+        TestimonialService.require_author(testimonial, author)
+
+        if testimonial.status == TestimonialStatus.HIDDEN:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="This testimonial has been hidden and can no longer be edited.",
+            )
+
+        data = payload.model_dump(exclude_unset=True)
+        if "project_id" in data:
+            TestimonialService.validate_project(db, data["project_id"])
+
+        content_changed = "body" in data or "relationship" in data
+
+        if "relationship" in data:
+            testimonial.relationship_type = data.pop("relationship")
+        for field, value in data.items():
+            setattr(testimonial, field, value)
+
+        if content_changed and testimonial.status == TestimonialStatus.APPROVED:
+            testimonial.status = TestimonialStatus.PENDING
+            testimonial.is_featured = False
+            testimonial.responded_at = None
+
+        testimonial.updated_at = datetime.now(timezone.utc)
+        db.commit()
+        db.refresh(testimonial)
+        return testimonial
+
+    @staticmethod
+    def delete(db: Session, testimonial_id: uuid.UUID, user: User) -> None:
+        """
+        Only the author may delete. The subject can hide a testimonial but not
+        erase it -- someone else's opinion is not theirs to destroy, and a
+        subject who could delete would be curating rather than receiving.
+        """
+        testimonial = TestimonialService.get_testimonial_or_404(db, testimonial_id)
+        TestimonialService.require_author(testimonial, user)
+
+        db.delete(testimonial)
+        db.commit()
+
+    # ------------------------------------------------------------------
+    # Moderation
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def approve(db: Session, testimonial_id: uuid.UUID, subject: User) -> Testimonial:
+        testimonial = TestimonialService.get_testimonial_or_404(db, testimonial_id)
+        TestimonialService.require_subject(testimonial, subject)
+
+        now = datetime.now(timezone.utc)
+        testimonial.status = TestimonialStatus.APPROVED
+        testimonial.responded_at = now
+        testimonial.updated_at = now
+
+        db.commit()
+        db.refresh(testimonial)
+        return testimonial
+
+    @staticmethod
+    def hide(db: Session, testimonial_id: uuid.UUID, subject: User) -> Testimonial:
+        testimonial = TestimonialService.get_testimonial_or_404(db, testimonial_id)
+        TestimonialService.require_subject(testimonial, subject)
+
+        now = datetime.now(timezone.utc)
+        testimonial.status = TestimonialStatus.HIDDEN
+        # A hidden testimonial cannot stay featured, or hiding would only
+        # remove it from the list while leaving it at the top of the profile.
+        testimonial.is_featured = False
+        testimonial.responded_at = now
+        testimonial.updated_at = now
+
+        db.commit()
+        db.refresh(testimonial)
+        return testimonial
+
+    @staticmethod
+    def set_featured(
+        db: Session,
+        testimonial_id: uuid.UUID,
+        subject: User,
+        featured: bool = True,
+    ) -> Testimonial:
+        testimonial = TestimonialService.get_testimonial_or_404(db, testimonial_id)
+        TestimonialService.require_subject(testimonial, subject)
+
+        if featured:
+            if testimonial.status != TestimonialStatus.APPROVED:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Only an approved testimonial can be featured.",
+                )
+
+            already = int(
+                db.scalar(
+                    select(func.count(Testimonial.id)).where(
+                        Testimonial.subject_id == subject.id,
+                        Testimonial.is_featured.is_(True),
+                        Testimonial.id != testimonial.id,
+                    )
+                )
+                or 0
+            )
+            if already >= MAX_FEATURED:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"You can feature at most {MAX_FEATURED} testimonials.",
+                )
+
+        testimonial.is_featured = featured
+        testimonial.updated_at = datetime.now(timezone.utc)
+
+        db.commit()
+        db.refresh(testimonial)
+        return testimonial
+
+    # ------------------------------------------------------------------
+    # Reads
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def list_for_subject(
+        db: Session,
+        subject: User,
+        viewer: User | None,
+        status_filter: TestimonialStatus | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> tuple[list[Testimonial], int]:
+        is_subject = viewer is not None and viewer.id == subject.id
+
+        conditions = [Testimonial.subject_id == subject.id]
+        if is_subject:
+            # The subject may filter across their whole inbox; with no filter
+            # they see everything, which is what a moderation queue needs.
+            if status_filter is not None:
+                conditions.append(Testimonial.status == status_filter)
+        else:
+            # Everyone else sees approved only, whatever they ask for.
+            conditions.append(Testimonial.status == TestimonialStatus.APPROVED)
+
+        total = int(db.scalar(select(func.count(Testimonial.id)).where(*conditions)) or 0)
+
+        stmt = (
+            select(Testimonial)
+            .where(*conditions)
+            .options(selectinload(Testimonial.author), selectinload(Testimonial.subject))
+            # Featured first, then newest.
+            .order_by(Testimonial.is_featured.desc(), Testimonial.created_at.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+        return list(db.scalars(stmt).all()), total
+
+    @staticmethod
+    def list_written_by(
+        db: Session,
+        author: User,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> tuple[list[Testimonial], int]:
+        conditions = [Testimonial.author_id == author.id]
+        total = int(db.scalar(select(func.count(Testimonial.id)).where(*conditions)) or 0)
+
+        stmt = (
+            select(Testimonial)
+            .where(*conditions)
+            .options(selectinload(Testimonial.subject))
+            .order_by(Testimonial.created_at.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+        return list(db.scalars(stmt).all()), total
+
+    @staticmethod
+    def summarise(db: Session, subject: User) -> TestimonialSummary:
+        approved = list(
+            db.scalars(
+                select(Testimonial)
+                .where(
+                    Testimonial.subject_id == subject.id,
+                    Testimonial.status == TestimonialStatus.APPROVED,
+                )
+                .options(selectinload(Testimonial.author))
+                .order_by(Testimonial.is_featured.desc(), Testimonial.created_at.desc())
+            ).all()
+        )
+
+        counter: Counter[TestimonialRelationship] = Counter(
+            item.relationship_type for item in approved
+        )
+
+        return TestimonialSummary(
+            user_id=subject.id,
+            username=subject.username,
+            total_approved=len(approved),
+            featured=[item for item in approved if item.is_featured][:MAX_FEATURED],
+            by_relationship=[
+                RelationshipCount(relationship=relationship, count=count)
+                for relationship, count in sorted(
+                    counter.items(), key=lambda pair: (-pair[1], pair[0].value)
+                )
+            ],
+            max_featured=MAX_FEATURED,
+        )
+
+
+__all__ = ["TestimonialService", "MAX_FEATURED"]

--- a/backend/tests/test_testimonials.py
+++ b/backend/tests/test_testimonials.py
@@ -1,0 +1,534 @@
+"""
+Unit & integration tests for peer testimonials (#1044).
+
+The permission rules are the feature here, so most of these tests are about
+who may do what rather than about storage.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+# Aliased away from a Test* prefix so pytest does not try to collect the
+# model and schema classes as test cases.
+from app.models.testimonial import MAX_BODY_LENGTH, MAX_FEATURED, MIN_BODY_LENGTH
+from app.models.testimonial import Testimonial as DbTestimonial
+from app.models.testimonial import TestimonialStatus as Status
+from app.models.user import User
+from app.schemas.testimonial import TestimonialCreate as CreatePayload
+from app.schemas.testimonial import TestimonialUpdate as UpdatePayload
+from app.services.testimonial_service import TestimonialService
+
+GOOD_BODY = (
+    "We shipped the ingest pipeline together over three months. Calm under "
+    "pressure, wrote the tests nobody wanted to write, and left the codebase "
+    "better than they found it."
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_user(username: str = "ada") -> MagicMock:
+    user = MagicMock(spec=User)
+    user.id = uuid.uuid4()
+    user.username = username
+    return user
+
+
+def _make_testimonial(
+    subject_id: uuid.UUID,
+    author_id: uuid.UUID,
+    status: Status = Status.PENDING,
+) -> MagicMock:
+    item = MagicMock(spec=DbTestimonial)
+    item.id = uuid.uuid4()
+    item.subject_id = subject_id
+    item.author_id = author_id
+    item.status = status
+    item.is_featured = False
+    return item
+
+
+# ---------------------------------------------------------------------------
+# 1. Body validation
+# ---------------------------------------------------------------------------
+
+
+class TestBodyValidation:
+    def test_a_real_testimonial_is_accepted(self):
+        payload = CreatePayload(
+            subject_id=uuid.uuid4(), relationship="collaborator", body=GOOD_BODY
+        )
+        assert payload.body == GOOD_BODY
+
+    def test_two_words_is_rejected(self):
+        # A one-line "great dev!" carries no information and dilutes the
+        # testimonials that do.
+        with pytest.raises(Exception):
+            CreatePayload(subject_id=uuid.uuid4(), relationship="mentor", body="Great dev!")
+
+    def test_exactly_the_minimum_is_accepted(self):
+        payload = CreatePayload(
+            subject_id=uuid.uuid4(), relationship="mentor", body="x" * MIN_BODY_LENGTH
+        )
+        assert len(payload.body) == MIN_BODY_LENGTH
+
+    def test_whitespace_padding_does_not_buy_length(self):
+        padded = "  " + ("x" * (MIN_BODY_LENGTH - 10)) + "  "
+        with pytest.raises(Exception):
+            CreatePayload(subject_id=uuid.uuid4(), relationship="mentor", body=padded)
+
+    def test_body_is_stripped(self):
+        payload = CreatePayload(
+            subject_id=uuid.uuid4(), relationship="client", body=f"  {GOOD_BODY}  "
+        )
+        assert payload.body == GOOD_BODY
+
+    def test_overlong_body_is_rejected(self):
+        with pytest.raises(Exception):
+            CreatePayload(
+                subject_id=uuid.uuid4(), relationship="client", body="x" * (MAX_BODY_LENGTH + 1)
+            )
+
+    def test_unknown_relationship_is_rejected(self):
+        with pytest.raises(Exception):
+            CreatePayload(subject_id=uuid.uuid4(), relationship="nemesis", body=GOOD_BODY)
+
+    def test_update_omits_unset_fields(self):
+        assert UpdatePayload(body=GOOD_BODY).model_dump(exclude_unset=True) == {
+            "body": GOOD_BODY
+        }
+
+
+# ---------------------------------------------------------------------------
+# 2. Write guards
+# ---------------------------------------------------------------------------
+
+
+class TestWriteGuards:
+    def test_self_testimonial_is_rejected(self):
+        db = MagicMock(spec=Session)
+        user = _make_user()
+        with pytest.raises(HTTPException) as exc:
+            TestimonialService.require_writable(db, user, user.id)
+        assert exc.value.status_code == 400
+        assert "yourself" in exc.value.detail
+
+    def test_blocked_pair_is_rejected(self):
+        db = MagicMock(spec=Session)
+        author = _make_user("author")
+        subject_id = uuid.uuid4()
+
+        with patch("app.services.testimonial_service.BlockService.is_blocked", return_value=True):
+            with pytest.raises(HTTPException) as exc:
+                TestimonialService.require_writable(db, author, subject_id)
+        assert exc.value.status_code == 403
+
+    def test_unblocked_pair_is_allowed(self):
+        db = MagicMock(spec=Session)
+        author = _make_user("author")
+        with patch("app.services.testimonial_service.BlockService.is_blocked", return_value=False):
+            TestimonialService.require_writable(db, author, uuid.uuid4())
+
+    def test_self_check_runs_before_the_block_lookup(self):
+        # Writing about yourself is always wrong, block or no block.
+        db = MagicMock(spec=Session)
+        user = _make_user()
+        with patch("app.services.testimonial_service.BlockService.is_blocked") as is_blocked:
+            with pytest.raises(HTTPException):
+                TestimonialService.require_writable(db, user, user.id)
+            is_blocked.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 3. Role guards
+# ---------------------------------------------------------------------------
+
+
+class TestRoleGuards:
+    def test_author_may_edit(self):
+        author = _make_user("author")
+        item = _make_testimonial(uuid.uuid4(), author.id)
+        TestimonialService.require_author(item, author)
+
+    def test_subject_may_not_edit(self):
+        subject = _make_user("subject")
+        item = _make_testimonial(subject.id, uuid.uuid4())
+        with pytest.raises(HTTPException) as exc:
+            TestimonialService.require_author(item, subject)
+        assert exc.value.status_code == 403
+
+    def test_subject_may_moderate(self):
+        subject = _make_user("subject")
+        item = _make_testimonial(subject.id, uuid.uuid4())
+        TestimonialService.require_subject(item, subject)
+
+    def test_author_may_not_moderate(self):
+        # If the author could approve their own testimonial, approval would
+        # mean nothing at all.
+        author = _make_user("author")
+        item = _make_testimonial(uuid.uuid4(), author.id)
+        with pytest.raises(HTTPException) as exc:
+            TestimonialService.require_subject(item, author)
+        assert exc.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# 4. Visibility
+# ---------------------------------------------------------------------------
+
+
+class TestVisibility:
+    def test_approved_is_public(self):
+        item = _make_testimonial(uuid.uuid4(), uuid.uuid4(), Status.APPROVED)
+        assert TestimonialService.can_view(item, None) is True
+
+    def test_pending_is_not_public(self):
+        item = _make_testimonial(uuid.uuid4(), uuid.uuid4(), Status.PENDING)
+        assert TestimonialService.can_view(item, None) is False
+        assert TestimonialService.can_view(item, _make_user("stranger")) is False
+
+    def test_pending_is_visible_to_both_parties(self):
+        subject = _make_user("subject")
+        author = _make_user("author")
+        item = _make_testimonial(subject.id, author.id, Status.PENDING)
+
+        assert TestimonialService.can_view(item, subject) is True
+        assert TestimonialService.can_view(item, author) is True
+
+    def test_hidden_is_not_public(self):
+        item = _make_testimonial(uuid.uuid4(), uuid.uuid4(), Status.HIDDEN)
+        assert TestimonialService.can_view(item, None) is False
+
+
+# ---------------------------------------------------------------------------
+# 5. HTTP surface (real database)
+# ---------------------------------------------------------------------------
+
+
+class TestTestimonialEndpoints:
+    @staticmethod
+    def _auth(token: str) -> dict[str, str]:
+        return {"Authorization": f"Bearer {token}"}
+
+    def _write(self, client, token, subject_id, **overrides):
+        payload = {
+            "subject_id": str(subject_id),
+            "relationship": "collaborator",
+            "body": GOOD_BODY,
+        }
+        payload.update(overrides)
+        return client.post("/api/v1/testimonials", json=payload, headers=self._auth(token))
+
+    def test_writing_requires_authentication(self, client):
+        response = client.post(
+            "/api/v1/testimonials",
+            json={"subject_id": str(uuid.uuid4()), "relationship": "mentor", "body": GOOD_BODY},
+        )
+        assert response.status_code in (401, 403)
+
+    def test_unknown_subject_is_404(self, client, register_and_login):
+        _, token = register_and_login("ts1@example.com", "tsuser1")
+        assert self._write(client, token, uuid.uuid4()).status_code == 404
+
+    def test_self_testimonial_is_400(self, client, register_and_login):
+        user_id, token = register_and_login("ts2@example.com", "tsuser2")
+        response = self._write(client, token, user_id)
+        assert response.status_code == 400
+        assert "yourself" in response.json()["detail"]
+
+    def test_new_testimonial_is_pending_and_hidden_from_the_public(
+        self, client, register_and_login
+    ):
+        subject_id, _ = register_and_login("ts3@example.com", "tsuser3")
+        _, author_token = register_and_login("ts4@example.com", "tsuser4")
+
+        created = self._write(client, author_token, subject_id)
+        assert created.status_code == 201, created.text
+        assert created.json()["status"] == "pending"
+        assert created.json()["is_featured"] is False
+
+        # Not on the public profile...
+        public = client.get("/api/v1/users/tsuser3/testimonials")
+        assert public.status_code == 200
+        assert public.json()["total"] == 0
+
+        # ...but the author can see their own.
+        written = client.get(
+            "/api/v1/testimonials/written", headers=self._auth(author_token)
+        )
+        assert written.json()["total"] == 1
+
+    def test_subject_sees_pending_in_their_queue(self, client, register_and_login):
+        subject_id, subject_token = register_and_login("ts5@example.com", "tsuser5")
+        _, author_token = register_and_login("ts6@example.com", "tsuser6")
+        self._write(client, author_token, subject_id)
+
+        received = client.get(
+            "/api/v1/testimonials/received", headers=self._auth(subject_token)
+        )
+        assert received.status_code == 200
+        assert received.json()["total"] == 1
+        assert received.json()["items"][0]["status"] == "pending"
+
+    def test_approval_publishes_it(self, client, register_and_login):
+        subject_id, subject_token = register_and_login("ts7@example.com", "tsuser7")
+        _, author_token = register_and_login("ts8@example.com", "tsuser8")
+        testimonial_id = self._write(client, author_token, subject_id).json()["id"]
+
+        approved = client.post(
+            f"/api/v1/testimonials/{testimonial_id}/approve", headers=self._auth(subject_token)
+        )
+        assert approved.status_code == 200
+        assert approved.json()["status"] == "approved"
+        assert approved.json()["responded_at"] is not None
+
+        public = client.get("/api/v1/users/tsuser7/testimonials")
+        assert public.json()["total"] == 1
+
+    def test_author_cannot_approve_their_own(self, client, register_and_login):
+        subject_id, _ = register_and_login("ts9@example.com", "tsuser9")
+        _, author_token = register_and_login("ts10@example.com", "tsuser10")
+        testimonial_id = self._write(client, author_token, subject_id).json()["id"]
+
+        response = client.post(
+            f"/api/v1/testimonials/{testimonial_id}/approve", headers=self._auth(author_token)
+        )
+        assert response.status_code == 403
+
+        # And it is still pending.
+        assert client.get("/api/v1/users/tsuser9/testimonials").json()["total"] == 0
+
+    def test_a_stranger_cannot_approve(self, client, register_and_login):
+        subject_id, _ = register_and_login("ts11@example.com", "tsuser11")
+        _, author_token = register_and_login("ts12@example.com", "tsuser12")
+        testimonial_id = self._write(client, author_token, subject_id).json()["id"]
+
+        _, stranger_token = register_and_login("ts13@example.com", "tsuser13")
+        response = client.post(
+            f"/api/v1/testimonials/{testimonial_id}/approve", headers=self._auth(stranger_token)
+        )
+        assert response.status_code == 403
+
+    def test_second_testimonial_for_the_same_person_is_409(self, client, register_and_login):
+        subject_id, _ = register_and_login("ts14@example.com", "tsuser14")
+        _, author_token = register_and_login("ts15@example.com", "tsuser15")
+
+        assert self._write(client, author_token, subject_id).status_code == 201
+        second = self._write(client, author_token, subject_id)
+        assert second.status_code == 409
+        assert "already written" in second.json()["detail"]
+
+    def test_editing_an_approved_testimonial_resets_it_to_pending(
+        self, client, register_and_login
+    ):
+        # Otherwise approval is a rubber stamp: get something bland approved,
+        # then swap the text for anything at all.
+        subject_id, subject_token = register_and_login("ts16@example.com", "tsuser16")
+        _, author_token = register_and_login("ts17@example.com", "tsuser17")
+        testimonial_id = self._write(client, author_token, subject_id).json()["id"]
+
+        client.post(
+            f"/api/v1/testimonials/{testimonial_id}/approve", headers=self._auth(subject_token)
+        )
+        client.post(
+            f"/api/v1/testimonials/{testimonial_id}/feature", headers=self._auth(subject_token)
+        )
+
+        edited = client.patch(
+            f"/api/v1/testimonials/{testimonial_id}",
+            json={"body": GOOD_BODY + " Also shipped the migration single-handed."},
+            headers=self._auth(author_token),
+        )
+        assert edited.status_code == 200
+        assert edited.json()["status"] == "pending"
+        assert edited.json()["is_featured"] is False
+
+        # And it drops off the public profile again.
+        assert client.get("/api/v1/users/tsuser16/testimonials").json()["total"] == 0
+
+    def test_subject_cannot_edit_the_text(self, client, register_and_login):
+        subject_id, subject_token = register_and_login("ts18@example.com", "tsuser18")
+        _, author_token = register_and_login("ts19@example.com", "tsuser19")
+        testimonial_id = self._write(client, author_token, subject_id).json()["id"]
+
+        response = client.patch(
+            f"/api/v1/testimonials/{testimonial_id}",
+            json={"body": "x" * MIN_BODY_LENGTH},
+            headers=self._auth(subject_token),
+        )
+        assert response.status_code == 403
+
+    def test_subject_can_hide_but_not_delete(self, client, register_and_login):
+        subject_id, subject_token = register_and_login("ts20@example.com", "tsuser20")
+        _, author_token = register_and_login("ts21@example.com", "tsuser21")
+        testimonial_id = self._write(client, author_token, subject_id).json()["id"]
+
+        client.post(
+            f"/api/v1/testimonials/{testimonial_id}/approve", headers=self._auth(subject_token)
+        )
+
+        hidden = client.post(
+            f"/api/v1/testimonials/{testimonial_id}/hide", headers=self._auth(subject_token)
+        )
+        assert hidden.status_code == 200
+        assert hidden.json()["status"] == "hidden"
+
+        # Someone else's opinion is not theirs to erase.
+        deleted = client.delete(
+            f"/api/v1/testimonials/{testimonial_id}", headers=self._auth(subject_token)
+        )
+        assert deleted.status_code == 403
+
+    def test_author_can_delete_their_own(self, client, register_and_login):
+        subject_id, _ = register_and_login("ts22@example.com", "tsuser22")
+        _, author_token = register_and_login("ts23@example.com", "tsuser23")
+        testimonial_id = self._write(client, author_token, subject_id).json()["id"]
+
+        response = client.delete(
+            f"/api/v1/testimonials/{testimonial_id}", headers=self._auth(author_token)
+        )
+        assert response.status_code == 204
+
+    def test_featuring_requires_approval(self, client, register_and_login):
+        subject_id, subject_token = register_and_login("ts24@example.com", "tsuser24")
+        _, author_token = register_and_login("ts25@example.com", "tsuser25")
+        testimonial_id = self._write(client, author_token, subject_id).json()["id"]
+
+        response = client.post(
+            f"/api/v1/testimonials/{testimonial_id}/feature", headers=self._auth(subject_token)
+        )
+        assert response.status_code == 400
+
+    def test_featuring_a_fourth_is_rejected(self, client, register_and_login):
+        subject_id, subject_token = register_and_login("ts26@example.com", "tsuser26")
+
+        ids = []
+        for i in range(MAX_FEATURED + 1):
+            _, author_token = register_and_login(f"ts26a{i}@example.com", f"tsauthor26{i}")
+            testimonial_id = self._write(client, author_token, subject_id).json()["id"]
+            client.post(
+                f"/api/v1/testimonials/{testimonial_id}/approve",
+                headers=self._auth(subject_token),
+            )
+            ids.append(testimonial_id)
+
+        for testimonial_id in ids[:MAX_FEATURED]:
+            response = client.post(
+                f"/api/v1/testimonials/{testimonial_id}/feature",
+                headers=self._auth(subject_token),
+            )
+            assert response.status_code == 200
+
+        one_too_many = client.post(
+            f"/api/v1/testimonials/{ids[MAX_FEATURED]}/feature",
+            headers=self._auth(subject_token),
+        )
+        assert one_too_many.status_code == 400
+        assert str(MAX_FEATURED) in one_too_many.json()["detail"]
+
+    def test_un_featuring_frees_a_slot(self, client, register_and_login):
+        subject_id, subject_token = register_and_login("ts27@example.com", "tsuser27")
+
+        ids = []
+        for i in range(MAX_FEATURED + 1):
+            _, author_token = register_and_login(f"ts27a{i}@example.com", f"tsauthor27{i}")
+            testimonial_id = self._write(client, author_token, subject_id).json()["id"]
+            client.post(
+                f"/api/v1/testimonials/{testimonial_id}/approve",
+                headers=self._auth(subject_token),
+            )
+            ids.append(testimonial_id)
+
+        for testimonial_id in ids[:MAX_FEATURED]:
+            client.post(
+                f"/api/v1/testimonials/{testimonial_id}/feature",
+                headers=self._auth(subject_token),
+            )
+
+        client.post(
+            f"/api/v1/testimonials/{ids[0]}/feature",
+            params={"featured": False},
+            headers=self._auth(subject_token),
+        )
+
+        response = client.post(
+            f"/api/v1/testimonials/{ids[MAX_FEATURED]}/feature",
+            headers=self._auth(subject_token),
+        )
+        assert response.status_code == 200
+
+    def test_hiding_un_features(self, client, register_and_login):
+        subject_id, subject_token = register_and_login("ts28@example.com", "tsuser28")
+        _, author_token = register_and_login("ts29@example.com", "tsuser29")
+        testimonial_id = self._write(client, author_token, subject_id).json()["id"]
+
+        client.post(
+            f"/api/v1/testimonials/{testimonial_id}/approve", headers=self._auth(subject_token)
+        )
+        client.post(
+            f"/api/v1/testimonials/{testimonial_id}/feature", headers=self._auth(subject_token)
+        )
+
+        hidden = client.post(
+            f"/api/v1/testimonials/{testimonial_id}/hide", headers=self._auth(subject_token)
+        )
+        assert hidden.json()["is_featured"] is False
+
+    def test_pending_testimonial_is_404_for_a_stranger(self, client, register_and_login):
+        subject_id, _ = register_and_login("ts30@example.com", "tsuser30")
+        _, author_token = register_and_login("ts31@example.com", "tsuser31")
+        testimonial_id = self._write(client, author_token, subject_id).json()["id"]
+
+        # A 403 would confirm an unapproved testimonial about this person
+        # exists, which is exactly what moderation is meant to hide.
+        assert client.get(f"/api/v1/testimonials/{testimonial_id}").status_code == 404
+        assert (
+            client.get(
+                f"/api/v1/testimonials/{testimonial_id}", headers=self._auth(author_token)
+            ).status_code
+            == 200
+        )
+
+    def test_status_filter_is_ignored_for_the_public(self, client, register_and_login):
+        subject_id, _ = register_and_login("ts32@example.com", "tsuser32")
+        _, author_token = register_and_login("ts33@example.com", "tsuser33")
+        self._write(client, author_token, subject_id)
+
+        response = client.get(
+            "/api/v1/users/tsuser32/testimonials", params={"status": "pending"}
+        )
+        assert response.status_code == 200
+        assert response.json()["total"] == 0
+
+    def test_summary_counts_only_approved(self, client, register_and_login):
+        subject_id, subject_token = register_and_login("ts34@example.com", "tsuser34")
+
+        _, first_token = register_and_login("ts35@example.com", "tsuser35")
+        approved_id = self._write(
+            client, first_token, subject_id, relationship="mentor"
+        ).json()["id"]
+        client.post(
+            f"/api/v1/testimonials/{approved_id}/approve", headers=self._auth(subject_token)
+        )
+
+        _, second_token = register_and_login("ts36@example.com", "tsuser36")
+        self._write(client, second_token, subject_id, relationship="client")
+
+        summary = client.get("/api/v1/users/tsuser34/testimonials/summary")
+        assert summary.status_code == 200
+        body = summary.json()
+        assert body["total_approved"] == 1
+        assert body["max_featured"] == MAX_FEATURED
+        assert [entry["relationship"] for entry in body["by_relationship"]] == ["mentor"]
+        assert body["featured"] == []
+
+    def test_unknown_username_is_404(self, client):
+        assert client.get("/api/v1/users/no-such-person/testimonials").status_code == 404


### PR DESCRIPTION
Closes #1044

## Why

Every trust signal on DevLink is currently machine-generated — reputation logs, badges, repository quality scores, profile completion percentages. None of it is the thing that actually persuades a recruiter or a project owner: another human writing a paragraph about what you were like to work with.

**This is not #257 (Skill Endorsement API).** An endorsement is a +1 on a skill tag — a counter. A testimonial is free text with an author, a stated relationship, and a moderation lifecycle. Different table, different rules, and they compose fine.

## The rules are the feature

A testimonial system where the subject can quietly rewrite what was said about them, or where the author can approve their own praise, is worth *less* than having no testimonials at all: it looks like social proof while carrying none. So the interesting part of this PR is the permission matrix, not the storage.

| | Author | Subject | Everyone else |
|---|---|---|---|
| Write | ✅ | ✗ (self) | — |
| Edit text | ✅ | ✗ 403 | ✗ |
| Approve / hide | ✗ 403 | ✅ | ✗ 403 |
| Feature | ✗ | ✅ | ✗ |
| Delete | ✅ | ✗ 403 | ✗ |
| See while pending | ✅ | ✅ | ✗ 404 |

Specifically:

- **You cannot write about yourself** — 400, and the check runs *before* the block lookup, since it is wrong regardless.
- **A block in either direction rejects the write.** `BlockService.is_blocked` is already bidirectional. A block means these two have opted out of each other, and a testimonial is a channel from one onto the other's profile.
- **Editing the text of an approved testimonial returns it to `pending` and clears `is_featured`.** This is the rule that makes approval mean something. Without it: get something bland approved, then swap the text for anything at all, and it stays live on their profile under their approval.
- **The author may delete; the subject may hide but not erase.** A subject who could delete would be curating rather than receiving. Hiding also un-features — otherwise hiding would remove it from the list while leaving it pinned at the top of the profile.
- **Featuring requires `approved` and caps at 3.** Un-featuring frees a slot.
- **A pending testimonial is a 404, not a 403**, for anyone but the two parties. A 403 confirms that an unapproved testimonial about this person exists, which is precisely what moderation hides.
- **`?status=` is honoured for the subject and ignored for everyone else**, so the public listing cannot be coaxed into showing the queue.

**The 50-character body floor is deliberate.** "Great dev!" carries no information and dilutes the testimonials that do. Whitespace padding does not get you over the line — the validator strips first, then measures.

## Data model

`testimonials` — `subject_id`, `author_id`, nullable `project_id` (`SET NULL`; the testimonial is about the person, not the project), `relationship` enum, `body`, `status` enum, `is_featured`, `responded_at`.

`UNIQUE (author_id, subject_id)` — one per pair. Someone with an opinion worth stating twice can edit the one they already wrote. A `CHECK (author_id <> subject_id)` backs the self-testimonial rule at the database level too.

One wrinkle worth flagging for review: the column is `relationship`, which is also SQLAlchemy's own name in that module's namespace, so the mapped attribute is `relationship_type` with `name="relationship"` and a small read-only `relationship` property bridging back for the response schema. It is commented in place.

## Endpoints

```
POST   /api/v1/testimonials
PATCH  /api/v1/testimonials/{id}
DELETE /api/v1/testimonials/{id}
POST   /api/v1/testimonials/{id}/approve
POST   /api/v1/testimonials/{id}/hide
POST   /api/v1/testimonials/{id}/feature       ?featured=false to un-feature
GET    /api/v1/testimonials/received           ?status=
GET    /api/v1/testimonials/written
GET    /api/v1/testimonials/{id}
GET    /api/v1/users/{username}/testimonials    ?status= (subject only)
GET    /api/v1/users/{username}/testimonials/summary
```

## Migration

`d9e2b7c4f183`, branching from `d4e5f6a7b8c9`. Creates `testimonialrelationship` and `testimonialstatus` with `checkfirst=True`, drops them on downgrade. Single head.

## Tests

41 cases, weighted towards the permission matrix:

- Author approving their own → 403, **and the testimonial is still absent from the public profile afterwards**.
- Stranger approving → 403. Subject editing the text → 403. Subject deleting → 403.
- Approve, feature, then edit → back to `pending`, `is_featured: false`, and gone from the public listing again.
- Fourth feature → 400 naming the limit; un-featuring one then lets the fourth through.
- Hiding an approved+featured testimonial clears `is_featured`.
- Pending is 404 for a stranger and 200 for its author, same id.
- `?status=pending` on the public endpoint returns 0.
- Self-testimonial 400; second testimonial for the same pair 409; body floor, ceiling, and whitespace-padding rejection.
- Summary counts approved only and groups by relationship.

```
41 passed
```
