### PR TITLE
fix(api): stop replaying non-idempotent requests on retry (fixes #1102)

### DIFF
--- a/frontend/src/api/__tests__/client.test.ts
+++ b/frontend/src/api/__tests__/client.test.ts
@@ -320,3 +320,95 @@ describe("backoffDelay", () => {
     expect(backoffDelay(20)).toBe(8000);
   });
 });
+
+/**
+ * The refresh path only engages when a base URL is configured, so these load a
+ * fresh copy of the module with `VITE_API_BASE_URL` stubbed. Without that,
+ * `refreshAccessToken` short-circuits and the replay never happens — a test
+ * written against the default module passes without exercising anything.
+ */
+describe("the post-refresh replay", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let client: typeof import("../client");
+
+  beforeEach(async () => {
+    vi.stubEnv("VITE_API_BASE_URL", "https://api.test");
+    vi.resetModules();
+
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(Math, "random").mockReturnValue(0);
+
+    client = await import("../client");
+    const tokens = await import("../tokens");
+    tokens.tokenStore.set("stale-access", "refresh-token");
+  });
+
+  afterEach(async () => {
+    const tokens = await import("../tokens");
+    tokens.tokenStore.clear();
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("replays the request once with the refreshed token", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(401, { detail: "Expired" }))
+      .mockResolvedValueOnce(jsonResponse(200, { access_token: "fresh" }))
+      .mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+
+    await expect(client.api.get("/projects", { retries: 0 })).resolves.toEqual({ ok: true });
+
+    const [, replayInit] = fetchMock.mock.calls[2];
+    expect(new Headers(replayInit.headers).get("Authorization")).toBe("Bearer fresh");
+  });
+
+  it("gives the replay a signal, so it can time out and be cancelled", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(401, { detail: "Expired" }))
+      .mockResolvedValueOnce(jsonResponse(200, { access_token: "fresh" }))
+      .mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+
+    await client.api.get("/projects", { retries: 0 });
+
+    // Previously this was a bare fetch with no signal at all.
+    const [, replayInit] = fetchMock.mock.calls[2];
+    expect(replayInit.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("surfaces a network failure during the replay as an ApiError", async () => {
+    // The replay sits outside the retry loop, so nothing there would convert a
+    // raw fetch rejection. Callers only ever catch ApiError.
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(401, { detail: "Expired" }))
+      .mockResolvedValueOnce(jsonResponse(200, { access_token: "fresh" }))
+      .mockRejectedValueOnce(networkError());
+
+    await expect(client.api.get("/projects", { retries: 0 })).rejects.toBeInstanceOf(
+      client.ApiError,
+    );
+  });
+
+  it("surfaces an abort during the replay as a 408", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(401, { detail: "Expired" }))
+      .mockResolvedValueOnce(jsonResponse(200, { access_token: "fresh" }))
+      .mockRejectedValueOnce(abortError());
+
+    await expect(client.api.get("/projects", { retries: 0 })).rejects.toMatchObject({
+      status: 408,
+    });
+  });
+
+  it("does not replay when the refresh itself fails", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(401, { detail: "Expired" }))
+      .mockResolvedValueOnce(jsonResponse(401, { detail: "Refresh rejected" }));
+
+    await expect(client.api.get("/projects", { retries: 0 })).rejects.toMatchObject({
+      status: 401,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/api/__tests__/client.test.ts
+++ b/frontend/src/api/__tests__/client.test.ts
@@ -1,0 +1,322 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiError, api, backoffDelay, parseRetryAfter, request } from "../client";
+import { tokenStore } from "../tokens";
+
+/** A JSON response, the shape the client actually parses. */
+function jsonResponse(status: number, body: unknown, headers: Record<string, string> = {}) {
+  // 204 and 304 are not allowed to carry a body.
+  const hasBody = status !== 204 && status !== 304;
+  return new Response(hasBody ? JSON.stringify(body) : null, {
+    status,
+    headers: { "Content-Type": "application/json", ...headers },
+  });
+}
+
+/** The error `fetch` throws when the connection drops. */
+function networkError() {
+  return new TypeError("Failed to fetch");
+}
+
+/** The error `fetch` throws when its signal is aborted. */
+function abortError() {
+  return new DOMException("The operation was aborted.", "AbortError");
+}
+
+describe("api client retry policy", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    // Full-jitter backoff would otherwise make these tests sleep for real.
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    tokenStore.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  describe("non-idempotent methods", () => {
+    it("does not replay a POST after a network failure", async () => {
+      fetchMock.mockRejectedValue(networkError());
+
+      await expect(api.post("/applications", { flare_id: "x" })).rejects.toBeInstanceOf(ApiError);
+
+      // The whole point: one application attempt means at most one application.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not replay a POST that came back 502", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(502, { detail: "Bad gateway" }));
+
+      await expect(api.post("/applications", { flare_id: "x" })).rejects.toMatchObject({
+        status: 502,
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not replay a POST that timed out", async () => {
+      fetchMock.mockRejectedValue(abortError());
+
+      await expect(api.post("/applications")).rejects.toMatchObject({ status: 408 });
+
+      // A timeout is the dangerous case — the write may well have landed.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not replay a PATCH", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(503, { detail: "Unavailable" }));
+
+      await expect(api.patch("/applications/1/accept")).rejects.toMatchObject({ status: 503 });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("idempotent methods", () => {
+    it("retries a GET after a network failure and returns the eventual success", async () => {
+      fetchMock
+        .mockRejectedValueOnce(networkError())
+        .mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+
+      await expect(api.get("/projects")).resolves.toEqual({ ok: true });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("retries a GET on 500 up to the configured limit", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(500, { detail: "boom" }));
+
+      await expect(api.get("/projects")).rejects.toMatchObject({ status: 500 });
+
+      // Default `retries` is 2, so three attempts in total.
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it("retries a DELETE, which is idempotent by spec", async () => {
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse(503, { detail: "Unavailable" }))
+        .mockResolvedValueOnce(jsonResponse(204, null));
+
+      await expect(api.delete("/followers/1")).resolves.toBeNull();
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("retries 429, which is the one status that explicitly asks you to", async () => {
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse(429, { detail: "Slow down" }))
+        .mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+
+      await expect(api.get("/search")).resolves.toEqual({ ok: true });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not retry a 4xx that will fail identically next time", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(404, { detail: "Not found" }));
+
+      await expect(api.get("/projects/nope")).rejects.toMatchObject({ status: 404 });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("honours retries: 0", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(500, { detail: "boom" }));
+
+      await expect(api.get("/projects", { retries: 0 })).rejects.toMatchObject({ status: 500 });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("the idempotent escape hatch", () => {
+    it("retries a POST when the caller vouches for it", async () => {
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse(500, { detail: "boom" }))
+        .mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+
+      await expect(api.post("/search/reindex", undefined, { idempotent: true })).resolves.toEqual({
+        ok: true,
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("lets a GET opt out of retrying", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(500, { detail: "boom" }));
+
+      await expect(api.get("/expensive", { idempotent: false })).rejects.toMatchObject({
+        status: 500,
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not forward the flag to the server as a header or body field", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(200, {}));
+
+      await api.post("/posts", { content: "hi" }, { idempotent: true });
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect(init.body).toBe(JSON.stringify({ content: "hi" }));
+      expect(new Headers(init.headers).has("idempotent")).toBe(false);
+    });
+  });
+
+  describe("cancellation and timeouts", () => {
+    it("rejects immediately when the caller's signal is already aborted", async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      await expect(api.get("/projects", { signal: controller.signal })).rejects.toMatchObject({
+        status: 408,
+      });
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("stops retrying once the caller aborts mid-flight", async () => {
+      const controller = new AbortController();
+      fetchMock.mockImplementation(() => {
+        controller.abort();
+        return Promise.reject(abortError());
+      });
+
+      await expect(api.get("/projects", { signal: controller.signal })).rejects.toMatchObject({
+        status: 408,
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not leave an abort listener behind for every attempt", async () => {
+      const controller = new AbortController();
+      const addSpy = vi.spyOn(controller.signal, "addEventListener");
+      const removeSpy = vi.spyOn(controller.signal, "removeEventListener");
+
+      fetchMock.mockResolvedValue(jsonResponse(500, { detail: "boom" }));
+
+      await expect(api.get("/projects", { signal: controller.signal })).rejects.toBeInstanceOf(
+        ApiError,
+      );
+
+      expect(addSpy).toHaveBeenCalledTimes(3);
+      expect(removeSpy).toHaveBeenCalledTimes(3);
+    });
+
+    it("passes a signal to fetch on every attempt, including the first", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(200, {}));
+
+      await api.get("/projects");
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect(init.signal).toBeInstanceOf(AbortSignal);
+    });
+  });
+
+  describe("maintenance mode", () => {
+    it("does not throw when there is no window (SSR)", async () => {
+      const originalWindow = globalThis.window;
+      // Simulate a server-side render, where `window.location` is not there.
+      // @ts-expect-error deliberately removing a global for this assertion
+      delete globalThis.window;
+
+      fetchMock.mockResolvedValue(jsonResponse(503, { detail: "Maintenance Mode" }));
+
+      try {
+        await expect(api.get("/projects", { retries: 0 })).rejects.toMatchObject({ status: 503 });
+      } finally {
+        globalThis.window = originalWindow;
+      }
+    });
+  });
+
+  describe("error surfacing", () => {
+    it("prefers a nested error.message over detail", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse(400, { error: { message: "Flare is closed" }, detail: "Bad request" }),
+      );
+
+      await expect(api.post("/applications")).rejects.toMatchObject({
+        message: "Flare is closed",
+        status: 400,
+      });
+    });
+
+    it("falls back to detail", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(400, { detail: "Bad request" }));
+
+      await expect(api.post("/applications")).rejects.toMatchObject({
+        message: "Bad request",
+      });
+    });
+
+    it("reports a network failure as status 0", async () => {
+      fetchMock.mockRejectedValue(networkError());
+
+      await expect(request("/projects", { method: "POST" })).rejects.toMatchObject({ status: 0 });
+    });
+  });
+});
+
+describe("parseRetryAfter", () => {
+  const NOW = Date.parse("2026-08-12T10:00:00Z");
+
+  it("returns null for an absent header", () => {
+    expect(parseRetryAfter(null, NOW)).toBeNull();
+  });
+
+  it("returns null for an empty header", () => {
+    expect(parseRetryAfter("   ", NOW)).toBeNull();
+  });
+
+  it("reads delta-seconds", () => {
+    expect(parseRetryAfter("3", NOW)).toBe(3000);
+  });
+
+  it("reads the HTTP-date form", () => {
+    expect(parseRetryAfter("Wed, 12 Aug 2026 10:00:05 GMT", NOW)).toBe(5000);
+  });
+
+  it("treats a date in the past as retry now", () => {
+    expect(parseRetryAfter("Wed, 12 Aug 2026 09:59:00 GMT", NOW)).toBe(0);
+  });
+
+  it("caps an absurd wait rather than hanging the request", () => {
+    expect(parseRetryAfter("86400", NOW)).toBe(20_000);
+  });
+
+  it("returns null for something it cannot parse", () => {
+    expect(parseRetryAfter("soon please", NOW)).toBeNull();
+  });
+
+  it("rejects a negative delta rather than reading it as a date", () => {
+    expect(parseRetryAfter("-5", NOW)).toBeNull();
+  });
+});
+
+describe("backoffDelay", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("grows exponentially at the top of the jitter window", () => {
+    vi.spyOn(Math, "random").mockReturnValue(1);
+
+    expect(backoffDelay(0)).toBe(200);
+    expect(backoffDelay(1)).toBe(400);
+    expect(backoffDelay(2)).toBe(800);
+  });
+
+  it("can return zero, so retries are spread rather than synchronised", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+
+    expect(backoffDelay(3)).toBe(0);
+  });
+
+  it("caps the window so a long retry chain does not stall for minutes", () => {
+    vi.spyOn(Math, "random").mockReturnValue(1);
+
+    expect(backoffDelay(20)).toBe(8000);
+  });
+});

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -311,9 +311,21 @@ async function coreFetch(path: string, opts: RequestOptions): Promise<Response> 
       const newToken = await refreshAccessToken();
       if (newToken) {
         finalHeaders.set("Authorization", `Bearer ${newToken}`);
-        // A 401 means the server rejected the request before acting on it, so
-        // replaying it is safe regardless of method.
-        res = await sendOnce(url, { ...init, headers: finalHeaders }, timeout, signal);
+        try {
+          // A 401 means the server rejected the request before acting on it,
+          // so replaying it is safe regardless of method.
+          res = await sendOnce(url, { ...init, headers: finalHeaders }, timeout, signal);
+        } catch (err) {
+          // This replay is outside the retry loop, so nothing below would
+          // convert a raw fetch rejection into an ApiError. Callers catch
+          // ApiError; letting a bare TypeError through here would slip past
+          // every one of them.
+          if (err instanceof ApiError) throw err;
+          if (err instanceof DOMException && err.name === "AbortError") {
+            throw new ApiError("Request cancelled or timed out", 408, null);
+          }
+          throw new ApiError(err instanceof Error ? err.message : "Network error", 0, null);
+        }
       }
     }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -3,7 +3,8 @@
 // - Attaches JWT access token
 // - Auto-refreshes on 401 using refresh token
 // - Standardized ApiError with status + payload
-// - Simple retry with exponential backoff for network / 5xx
+// - Retry with exponential backoff, but only for requests that are safe to
+//   replay. See `isRetryableRequest` below.
 
 import { tokenStore } from "./tokens";
 
@@ -30,6 +31,86 @@ export interface RequestOptions extends Omit<RequestInit, "body"> {
   signal?: AbortSignal;
   query?: Record<string, string | number | boolean | undefined | null>;
   raw?: boolean;
+  /**
+   * Force the retry decision instead of inferring it from the method.
+   *
+   * Set this to `true` on a POST only when the endpoint is genuinely safe to
+   * replay — either it is naturally idempotent server-side, or you are also
+   * passing an `Idempotency-Key` header so the server can collapse duplicates.
+   * Set it to `false` to opt a GET out of retrying.
+   */
+  idempotent?: boolean;
+}
+
+/**
+ * Methods that RFC 9110 defines as idempotent: sending the same request twice
+ * has the same effect on the server as sending it once. These are the only
+ * ones we replay without being asked to.
+ *
+ * POST and PATCH are deliberately absent. A POST that times out on the way
+ * back has very likely already been applied, and the client has no way to tell
+ * that apart from a request that never arrived — replaying it is how you end
+ * up with three applications to the same flare.
+ */
+const IDEMPOTENT_METHODS = new Set(["GET", "HEAD", "OPTIONS", "PUT", "DELETE"]);
+
+/** Statuses worth a second attempt, assuming the request itself is replayable. */
+const RETRYABLE_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+/** Longest we will wait on a server-provided `Retry-After` before giving up on it. */
+const MAX_RETRY_AFTER_MS = 20_000;
+
+function isRetryableRequest(method: string, opts: RequestOptions): boolean {
+  if (opts.idempotent !== undefined) return opts.idempotent;
+  return IDEMPOTENT_METHODS.has(method.toUpperCase());
+}
+
+/**
+ * `Retry-After` in milliseconds, or `null` when the header is absent or
+ * unusable. The header comes in two forms — delta-seconds and an HTTP-date —
+ * and servers send both.
+ */
+export function parseRetryAfter(header: string | null, now: number = Date.now()): number | null {
+  if (!header) return null;
+
+  const trimmed = header.trim();
+  if (trimmed === "") return null;
+
+  // Delta-seconds. Guard against the negative and non-finite cases rather than
+  // trusting the header to be well formed.
+  if (/^\d+$/.test(trimmed)) {
+    const seconds = Number(trimmed);
+    if (!Number.isFinite(seconds)) return null;
+    return Math.min(seconds * 1000, MAX_RETRY_AFTER_MS);
+  }
+
+  // A header that is numeric but did not match above is a malformed
+  // delta-seconds, not a date. Without this guard `Date.parse("-5")` reads it
+  // as a year and we would wait until the year 5 BC — that is, not at all.
+  if (/^[+-]?\d*\.?\d+$/.test(trimmed)) return null;
+
+  const date = Date.parse(trimmed);
+  if (Number.isNaN(date)) return null;
+
+  const delta = date - now;
+  if (delta <= 0) return 0;
+  return Math.min(delta, MAX_RETRY_AFTER_MS);
+}
+
+/**
+ * Exponential backoff with full jitter.
+ *
+ * Without the jitter every open tab that hit the same 503 retries at exactly
+ * the same moment, which is precisely the load pattern a struggling API does
+ * not need. Full jitter spreads them across the whole window.
+ */
+export function backoffDelay(attempt: number, base = 200): number {
+  const ceiling = Math.min(base * 2 ** attempt, 8000);
+  return Math.round(Math.random() * ceiling);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function buildUrl(path: string, query?: RequestOptions["query"]): string {
@@ -92,7 +173,54 @@ async function refreshAccessToken(): Promise<string | null> {
   return refreshInFlight;
 }
 
-async function coreFetch(path: string, opts: RequestOptions, attempt = 0): Promise<Response> {
+/**
+ * Send the request once, with its own timeout and linked to the caller's
+ * abort signal.
+ *
+ * Split out from the retry loop so that every attempt — including the replay
+ * after a token refresh — goes through the same timeout and cancellation
+ * plumbing. Previously the post-refresh replay was a bare `fetch` with no
+ * signal at all, so it could hang indefinitely and ignored cancellation.
+ */
+async function sendOnce(
+  url: string,
+  init: RequestInit,
+  timeout: number,
+  signal: AbortSignal | undefined,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+  // If the caller already gave up before we got here, do not open a socket.
+  if (signal?.aborted) {
+    clearTimeout(timeoutId);
+    throw new ApiError("Request cancelled or timed out", 408, null);
+  }
+
+  const forwardAbort = () => controller.abort();
+  signal?.addEventListener("abort", forwardAbort, { once: true });
+
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeoutId);
+    // Retries reuse the caller's signal, so the listener has to come off or
+    // each attempt leaves one behind for the lifetime of the signal.
+    signal?.removeEventListener("abort", forwardAbort);
+  }
+}
+
+/** Send the browser to the maintenance page, if we are in a browser at all. */
+function redirectToMaintenance(): void {
+  // This client also runs during SSR, where `window` does not exist. Reading
+  // `window.location` unguarded turned a maintenance response into a 500.
+  if (typeof window === "undefined") return;
+  if (window.location.pathname !== "/maintenance") {
+    window.location.href = "/maintenance";
+  }
+}
+
+async function coreFetch(path: string, opts: RequestOptions): Promise<Response> {
   const {
     body,
     auth = true,
@@ -101,10 +229,17 @@ async function coreFetch(path: string, opts: RequestOptions, attempt = 0): Promi
     timeout = 10000,
     signal,
     raw: _raw,
+    idempotent: _idempotent,
     headers,
     ...rest
   } = opts;
   void _raw;
+  void _idempotent;
+
+  const method = (rest.method ?? "GET").toUpperCase();
+  const canRetry = isRetryableRequest(method, opts);
+  const maxAttempts = canRetry ? retries + 1 : 1;
+
   const finalHeaders = new Headers(headers);
   if (body !== undefined && !(body instanceof FormData)) {
     if (!finalHeaders.has("Content-Type")) finalHeaders.set("Content-Type", "application/json");
@@ -122,73 +257,81 @@ async function coreFetch(path: string, opts: RequestOptions, attempt = 0): Promi
     `req_${crypto.randomUUID ? crypto.randomUUID().replace(/-/g, "") : Math.random().toString(36).slice(2)}`,
   );
 
-  const init: RequestInit = {
-    ...rest,
-    headers: finalHeaders,
-    body: body === undefined ? undefined : body instanceof FormData ? body : JSON.stringify(body),
-  };
+  const serialisedBody =
+    body === undefined ? undefined : body instanceof FormData ? body : JSON.stringify(body);
 
-  let res: Response;
+  const url = buildUrl(path, query);
 
-  const controller = new AbortController();
+  let lastNetworkError: unknown = null;
 
-  const timeoutId = setTimeout(() => {
-    controller.abort();
-  }, timeout);
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    // Rebuilt per attempt so a token refreshed mid-flight is picked up, and so
+    // the request id is unique per attempt (the correlation id is not, on
+    // purpose — that is what ties the attempts together in the logs).
+    const init: RequestInit = { ...rest, headers: finalHeaders, body: serialisedBody };
 
-  if (signal) {
-    signal.addEventListener("abort", () => controller.abort(), { once: true });
-  }
-
-  try {
-    res = await fetch(buildUrl(path, query), {
-      ...init,
-      signal: controller.signal,
-    });
-
-    clearTimeout(timeoutId);
-  } catch (err) {
-    clearTimeout(timeoutId);
-
-    if (err instanceof DOMException && err.name === "AbortError") {
-      throw new ApiError("Request cancelled or timed out", 408, null);
-    }
-
-    if (attempt < retries) {
-      await new Promise((r) => setTimeout(r, 200 * 2 ** attempt));
-      return coreFetch(path, opts, attempt + 1);
-    }
-
-    throw new ApiError(err instanceof Error ? err.message : "Network error", 0, null);
-  }
-
-  if (res.status === 503) {
+    let res: Response;
     try {
-      const payload = await res.clone().json();
-      if (payload?.detail === "Maintenance Mode") {
-        if (window.location.pathname !== "/maintenance") {
-          window.location.href = "/maintenance";
+      res = await sendOnce(url, init, timeout, signal);
+    } catch (err) {
+      if (err instanceof ApiError) throw err;
+
+      if (err instanceof DOMException && err.name === "AbortError") {
+        // A timeout is indistinguishable from "the server is still working on
+        // it", so this is exactly the case a non-idempotent replay must not
+        // take. `canRetry` already decided that for us.
+        if (signal?.aborted || attempt === maxAttempts - 1) {
+          throw new ApiError("Request cancelled or timed out", 408, null);
         }
+        lastNetworkError = err;
+        await sleep(backoffDelay(attempt));
+        continue;
       }
-    } catch (e) {
-      // Not JSON, ignore
+
+      lastNetworkError = err;
+      if (attempt === maxAttempts - 1) {
+        throw new ApiError(err instanceof Error ? err.message : "Network error", 0, null);
+      }
+      await sleep(backoffDelay(attempt));
+      continue;
     }
-  }
 
-  if (res.status === 401 && auth && !path.includes("/auth/")) {
-    const newToken = await refreshAccessToken();
-    if (newToken) {
-      finalHeaders.set("Authorization", `Bearer ${newToken}`);
-      res = await fetch(buildUrl(path, query), { ...init, headers: finalHeaders });
+    if (res.status === 503) {
+      try {
+        const payload = await res.clone().json();
+        if (payload?.detail === "Maintenance Mode") {
+          redirectToMaintenance();
+        }
+      } catch {
+        // Not JSON, ignore.
+      }
     }
+
+    if (res.status === 401 && auth && !path.includes("/auth/")) {
+      const newToken = await refreshAccessToken();
+      if (newToken) {
+        finalHeaders.set("Authorization", `Bearer ${newToken}`);
+        // A 401 means the server rejected the request before acting on it, so
+        // replaying it is safe regardless of method.
+        res = await sendOnce(url, { ...init, headers: finalHeaders }, timeout, signal);
+      }
+    }
+
+    if (RETRYABLE_STATUSES.has(res.status) && attempt < maxAttempts - 1) {
+      const retryAfter = parseRetryAfter(res.headers.get("Retry-After"));
+      await sleep(retryAfter ?? backoffDelay(attempt));
+      continue;
+    }
+
+    return res;
   }
 
-  if (res.status >= 500 && attempt < retries) {
-    await new Promise((r) => setTimeout(r, 200 * 2 ** attempt));
-    return coreFetch(path, opts, attempt + 1);
-  }
-
-  return res;
+  // Only reachable when every attempt failed at the network layer.
+  throw new ApiError(
+    lastNetworkError instanceof Error ? lastNetworkError.message : "Network error",
+    0,
+    null,
+  );
 }
 
 async function parseBody(res: Response): Promise<unknown> {
@@ -202,9 +345,10 @@ export async function request<T>(path: string, opts: RequestOptions = {}): Promi
   const res = await coreFetch(path, opts);
   const payload = await parseBody(res);
   if (!res.ok) {
-    const errorObj = typeof payload === "object" && payload && "error" in payload
-      ? (payload as any).error
-      : payload;
+    const errorObj =
+      typeof payload === "object" && payload && "error" in payload
+        ? (payload as any).error
+        : payload;
 
     const message =
       (errorObj && typeof errorObj === "object" && "message" in errorObj


### PR DESCRIPTION
# Pull Request

## Summary

`coreFetch` retried on network failures and on any 5xx without checking the HTTP method first, so every `api.post` / `api.patch` was replayed up to two extra times. This makes retrying conditional on whether the request is safe to replay, and fixes four related problems in the same code path.

---

## Related Issue

Closes #1102

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [ ] UI/UX enhancement
- [x] Tests
- [ ] Other

---

## Changes Made

**The main fix — retry only what is safe to replay**

- Added `IDEMPOTENT_METHODS` (GET, HEAD, OPTIONS, PUT, DELETE) and gate the retry loop on it. POST and PATCH no longer retry by default.
- Added an `idempotent?: boolean` request option so a caller can override the decision either way: `true` for a POST that is genuinely safe to replay (or that carries an `Idempotency-Key`), `false` to opt an expensive GET out.

The case that motivated this is the one that is easy to miss: a request that *succeeded* and then failed on the way back — gateway timeout, connection reset after the response was committed, our own 10s timeout firing while the server was still writing. The client cannot tell that apart from "never arrived", so replaying it duplicates the write. `applyToFlare`, `followUser` and the like/comment endpoints all sit on that path.

**Same code path, four smaller fixes**

- The replay after a 401 token refresh was a bare `fetch(...)` with no signal, so it ignored `timeout` and could not be cancelled by the caller. Extracted `sendOnce()` so that every attempt, including that one, gets the same timeout and abort plumbing.
- The 503 maintenance branch read `window.location.pathname` unguarded. This client runs during SSR too, so a 503 from a server-side loader threw `window is not defined` and turned a maintenance page into a 500. Now guarded in `redirectToMaintenance()`.
- Backoff was `200 * 2 ** attempt` with no jitter, so every open tab retried in lockstep against an API that was already shedding load. Now full jitter, capped at 8s.
- `Retry-After` is now honoured in both the delta-seconds and HTTP-date forms, capped at 20s so a hostile or misconfigured header cannot park a request indefinitely. 429 is now retried at all — it previously was not, despite being the one status that explicitly asks you to.

**One more thing**

`signal.addEventListener("abort", ...)` was added per attempt and never removed, so a retried request left a listener behind on the caller's signal for each attempt. `sendOnce` now removes it in a `finally`. It also short-circuits when the caller's signal is already aborted, rather than opening a socket and immediately abandoning it.

---

## Testing

- [x] Tested locally
- [x] Existing tests pass
- [x] Added new tests

Added `frontend/src/api/__tests__/client.test.ts` — 32 tests covering:

- POST/PATCH not replayed after a network error, a 502, a 503, or a timeout
- GET/DELETE still retried, on both network errors and retryable statuses
- 429 retried; 404 and other 4xx not retried
- `retries: 0` and the `idempotent` override in both directions
- `idempotent` is not leaked into the request body or headers
- already-aborted signals short-circuit before `fetch`; mid-flight aborts stop the retry loop
- abort listeners are added and removed in equal numbers
- 503 maintenance handling does not throw when `window` is absent
- `parseRetryAfter` across both header forms, past dates, the cap, and malformed input (including `-5`, which `Date.parse` would otherwise read as a year)
- `backoffDelay` growth, jitter floor, and ceiling

Full suite: 514 tests pass, `tsc --noEmit` and `eslint` clean.

---

## Notes for reviewers

This is a behaviour change for POST and PATCH callers that were quietly relying on the retry. I went looking and did not find one that needs it — the POSTs in `src/api/modules` are all writes — but if a reviewer knows of a POST endpoint that is a disguised read, `idempotent: true` is the one-line fix for it.
