### PR TITLE
feat(bookmarks): redesign bookmarks into compact collections

### DIFF
--- a/frontend/src/components/bookmarks/BookmarkListItem.tsx
+++ b/frontend/src/components/bookmarks/BookmarkListItem.tsx
@@ -1,0 +1,88 @@
+import type { ReactNode } from "react";
+import { Avatar, TagChip } from "@/components/shared/primitives";
+import { cn } from "@/lib/utils";
+
+/**
+ * A single compact row inside a bookmarks list. Replaces the old grid of
+ * large cards — one row per saved item, with the primary content on the
+ * left (usually wrapped in a `Link` by the caller) and hover-revealed
+ * actions on the right, kept as siblings so they never conflict with the
+ * row's own link.
+ */
+export function BookmarkListItem({
+  children,
+  actions,
+  className,
+}: {
+  children: ReactNode;
+  actions?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "group flex items-center gap-3 rounded-lg border-b border-border/50 px-2 py-2.5 -mx-2 last:border-b-0 transition-colors hover:bg-muted/30",
+        className,
+      )}
+    >
+      <div className="min-w-0 flex-1">{children}</div>
+      {actions && (
+        <div className="flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
+          {actions}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Shared avatar/title/subtitle/tags layout used inside a `BookmarkListItem`.
+ * Keeps every saved-item row (developers, projects, repositories, posts)
+ * visually consistent.
+ */
+export function BookmarkRowContent({
+  avatarSrc,
+  icon,
+  title,
+  subtitle,
+  badge,
+  tags,
+  meta,
+}: {
+  avatarSrc?: string | null;
+  icon?: ReactNode;
+  title: string;
+  subtitle?: string;
+  badge?: ReactNode;
+  tags?: string[];
+  meta?: ReactNode;
+}) {
+  return (
+    <div className="flex items-center gap-3">
+      {avatarSrc !== undefined ? (
+        <Avatar src={avatarSrc} alt={title} size={36} />
+      ) : (
+        <span className="grid h-9 w-9 shrink-0 place-items-center rounded-lg bg-muted text-base">
+          {icon}
+        </span>
+      )}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <p className="truncate text-[13px] font-semibold text-foreground">{title}</p>
+          {badge}
+        </div>
+        {subtitle && <p className="truncate text-[12px] text-muted-foreground">{subtitle}</p>}
+        {tags && tags.length > 0 && (
+          <div className="mt-1 flex flex-wrap gap-1">
+            {tags.slice(0, 3).map((t) => (
+              <TagChip key={t} className="px-1.5 py-0 text-[10px]">
+                {t}
+              </TagChip>
+            ))}
+          </div>
+        )}
+      </div>
+      {meta && <div className="shrink-0 text-[11px] text-muted-foreground">{meta}</div>}
+    </div>
+  );
+}

--- a/frontend/src/components/bookmarks/index.ts
+++ b/frontend/src/components/bookmarks/index.ts
@@ -1,3 +1,4 @@
 export { CollectionDialog } from "./CollectionDialog";
 export { CollectionSidebar } from "./CollectionSidebar";
 export { AddToCollectionMenu, BookmarkCollectionIndicator } from "./AddToCollectionMenu";
+export { BookmarkListItem, BookmarkRowContent } from "./BookmarkListItem";

--- a/frontend/src/routes/_app.bookmarks.tsx
+++ b/frontend/src/routes/_app.bookmarks.tsx
@@ -1,13 +1,15 @@
 import { useState, useCallback } from "react";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { Card, EmptyState, TagChip, Avatar } from "@/components/shared/primitives";
-import { projects, flares } from "@/mocks/seed";
+import { Card, EmptyState } from "@/components/shared/primitives";
+import { projects, flares, builders } from "@/mocks/seed";
+import { repositories } from "@/mocks/repositories";
 
-import { Bookmark, FolderOpen, Trash2, MapPin, Briefcase, Users } from "lucide-react";
+import { FolderOpen, Trash2, Users, FolderKanban, GitBranch, FileText, Star } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { CollectionSidebar } from "@/components/bookmarks/CollectionSidebar";
 import { CollectionDialog } from "@/components/bookmarks/CollectionDialog";
 import { AddToCollectionMenu } from "@/components/bookmarks/AddToCollectionMenu";
+import { BookmarkListItem, BookmarkRowContent } from "@/components/bookmarks/BookmarkListItem";
 
 import { BookmarkToggleButton } from "@/components/shared/BookmarkToggleButton";
 import {
@@ -18,6 +20,7 @@ import {
 } from "@/hooks/useBookmarkCollections";
 import type { BookmarkCollection } from "@/api";
 import { ProjectDifficultyBadge } from "@/components/project/ProjectDifficultyBadge";
+import type { RepositoryItem } from "@/mocks/repositories";
 
 export const Route = createFileRoute("/_app/bookmarks")({
   head: () => ({
@@ -25,7 +28,7 @@ export const Route = createFileRoute("/_app/bookmarks")({
       { title: "Bookmarks — DevLink" },
       {
         name: "description",
-        content: "Projects, builders and flares you've saved for later.",
+        content: "Projects, developers, repositories and posts you've saved for later.",
       },
     ],
   }),
@@ -38,20 +41,41 @@ type Developer = {
   name?: string;
   role?: string;
   location?: string;
-  experience?: string;
   skills?: string[];
 };
+
+function SectionHeader({ icon: Icon, label }: { icon: typeof Users; label: string }) {
+  return (
+    <p className="mb-2 flex items-center gap-1.5 text-[12px] font-semibold uppercase tracking-wider text-muted-foreground">
+      <Icon size={14} /> {label}
+    </p>
+  );
+}
 
 function BookmarksPage() {
   const [activeCollectionId, setActiveCollectionId] = useState<string | null>(null);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [renameTarget, setRenameTarget] = useState<BookmarkCollection | null>(null);
 
-  const [bookmarkedDevs, setBookmarkedDevs] = useState<Developer[]>([]);
-  const toggleBookmark = useCallback((dev: Developer) => {
-    setBookmarkedDevs((prev) =>
-      prev.some((d) => d.id === dev.id) ? prev.filter((d) => d.id !== dev.id) : [...prev, dev],
-    );
+  const [bookmarkedDevs, setBookmarkedDevs] = useState<Developer[]>(() =>
+    builders.slice(0, 3).map((b) => ({
+      id: b.id,
+      avatar_url: b.avatar,
+      name: b.name,
+      role: b.role,
+      location: b.country,
+      skills: b.skills,
+    })),
+  );
+  const toggleDevBookmark = useCallback((dev: Developer) => {
+    setBookmarkedDevs((prev) => prev.filter((d) => d.id !== dev.id));
+  }, []);
+
+  const [bookmarkedRepos, setBookmarkedRepos] = useState<RepositoryItem[]>(() =>
+    repositories.slice(0, 3),
+  );
+  const removeRepoBookmark = useCallback((repo: RepositoryItem) => {
+    setBookmarkedRepos((prev) => prev.filter((r) => r.id !== repo.id));
   }, []);
 
   const createCollection = useCreateCollection();
@@ -105,6 +129,7 @@ function BookmarksPage() {
   );
 
   const bookmarkedProjects = projects.slice(0, 3);
+  const bookmarkedPosts = flares.slice(0, 2);
 
   return (
     <div className="flex gap-6">
@@ -127,7 +152,7 @@ function BookmarksPage() {
             <p className="text-[13px] text-muted-foreground">
               {activeCollectionId
                 ? "Filtered by collection"
-                : "Projects, developers, and flares you've saved."}
+                : "Developers, projects, repositories and posts you've saved."}
             </p>
           </div>
           <Button
@@ -141,153 +166,172 @@ function BookmarksPage() {
           </Button>
         </div>
 
-        {/* SAVED DEVELOPERS / BUILDERS SECTION */}
+        {/* SAVED DEVELOPERS */}
         <section>
-          <div className="mb-2 flex items-center justify-between">
-            <p className="text-[12px] font-semibold uppercase tracking-wider text-muted-foreground flex items-center gap-1.5">
-              <Users size={14} /> Saved Developers
-            </p>
-          </div>
+          <SectionHeader icon={Users} label="Saved Developers" />
           {bookmarkedDevs.length === 0 ? (
-            <Card className="p-6 text-center border-dashed">
+            <Card className="border-dashed p-6 text-center">
               <p className="text-[13px] text-muted-foreground">
                 No developers bookmarked yet. Save builders from their profiles to see them here!
               </p>
             </Card>
           ) : (
-            <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+            <Card className="px-2 py-1">
               {bookmarkedDevs.map((dev) => (
-                <Card key={dev.id} className="p-4 flex flex-col justify-between">
-                  <div>
-                    <div className="flex justify-between items-start mb-3">
-                      <div className="flex items-center gap-2.5">
-                        <Avatar
-                          src={dev.avatar_url || ""}
-                          alt={dev.name || "Developer"}
-                          size={40}
-                        />
-                        <div>
-                          <p className="text-[14px] font-semibold text-foreground">{dev.name}</p>
-                          <p className="text-[12px] text-muted-foreground">{dev.role}</p>
-                        </div>
-                      </div>
-                      <button
-                        onClick={() => toggleBookmark(dev)}
-                        title="Remove bookmark"
-                        className="p-1 text-muted-foreground hover:text-destructive transition-colors"
-                      >
-                        <Trash2 size={14} />
-                      </button>
-                    </div>
-
-                    <div className="space-y-1 mb-3 text-[11px] text-muted-foreground">
-                      {dev.location && (
-                        <div className="flex items-center gap-1.5">
-                          <MapPin size={12} />
-                          <span>{dev.location}</span>
-                        </div>
-                      )}
-                      {dev.experience && (
-                        <div className="flex items-center gap-1.5">
-                          <Briefcase size={12} />
-                          <span>{dev.experience}</span>
-                        </div>
-                      )}
-                    </div>
-
-                    {dev.skills && dev.skills.length > 0 && (
-                      <div className="flex flex-wrap gap-1 mb-3">
-                        {dev.skills.map((s) => (
-                          <TagChip key={s}>{s}</TagChip>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-
-                  <Link
-                    to="/builders/$builderId"
-                    params={{ builderId: dev.id || "" }}
-                    className="mt-2 block w-full text-center text-[12px] font-medium py-1.5 rounded-md border border-border hover:bg-muted text-foreground transition-colors"
-                  >
-                    View Profile
+                <BookmarkListItem
+                  key={dev.id}
+                  actions={
+                    <button
+                      onClick={() => toggleDevBookmark(dev)}
+                      title="Remove bookmark"
+                      aria-label={`Remove ${dev.name} bookmark`}
+                      className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-destructive"
+                    >
+                      <Trash2 size={14} />
+                    </button>
+                  }
+                >
+                  <Link to="/builders/$builderId" params={{ builderId: dev.id }} className="block">
+                    <BookmarkRowContent
+                      avatarSrc={dev.avatar_url}
+                      title={dev.name ?? "Developer"}
+                      subtitle={[dev.role, dev.location].filter(Boolean).join(" · ")}
+                      tags={dev.skills}
+                    />
                   </Link>
-                </Card>
+                </BookmarkListItem>
               ))}
-            </div>
+            </Card>
           )}
         </section>
 
-        {/* PROJECTS SECTION */}
+        {/* SAVED PROJECTS */}
         <section>
-          <div className="mb-2 flex items-center justify-between">
-            <p className="text-[12px] font-semibold uppercase tracking-wider text-muted-foreground">
-              Projects
-            </p>
-          </div>
+          <SectionHeader icon={FolderKanban} label="Saved Projects" />
           {bookmarkedProjects.length === 0 ? (
             <EmptyState
               title="No bookmarked projects"
               desc="Save projects you're interested in to see them here."
             />
           ) : (
-            <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+            <Card className="px-2 py-1">
               {bookmarkedProjects.map((p) => (
-                <div key={p.id} className="group relative">
-                  <Link to="/projects/$projectId" params={{ projectId: p.id }}>
-                    <Card interactive className="p-4">
-                      <div className="flex items-start gap-3">
-                        <span className="grid h-10 w-10 shrink-0 place-items-center rounded-md bg-muted text-xl">
-                          {p.icon}
-                        </span>
-                        <div className="min-w-0 flex-1">
-                          <div className="flex items-center gap-2">
-                            <p className="truncate text-[14px] font-semibold text-foreground">
-                              {p.name}
-                            </p>
-                            {p.difficulty && <ProjectDifficultyBadge difficulty={p.difficulty} />}
-                          </div>
-                          <p className="mt-0.5 text-[12px] text-muted-foreground line-clamp-2">
-                            {p.description}
-                          </p>
-                        </div>
-
-                        <Bookmark size={14} className="text-primary fill-primary" />
-
-                        <Bookmark size={14} className="text-primary fill-primary shrink-0" />
-                      </div>
-                      <div className="mt-3 flex flex-wrap gap-1">
-                        {p.stack.map((s) => (
-                          <TagChip key={s}>{s}</TagChip>
-                        ))}
-                      </div>
-                    </Card>
-                  </Link>
-                  <div className="absolute right-2 top-2 flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
-                    <BookmarkToggleButton projectId={p.id} />
-                    <AddToCollectionMenu
-                      bookmarkId={p.id}
-                      onAddToCollection={handleAddToCollection(p.id)}
+                <BookmarkListItem
+                  key={p.id}
+                  actions={
+                    <>
+                      <BookmarkToggleButton
+                        projectId={p.id}
+                        className="h-7 min-w-0 px-2 text-[11px]"
+                      />
+                      <AddToCollectionMenu
+                        bookmarkId={p.id}
+                        onAddToCollection={handleAddToCollection(p.id)}
+                      />
+                    </>
+                  }
+                >
+                  <Link to="/projects/$projectId" params={{ projectId: p.id }} className="block">
+                    <BookmarkRowContent
+                      icon={p.icon}
+                      title={p.name}
+                      subtitle={p.description}
+                      badge={p.difficulty && <ProjectDifficultyBadge difficulty={p.difficulty} />}
+                      tags={p.stack}
                     />
-                  </div>
-                </div>
+                  </Link>
+                </BookmarkListItem>
               ))}
-            </div>
+            </Card>
           )}
         </section>
 
-        {/* FLARES SECTION */}
+        {/* SAVED REPOSITORIES */}
         <section>
-          <p className="mb-2 text-[12px] font-semibold uppercase tracking-wider text-muted-foreground">
-            Flares
-          </p>
-          <div className="space-y-2">
-            {flares.slice(0, 2).map((f) => (
-              <Card key={f.id} className="p-4">
-                <p className="text-[13px] font-semibold text-foreground">{f.author.name}</p>
-                <p className="mt-1 text-[13px] text-foreground">{f.content}</p>
-              </Card>
-            ))}
-          </div>
+          <SectionHeader icon={GitBranch} label="Saved Repositories" />
+          {bookmarkedRepos.length === 0 ? (
+            <Card className="border-dashed p-6 text-center">
+              <p className="text-[13px] text-muted-foreground">
+                No repositories bookmarked yet. Save repositories from a project to see them here!
+              </p>
+            </Card>
+          ) : (
+            <Card className="px-2 py-1">
+              {bookmarkedRepos.map((repo) => (
+                <BookmarkListItem
+                  key={repo.id}
+                  actions={
+                    <button
+                      onClick={() => removeRepoBookmark(repo)}
+                      title="Remove bookmark"
+                      aria-label={`Remove ${repo.name} bookmark`}
+                      className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-destructive"
+                    >
+                      <Trash2 size={14} />
+                    </button>
+                  }
+                >
+                  <Link
+                    to="/projects/$projectId"
+                    params={{ projectId: repo.projectId }}
+                    className="block"
+                  >
+                    <BookmarkRowContent
+                      icon={<GitBranch size={16} />}
+                      title={repo.name}
+                      subtitle={repo.description}
+                      tags={[repo.language]}
+                      meta={
+                        <span className="flex items-center gap-1">
+                          <Star size={12} />
+                          {repo.stars}
+                        </span>
+                      }
+                    />
+                  </Link>
+                </BookmarkListItem>
+              ))}
+            </Card>
+          )}
+        </section>
+
+        {/* SAVED POSTS */}
+        <section>
+          <SectionHeader icon={FileText} label="Saved Posts" />
+          {bookmarkedPosts.length === 0 ? (
+            <EmptyState
+              title="No bookmarked posts"
+              desc="Save posts from the feed to see them here."
+            />
+          ) : (
+            <Card className="px-2 py-1">
+              {bookmarkedPosts.map((f) => (
+                <BookmarkListItem
+                  key={f.id}
+                  actions={
+                    <>
+                      <BookmarkToggleButton
+                        targetType="flare"
+                        targetId={f.id}
+                        className="h-7 min-w-0 px-2 text-[11px]"
+                      />
+                      <AddToCollectionMenu
+                        bookmarkId={f.id}
+                        onAddToCollection={handleAddToCollection(f.id)}
+                      />
+                    </>
+                  }
+                >
+                  <BookmarkRowContent
+                    avatarSrc={f.author.avatar}
+                    title={f.author.name}
+                    subtitle={f.content}
+                    meta={<span>{f.ago}</span>}
+                  />
+                </BookmarkListItem>
+              ))}
+            </Card>
+          )}
         </section>
       </div>
 


### PR DESCRIPTION
## Summary

Redesigns the bookmarks page into a cleaner, more compact collection-oriented layout by replacing large bookmark cards with reusable compact list items.

## Motivation

The existing bookmarks page used large cards and grid layouts for saved items, which made the page harder to scan and organize.

This change groups saved items into compact lists while reusing the existing collection and bookmark functionality.

## Changes

- Added a reusable `BookmarkListItem` component for compact bookmark rows.
- Added shared `BookmarkRowContent` for consistent avatar/icon, title, subtitle, tags, and metadata layouts.
- Updated the bookmarks component barrel export.
- Redesigned Saved Developers into compact list rows.
- Redesigned Saved Projects into compact list rows while preserving difficulty badges, stack tags, bookmark actions, and collection actions.
- Added a Saved Repositories section using the existing repository mock data.
- Redesigned Saved Posts into compact list rows.
- Reused the existing collection sidebar, collection dialog, bookmark toggle, and add-to-collection functionality.
- Preserved existing bookmark and collection behavior.

## Acceptance Criteria

- [x] Collections remain supported.
- [x] Saved developers are supported.
- [x] Saved projects are supported.
- [x] Saved repositories are supported.
- [x] Saved posts are supported.
- [x] Large bookmark cards are replaced with compact list items.
- [x] Bookmark and collection actions remain available.
- [x] Related saved content uses a consistent compact layout.

## Testing

- [x] TypeScript/typecheck passed.
- [x] ESLint passed.
- [x] Production build passed.
- [x] Full test suite passed (468 tests).

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Infrastructure

## Issue

Closes #946

## Screenshots
<img width="1920" height="869" alt="Screenshot 2026-08-11 150249" src="https://github.com/user-attachments/assets/72b8b396-c5f8-4a82-82ae-98ab917368df" />
<img width="1920" height="867" alt="Screenshot 2026-08-11 150252" src="https://github.com/user-attachments/assets/1c854c8c-5580-4958-bf50-1561419dc2ed" />
