### PR TITLE
fix(pagination): stop repeating the boundary row on every page (fixes #1103)

### DIFF
--- a/backend/app/core/pagination.py
+++ b/backend/app/core/pagination.py
@@ -1,10 +1,261 @@
-from typing import Any, List, Optional, Tuple, TypeVar
-from sqlalchemy.orm import Query
-from sqlalchemy import desc, asc, inspect
+"""
+Keyset ("cursor") pagination for SQLAlchemy queries.
 
-from app.schemas.pagination import PaginatedResponse, encode_cursor, decode_cursor
+The rule that makes keyset pagination work is that the cursor must describe a
+*strict* boundary over a *total* order. Get either half wrong and pages overlap
+or drop rows:
+
+* **Strict.** The cursor points at the last row of the page you just got. The
+  next page must be the rows strictly after it. An inclusive ``<=`` returns
+  that row again as the first row of the next page.
+* **Total.** ``created_at`` is not unique. Two rows written in the same
+  transaction share a timestamp, so ordering by it alone leaves their relative
+  order up to the planner, and it is free to answer differently between two
+  queries. Every comparison here carries the primary key as a tiebreaker, so
+  the order is total even when the sort column is not.
+
+Cursors are opaque to clients but not encrypted -- they are base64 of a small
+JSON object, and a client that decodes one learns only the sort value of a row
+it was already shown. They *are* type-tagged: a cursor over a ``DateTime``
+column has to come back out of the cursor as a ``datetime``, not as the string
+``'2026-08-11 10:54:43.123456+00:00'``, or the comparison against the column
+either raises or silently degrades to a text comparison with different ordering
+than the index.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+from decimal import Decimal
+from typing import Any, List, Literal, Optional, Tuple, TypeVar
+
+from sqlalchemy import and_, asc, desc, or_
+from sqlalchemy.orm import Query
+
+from app.schemas.pagination import PaginatedResponse, decode_cursor, encode_cursor
 
 T = TypeVar("T")
+
+Direction = Literal["next", "prev"]
+
+
+class InvalidCursor(ValueError):
+    """
+    Raised when a cursor cannot be decoded or does not describe this query.
+
+    This is a client error, not a server error: a caller that sends a cursor
+    from a different sort order, or a truncated one, has asked for something we
+    cannot answer. Silently falling back to page 1 is worse -- an infinite
+    scroll that hits it restarts from the top and loops forever.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Cursor value encoding
+# ---------------------------------------------------------------------------
+#
+# JSON has no datetime and no UUID, so a tag travels with the value and is used
+# to rebuild the original type on the way back in.
+
+_TAG_NULL = "null"
+_TAG_STR = "str"
+_TAG_INT = "int"
+_TAG_FLOAT = "float"
+_TAG_BOOL = "bool"
+_TAG_DECIMAL = "dec"
+_TAG_UUID = "uuid"
+_TAG_DATETIME = "dt"
+_TAG_DATE = "date"
+_TAG_TIME = "time"
+
+
+def encode_cursor_value(value: Any) -> dict:
+    """Tag a Python value so it survives a JSON round trip with its type."""
+    if value is None:
+        return {"t": _TAG_NULL, "v": None}
+    # bool before int: bool is a subclass of int and would otherwise be tagged
+    # as one and come back as 0/1.
+    if isinstance(value, bool):
+        return {"t": _TAG_BOOL, "v": value}
+    if isinstance(value, int):
+        return {"t": _TAG_INT, "v": value}
+    if isinstance(value, float):
+        return {"t": _TAG_FLOAT, "v": value}
+    if isinstance(value, Decimal):
+        return {"t": _TAG_DECIMAL, "v": str(value)}
+    if isinstance(value, uuid.UUID):
+        return {"t": _TAG_UUID, "v": str(value)}
+    # datetime before date: datetime is a subclass of date.
+    if isinstance(value, dt.datetime):
+        return {"t": _TAG_DATETIME, "v": value.isoformat()}
+    if isinstance(value, dt.date):
+        return {"t": _TAG_DATE, "v": value.isoformat()}
+    if isinstance(value, dt.time):
+        return {"t": _TAG_TIME, "v": value.isoformat()}
+    return {"t": _TAG_STR, "v": str(value)}
+
+
+def decode_cursor_value(payload: Any) -> Any:
+    """Rebuild a value tagged by :func:`encode_cursor_value`."""
+    if not isinstance(payload, dict) or "t" not in payload:
+        raise InvalidCursor("Cursor value is missing its type tag.")
+
+    tag = payload["t"]
+    raw = payload.get("v")
+
+    try:
+        if tag == _TAG_NULL:
+            return None
+        if tag == _TAG_BOOL:
+            return bool(raw)
+        if tag == _TAG_INT:
+            return int(raw)
+        if tag == _TAG_FLOAT:
+            return float(raw)
+        if tag == _TAG_DECIMAL:
+            return Decimal(str(raw))
+        if tag == _TAG_UUID:
+            return uuid.UUID(str(raw))
+        if tag == _TAG_DATETIME:
+            return dt.datetime.fromisoformat(str(raw))
+        if tag == _TAG_DATE:
+            return dt.date.fromisoformat(str(raw))
+        if tag == _TAG_TIME:
+            return dt.time.fromisoformat(str(raw))
+        if tag == _TAG_STR:
+            return str(raw)
+    except (TypeError, ValueError) as exc:
+        raise InvalidCursor(f"Cursor value is not a valid {tag}.") from exc
+
+    raise InvalidCursor(f"Unknown cursor value type: {tag!r}")
+
+
+def _column_key(column: Any, fallback: str) -> str:
+    """The attribute name behind a mapped column, for ``getattr``."""
+    return getattr(column, "key", None) or fallback
+
+
+def _build_cursor(
+    item: Any,
+    sort_column: Optional[Any],
+    id_column: Optional[Any],
+    direction: Direction,
+) -> str:
+    """Encode the boundary row that the next (or previous) page starts after."""
+    payload: dict[str, Any] = {"d": direction}
+
+    if sort_column is not None:
+        key = _column_key(sort_column, "id")
+        payload["val"] = encode_cursor_value(getattr(item, key, None))
+
+    if id_column is not None:
+        key = _column_key(id_column, "id")
+        payload["id"] = encode_cursor_value(getattr(item, key, None))
+
+    return encode_cursor(payload)
+
+
+def _parse_cursor(cursor: str) -> tuple[Direction, Any, Any, bool, bool]:
+    """
+    Decode a cursor into ``(direction, sort_value, id_value, has_val, has_id)``.
+
+    Raises :class:`InvalidCursor` rather than returning ``None``, so a bad
+    cursor surfaces as a client error instead of quietly restarting at page 1.
+    """
+    data = decode_cursor(cursor)
+    if data is None or not isinstance(data, dict):
+        raise InvalidCursor("Cursor could not be decoded.")
+
+    direction = data.get("d", "next")
+    if direction not in ("next", "prev"):
+        raise InvalidCursor(f"Unknown cursor direction: {direction!r}")
+
+    has_val = "val" in data
+    has_id = "id" in data
+
+    if not has_val and not has_id:
+        raise InvalidCursor("Cursor does not identify a row.")
+
+    sort_value = decode_cursor_value(data["val"]) if has_val else None
+    id_value = decode_cursor_value(data["id"]) if has_id else None
+
+    return direction, sort_value, id_value, has_val, has_id
+
+
+# ---------------------------------------------------------------------------
+# Keyset filter
+# ---------------------------------------------------------------------------
+
+
+def _keyset_filter(
+    sort_column: Optional[Any],
+    id_column: Optional[Any],
+    sort_value: Any,
+    id_value: Any,
+    has_val: bool,
+    has_id: bool,
+    descending: bool,
+):
+    """
+    The ``WHERE`` clause for "strictly after this row in this order".
+
+    With a tiebreaker the comparison is lexicographic over the pair, which is
+    the standard row-value form written out longhand because not every backend
+    we run on supports ``(a, b) < (:a, :b)`` with an index behind it::
+
+        sort < :sort  OR  (sort = :sort  AND  id < :id)
+
+    Ascending flips both operators. When only one column is available the pair
+    degenerates to a plain strict comparison on that column.
+    """
+    usable_sort = sort_column is not None and has_val and sort_value is not None
+    usable_id = id_column is not None and has_id and id_value is not None
+
+    if usable_sort and usable_id:
+        if descending:
+            return or_(
+                sort_column < sort_value,
+                and_(sort_column == sort_value, id_column < id_value),
+            )
+        return or_(
+            sort_column > sort_value,
+            and_(sort_column == sort_value, id_column > id_value),
+        )
+
+    if usable_sort:
+        # No tiebreaker available. Strict is still the right call -- it can drop
+        # rows that tie on the sort value, but inclusive duplicates them on
+        # every page, and a duplicate is the worse failure in a feed.
+        return sort_column < sort_value if descending else sort_column > sort_value
+
+    if usable_id:
+        return id_column < id_value if descending else id_column > id_value
+
+    return None
+
+
+def _order_by(
+    query: Query,
+    sort_column: Optional[Any],
+    id_column: Optional[Any],
+    descending: bool,
+) -> Query:
+    """Order by the sort column with the id as a tiebreaker, in that order."""
+    direction = desc if descending else asc
+
+    clauses = []
+    if sort_column is not None:
+        clauses.append(direction(sort_column))
+    if id_column is not None:
+        clauses.append(direction(id_column))
+
+    return query.order_by(*clauses) if clauses else query
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
 
 
 def paginate_query(
@@ -17,76 +268,80 @@ def paginate_query(
     id_column: Optional[Any] = None,
 ) -> Tuple[List[Any], int, Optional[str], Optional[str], bool, bool]:
     """
-    Paginate a SQLAlchemy query with cursor and offset support.
-    Returns (items, total_count, next_cursor, prev_cursor, has_next, has_prev).
+    Paginate a SQLAlchemy query.
+
+    Returns ``(items, total, next_cursor, prev_cursor, has_next, has_prev)``.
+
+    Pass ``cursor`` for keyset pagination (what you want for feeds and infinite
+    scroll) or ``offset`` for offset pagination (what you want for a page
+    picker that shows "page 7 of 40"). A cursor wins if both are given.
+
+    ``id_column`` should be the primary key. It is not strictly required, but
+    without it rows that tie on ``sort_column`` have no defined order and the
+    page boundary between them is not stable.
+
+    Raises :class:`InvalidCursor` if ``cursor`` is malformed.
     """
+    if limit < 1:
+        raise ValueError("limit must be at least 1")
+
     total = query.count()
 
-    cursor_data = decode_cursor(cursor) if cursor else None
-    
-    # If cursor data contains offset, fallback or use cursor offset
-    effective_offset = offset or 0
-    if cursor_data and "offset" in cursor_data and not (cursor_data.get("id") or cursor_data.get("val")):
-        effective_offset = cursor_data["offset"]
+    direction: Direction = "next"
+    sort_value = id_value = None
+    has_val = has_id = False
 
-    # Apply cursor filter if sort_column and id_column are available
-    if cursor_data and ("val" in cursor_data or "id" in cursor_data):
-        c_val = cursor_data.get("val")
-        c_id = cursor_data.get("id")
-        
-        if sort_column is not None and c_val is not None:
-            if is_desc:
-                query = query.filter(sort_column <= c_val)
-            else:
-                query = query.filter(sort_column >= c_val)
-        elif id_column is not None and c_id is not None:
-            if is_desc:
-                query = query.filter(id_column <= c_id)
-            else:
-                query = query.filter(id_column >= c_id)
+    if cursor:
+        direction, sort_value, id_value, has_val, has_id = _parse_cursor(cursor)
 
-    # Order query
-    if sort_column is not None:
-        query = query.order_by(desc(sort_column) if is_desc else asc(sort_column))
-    elif id_column is not None:
-        query = query.order_by(desc(id_column) if is_desc else asc(id_column))
+    effective_offset = 0 if cursor else max(0, offset or 0)
 
-    # Fetch limit + 1 items to determine has_next
-    fetch_limit = limit + 1
-    if effective_offset > 0:
+    # Walking backwards means running the query in the opposite order and
+    # flipping the page over at the end.
+    descending = is_desc if direction == "next" else not is_desc
+
+    if cursor:
+        condition = _keyset_filter(
+            sort_column,
+            id_column,
+            sort_value,
+            id_value,
+            has_val,
+            has_id,
+            descending,
+        )
+        if condition is not None:
+            query = query.filter(condition)
+
+    query = _order_by(query, sort_column, id_column, descending)
+
+    if effective_offset:
         query = query.offset(effective_offset)
 
-    raw_items = query.limit(fetch_limit).all()
-
-    has_next = len(raw_items) > limit
+    # One extra row tells us whether there is another page without a second
+    # count query.
+    raw_items = query.limit(limit + 1).all()
+    has_more = len(raw_items) > limit
     items = raw_items[:limit]
-    has_prev = effective_offset > 0 or (cursor_data is not None)
 
-    next_cursor = None
-    prev_cursor = None
+    if direction == "prev":
+        # The rows came back in reverse order; put them back the way the caller
+        # asked for them.
+        items = list(reversed(items))
+        has_next = True  # we necessarily came from a page after this one
+        has_prev = has_more
+    else:
+        has_next = has_more
+        has_prev = bool(cursor) or effective_offset > 0
+
+    next_cursor: Optional[str] = None
+    prev_cursor: Optional[str] = None
 
     if items:
-        last_item = items[-1]
-        first_item = items[0]
-
-        # Generate next cursor
-        next_data = {}
-        if id_column is not None and hasattr(last_item, id_column.key if hasattr(id_column, "key") else "id"):
-            next_data["id"] = str(getattr(last_item, id_column.key if hasattr(id_column, "key") else "id"))
-        if sort_column is not None and hasattr(last_item, sort_column.key if hasattr(sort_column, "key") else "id"):
-            val = getattr(last_item, sort_column.key if hasattr(sort_column, "key") else "id")
-            next_data["val"] = str(val) if val is not None else None
-        
-        if not next_data:
-            next_data["offset"] = effective_offset + len(items)
-
         if has_next:
-            next_cursor = encode_cursor(next_data)
-
-        # Generate prev cursor
+            next_cursor = _build_cursor(items[-1], sort_column, id_column, "next")
         if has_prev:
-            prev_offset = max(0, effective_offset - limit)
-            prev_cursor = encode_cursor({"offset": prev_offset})
+            prev_cursor = _build_cursor(items[0], sort_column, id_column, "prev")
 
     return items, total, next_cursor, prev_cursor, has_next, has_prev
 
@@ -102,6 +357,41 @@ def build_paginated_response(
 ) -> PaginatedResponse[T]:
     """Helper to build a PaginatedResponse pydantic model."""
     return PaginatedResponse[T](
+        items=items,
+        total=total,
+        limit=limit,
+        next_cursor=next_cursor,
+        prev_cursor=prev_cursor,
+        has_next=has_next,
+        has_prev=has_prev,
+    )
+
+
+def paginate_and_respond(
+    query: Query,
+    limit: int = 20,
+    cursor: Optional[str] = None,
+    offset: Optional[int] = 0,
+    sort_column: Optional[Any] = None,
+    is_desc: bool = True,
+    id_column: Optional[Any] = None,
+) -> PaginatedResponse[Any]:
+    """
+    :func:`paginate_query` and :func:`build_paginated_response` in one call.
+
+    Most routers want exactly this and nothing else, and threading six
+    positional results through by hand is how the two halves drift apart.
+    """
+    items, total, next_cursor, prev_cursor, has_next, has_prev = paginate_query(
+        query,
+        limit=limit,
+        cursor=cursor,
+        offset=offset,
+        sort_column=sort_column,
+        is_desc=is_desc,
+        id_column=id_column,
+    )
+    return build_paginated_response(
         items=items,
         total=total,
         limit=limit,

--- a/backend/tests/test_keyset_pagination.py
+++ b/backend/tests/test_keyset_pagination.py
@@ -1,0 +1,444 @@
+"""
+Tests for keyset pagination.
+
+The existing pagination test only ever asked for page 1, which is why the
+inclusive-boundary bug survived: it is invisible until you follow a cursor.
+Most of what is here walks the pages and asserts on the *concatenation*, which
+is the only way duplicates and dropped rows show up.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+
+import pytest
+
+from app.core.pagination import (
+    InvalidCursor,
+    decode_cursor_value,
+    encode_cursor_value,
+    paginate_and_respond,
+    paginate_query,
+)
+from app.models.skill import Skill
+from app.schemas.pagination import encode_cursor
+
+CATEGORY = "KeysetTest"
+
+
+def _make_skills(
+    db, names: list[str], created: list[dt.datetime] | None = None
+) -> list[Skill]:
+    """Insert skills in `names` order, optionally with explicit created_at."""
+    rows = []
+    for index, name in enumerate(names):
+        skill = Skill(
+            id=uuid.uuid4(),
+            name=name,
+            normalized_name=f"{CATEGORY.lower()}_{name.lower()}",
+            slug=f"{CATEGORY.lower()}-{name.lower()}",
+            category=CATEGORY,
+        )
+        if created is not None:
+            skill.created_at = created[index]
+        rows.append(skill)
+        db.add(skill)
+    db.commit()
+    return rows
+
+
+def _query(db):
+    return db.query(Skill).filter(Skill.category == CATEGORY)
+
+
+def _walk_forward(db, limit: int, **kwargs) -> list[Skill]:
+    """Follow next_cursor to the end and return every row, in order."""
+    seen: list[Skill] = []
+    cursor = None
+    # A guard so a regression that never terminates fails the test instead of
+    # hanging the suite.
+    for _ in range(50):
+        items, _total, next_cursor, _prev, has_next, _has_prev = paginate_query(
+            _query(db), limit=limit, cursor=cursor, **kwargs
+        )
+        seen.extend(items)
+        if not has_next:
+            return seen
+        assert next_cursor is not None
+        cursor = next_cursor
+    pytest.fail("pagination did not terminate")
+
+
+class TestBoundary:
+    def test_next_page_does_not_repeat_the_last_row(self, db):
+        _make_skills(db, ["a", "b", "c", "d", "e"])
+
+        page1, _, next_cursor, _, has_next, _ = paginate_query(
+            _query(db),
+            limit=3,
+            sort_column=Skill.name,
+            is_desc=False,
+            id_column=Skill.id,
+        )
+        assert [s.name for s in page1] == ["a", "b", "c"]
+        assert has_next is True
+
+        page2, _, _, _, _, _ = paginate_query(
+            _query(db),
+            limit=3,
+            cursor=next_cursor,
+            sort_column=Skill.name,
+            is_desc=False,
+            id_column=Skill.id,
+        )
+        # This is the regression: page 2 used to start with "c" again.
+        assert [s.name for s in page2] == ["d", "e"]
+
+    def test_full_walk_returns_every_row_exactly_once(self, db):
+        names = [f"skill{i:02d}" for i in range(11)]
+        _make_skills(db, names)
+
+        seen = _walk_forward(
+            db, limit=3, sort_column=Skill.name, is_desc=False, id_column=Skill.id
+        )
+
+        assert [s.name for s in seen] == names
+        assert len({s.id for s in seen}) == len(names)
+
+    def test_full_walk_descending(self, db):
+        names = [f"skill{i:02d}" for i in range(11)]
+        _make_skills(db, names)
+
+        seen = _walk_forward(
+            db, limit=4, sort_column=Skill.name, is_desc=True, id_column=Skill.id
+        )
+
+        assert [s.name for s in seen] == list(reversed(names))
+
+    def test_walk_when_limit_exactly_divides_the_row_count(self, db):
+        names = [f"skill{i:02d}" for i in range(6)]
+        _make_skills(db, names)
+
+        seen = _walk_forward(
+            db, limit=3, sort_column=Skill.name, is_desc=False, id_column=Skill.id
+        )
+
+        assert [s.name for s in seen] == names
+
+    def test_id_only_pagination_has_no_overlap(self, db):
+        _make_skills(db, ["a", "b", "c", "d", "e"])
+
+        seen = _walk_forward(db, limit=2, id_column=Skill.id, is_desc=False)
+
+        assert len(seen) == 5
+        assert len({s.id for s in seen}) == 5
+
+
+class TestTies:
+    """Rows sharing a sort value must still be totally ordered."""
+
+    def test_rows_with_identical_sort_values_are_not_duplicated(self, db):
+        shared = dt.datetime(2026, 8, 11, 10, 54, 43)
+        names = [f"tied{i}" for i in range(6)]
+        _make_skills(db, names, created=[shared] * 6)
+
+        seen = _walk_forward(
+            db, limit=2, sort_column=Skill.created_at, is_desc=True, id_column=Skill.id
+        )
+
+        # Six rows, one page boundary inside each tied group: without the id
+        # tiebreaker the whole tied set came back on every page.
+        assert len(seen) == 6
+        assert len({s.id for s in seen}) == 6
+
+    def test_partial_ties_keep_the_overall_order(self, db):
+        early = dt.datetime(2026, 8, 10, 9, 0, 0)
+        late = dt.datetime(2026, 8, 11, 9, 0, 0)
+        _make_skills(
+            db,
+            ["p", "q", "r", "s"],
+            created=[late, late, early, early],
+        )
+
+        seen = _walk_forward(
+            db, limit=1, sort_column=Skill.created_at, is_desc=True, id_column=Skill.id
+        )
+
+        assert len(seen) == 4
+        assert [s.created_at for s in seen] == [late, late, early, early]
+
+
+class TestBackwards:
+    def test_prev_cursor_goes_back_one_page_not_to_the_start(self, db):
+        names = [f"skill{i:02d}" for i in range(9)]
+        _make_skills(db, names)
+
+        kwargs = dict(sort_column=Skill.name, is_desc=False, id_column=Skill.id)
+
+        page1, _, cursor1, _, _, _ = paginate_query(_query(db), limit=3, **kwargs)
+        page2, _, cursor2, _, _, _ = paginate_query(
+            _query(db), limit=3, cursor=cursor1, **kwargs
+        )
+        page3, _, _, prev3, _, has_prev3 = paginate_query(
+            _query(db), limit=3, cursor=cursor2, **kwargs
+        )
+
+        assert [s.name for s in page1] == ["skill00", "skill01", "skill02"]
+        assert [s.name for s in page2] == ["skill03", "skill04", "skill05"]
+        assert [s.name for s in page3] == ["skill06", "skill07", "skill08"]
+        assert has_prev3 is True
+
+        back, _, _, _, _, _ = paginate_query(
+            _query(db), limit=3, cursor=prev3, **kwargs
+        )
+
+        # Previously prev_cursor was always {"offset": 0} and this was page 1.
+        assert [s.name for s in back] == ["skill03", "skill04", "skill05"]
+
+    def test_backwards_page_is_returned_in_forward_order(self, db):
+        _make_skills(db, ["a", "b", "c", "d", "e", "f"])
+
+        kwargs = dict(sort_column=Skill.name, is_desc=False, id_column=Skill.id)
+
+        _page1, _, cursor1, _, _, _ = paginate_query(_query(db), limit=2, **kwargs)
+        _page2, _, cursor2, _, _, _ = paginate_query(
+            _query(db), limit=2, cursor=cursor1, **kwargs
+        )
+        _page3, _, _, prev3, _, _ = paginate_query(
+            _query(db), limit=2, cursor=cursor2, **kwargs
+        )
+
+        back, _, _, _, _, _ = paginate_query(
+            _query(db), limit=2, cursor=prev3, **kwargs
+        )
+
+        # Ascending means ascending, even when we walked backwards to get here.
+        assert [s.name for s in back] == ["c", "d"]
+
+    def test_first_page_reports_no_previous(self, db):
+        _make_skills(db, ["a", "b", "c"])
+
+        _items, _total, _next, prev, _has_next, has_prev = paginate_query(
+            _query(db),
+            limit=2,
+            sort_column=Skill.name,
+            is_desc=False,
+            id_column=Skill.id,
+        )
+
+        assert has_prev is False
+        assert prev is None
+
+    def test_walking_back_from_the_second_page_reports_no_previous(self, db):
+        _make_skills(db, ["a", "b", "c", "d"])
+
+        kwargs = dict(sort_column=Skill.name, is_desc=False, id_column=Skill.id)
+
+        _page1, _, cursor1, _, _, _ = paginate_query(_query(db), limit=2, **kwargs)
+        _page2, _, _, prev2, _, _ = paginate_query(
+            _query(db), limit=2, cursor=cursor1, **kwargs
+        )
+
+        back, _, _, _, has_next, has_prev = paginate_query(
+            _query(db), limit=2, cursor=prev2, **kwargs
+        )
+
+        assert [s.name for s in back] == ["a", "b"]
+        assert has_next is True
+        assert has_prev is False
+
+
+class TestCursorValues:
+    """Cursor values must come back as the type they went in as."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            None,
+            True,
+            False,
+            0,
+            -17,
+            3.5,
+            "plain string",
+            "a string that looks like 2026-08-11T10:54:43",
+            uuid.UUID("11111111-1111-4111-8111-111111111111"),
+            dt.datetime(2026, 8, 11, 10, 54, 43, 123456),
+            dt.datetime(2026, 8, 11, 10, 54, 43, tzinfo=dt.timezone.utc),
+            dt.date(2026, 8, 11),
+            dt.time(10, 54, 43),
+        ],
+    )
+    def test_round_trip_preserves_type_and_value(self, value):
+        restored = decode_cursor_value(encode_cursor_value(value))
+
+        assert restored == value
+        assert type(restored) is type(value)
+
+    def test_bool_is_not_flattened_to_int(self):
+        assert encode_cursor_value(True)["t"] == "bool"
+        assert encode_cursor_value(1)["t"] == "int"
+
+    def test_datetime_is_not_flattened_to_date(self):
+        assert encode_cursor_value(dt.datetime(2026, 8, 11))["t"] == "dt"
+        assert encode_cursor_value(dt.date(2026, 8, 11))["t"] == "date"
+
+    def test_datetime_cursor_survives_a_real_page_walk(self, db):
+        base = dt.datetime(2026, 8, 11, 10, 0, 0)
+        names = [f"dated{i}" for i in range(7)]
+        _make_skills(
+            db, names, created=[base + dt.timedelta(minutes=i) for i in range(7)]
+        )
+
+        seen = _walk_forward(
+            db, limit=2, sort_column=Skill.created_at, is_desc=True, id_column=Skill.id
+        )
+
+        assert len(seen) == 7
+        assert [s.name for s in seen] == list(reversed(names))
+
+
+class TestInvalidCursors:
+    def test_undecodable_cursor_is_rejected(self, db):
+        _make_skills(db, ["a"])
+
+        with pytest.raises(InvalidCursor):
+            paginate_query(
+                _query(db), limit=2, cursor="not base64 at all!!!", id_column=Skill.id
+            )
+
+    def test_cursor_without_a_row_reference_is_rejected(self, db):
+        _make_skills(db, ["a"])
+
+        with pytest.raises(InvalidCursor):
+            paginate_query(_query(db), limit=2, cursor=encode_cursor({"d": "next"}))
+
+    def test_unknown_direction_is_rejected(self, db):
+        _make_skills(db, ["a"])
+
+        cursor = encode_cursor({"d": "sideways", "id": {"t": "str", "v": "x"}})
+
+        with pytest.raises(InvalidCursor):
+            paginate_query(_query(db), limit=2, cursor=cursor, id_column=Skill.id)
+
+    def test_untagged_cursor_value_is_rejected(self, db):
+        _make_skills(db, ["a"])
+
+        # The old cursor format, which stored bare stringified values.
+        cursor = encode_cursor({"id": "11111111-1111-4111-8111-111111111111"})
+
+        with pytest.raises(InvalidCursor):
+            paginate_query(_query(db), limit=2, cursor=cursor, id_column=Skill.id)
+
+    def test_value_that_does_not_match_its_tag_is_rejected(self, db):
+        _make_skills(db, ["a"])
+
+        cursor = encode_cursor({"id": {"t": "uuid", "v": "definitely not a uuid"}})
+
+        with pytest.raises(InvalidCursor):
+            paginate_query(_query(db), limit=2, cursor=cursor, id_column=Skill.id)
+
+
+class TestOffsetMode:
+    def test_offset_still_works_for_page_pickers(self, db):
+        names = [f"skill{i:02d}" for i in range(7)]
+        _make_skills(db, names)
+
+        kwargs = dict(sort_column=Skill.name, is_desc=False, id_column=Skill.id)
+
+        page1, total, _, _, _, has_prev1 = paginate_query(
+            _query(db), limit=3, offset=0, **kwargs
+        )
+        page2, _, _, _, has_next2, has_prev2 = paginate_query(
+            _query(db), limit=3, offset=3, **kwargs
+        )
+
+        assert total == 7
+        assert [s.name for s in page1] == ["skill00", "skill01", "skill02"]
+        assert [s.name for s in page2] == ["skill03", "skill04", "skill05"]
+        assert has_prev1 is False
+        assert has_prev2 is True
+        assert has_next2 is True
+
+    def test_offset_past_the_end_returns_nothing_and_no_cursors(self, db):
+        _make_skills(db, ["a", "b"])
+
+        items, total, next_c, prev_c, has_next, _ = paginate_query(
+            _query(db),
+            limit=3,
+            offset=99,
+            sort_column=Skill.name,
+            is_desc=False,
+            id_column=Skill.id,
+        )
+
+        assert items == []
+        assert total == 2
+        assert has_next is False
+        assert next_c is None
+        assert prev_c is None
+
+    def test_negative_offset_is_clamped_rather_than_raising(self, db):
+        _make_skills(db, ["a", "b", "c"])
+
+        items, _, _, _, _, _ = paginate_query(
+            _query(db),
+            limit=2,
+            offset=-5,
+            sort_column=Skill.name,
+            is_desc=False,
+            id_column=Skill.id,
+        )
+
+        assert [s.name for s in items] == ["a", "b"]
+
+
+class TestMisc:
+    def test_total_counts_the_whole_set_not_the_page(self, db):
+        _make_skills(db, [f"skill{i:02d}" for i in range(9)])
+
+        kwargs = dict(sort_column=Skill.name, is_desc=False, id_column=Skill.id)
+
+        _page1, total1, cursor1, _, _, _ = paginate_query(_query(db), limit=4, **kwargs)
+        _page2, total2, _, _, _, _ = paginate_query(
+            _query(db), limit=4, cursor=cursor1, **kwargs
+        )
+
+        assert total1 == 9
+        assert total2 == 9
+
+    def test_empty_result_set(self, db):
+        items, total, next_c, prev_c, has_next, has_prev = paginate_query(
+            _query(db),
+            limit=5,
+            sort_column=Skill.name,
+            is_desc=False,
+            id_column=Skill.id,
+        )
+
+        assert items == []
+        assert total == 0
+        assert (next_c, prev_c, has_next, has_prev) == (None, None, False, False)
+
+    def test_limit_below_one_is_rejected(self, db):
+        with pytest.raises(ValueError):
+            paginate_query(_query(db), limit=0, id_column=Skill.id)
+
+    def test_paginate_and_respond_matches_paginate_query(self, db):
+        _make_skills(db, ["a", "b", "c", "d"])
+
+        kwargs = dict(sort_column=Skill.name, is_desc=False, id_column=Skill.id)
+
+        items, total, next_c, prev_c, has_next, has_prev = paginate_query(
+            _query(db), limit=2, **kwargs
+        )
+        response = paginate_and_respond(_query(db), limit=2, **kwargs)
+
+        assert [s.id for s in response.items] == [s.id for s in items]
+        assert response.total == total
+        assert response.limit == 2
+        assert response.next_cursor == next_c
+        assert response.prev_cursor == prev_c
+        assert response.has_next == has_next
+        assert response.has_prev == has_prev


### PR DESCRIPTION
# Pull Request

## Summary

`paginate_query` built its keyset filter with inclusive comparisons (`<=` / `>=`) but generated the cursor from the last row of the page it had just returned, so that row was re-emitted as the first row of the next page. This makes the boundary strict, gives the sort a tiebreaker so it is a total order, preserves cursor value types, and replaces the broken `prev_cursor`.

---

## Related Issue

Closes #1103

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [ ] UI/UX enhancement
- [x] Tests
- [ ] Other

---

## Changes Made

### 1. The boundary is strict, and the order is total

With `limit=3` over five rows sorted descending (E, D, C, B, A), page 1 was `[E, D, C]` and page 2 was `[C, B, A]`.

The filter is now the standard row-value comparison, written out longhand:

```
sort < :sort  OR  (sort = :sort  AND  id < :id)
```

The tiebreaker matters as much as the strictness. `created_at` is not unique — rows written in the same transaction share a timestamp — so ordering by it alone leaves tied rows in whatever order the planner picks, and it is free to answer differently for the two queries that make up a page boundary. Carrying the primary key makes the order total, so the boundary is stable. `ORDER BY` gained the same tiebreaker.

I wrote the comparison out longhand rather than using `tuple_(a, b) < tuple_(x, y)` because SQLite (which the test suite runs on) does not put an index behind row-value comparisons, and the longhand form is what the query planner wants on Postgres anyway.

### 2. Cursor values keep their type

Values were serialised with `str(val)`, so a `datetime` went into the cursor as `'2026-08-11 10:54:43.123456+00:00'` and came back out of `decode_cursor` as a `str`, which was then compared against a `DateTime` column. Postgres raises on that; SQLite compares lexicographically and quietly returns different rows than the index order implies.

Values now carry a short type tag and are rebuilt on the way back in — `datetime`, `date`, `time`, `UUID`, `Decimal`, `int`, `float`, `bool`, `str`, `None`. Two ordering details that are easy to get wrong and are covered by tests: `bool` is checked before `int` (it is a subclass, and would otherwise round-trip as `0`/`1`) and `datetime` before `date` (same reason).

### 3. `prev_cursor` actually goes back one page

`next_cursor` was keyset-shaped but `prev_cursor` was always `{"offset": ...}` — and since `effective_offset` stays `0` for the whole of a forward keyset walk, it was `{"offset": 0}` on every page. "Previous" always meant "page 1".

It is now a real reverse keyset cursor carrying a direction flag. Walking backwards runs the query in the opposite order, then flips the page back before returning it, so an ascending list stays ascending regardless of which way you arrived.

### 4. A bad cursor is an error

A cursor that fails to decode used to fall through to page 1. That is the worst possible behaviour for an infinite scroll — it restarts from the top and loops. It now raises `InvalidCursor` (a `ValueError` subclass).

Worth flagging for reviewers: this is a behaviour change, but nothing outside the tests calls `paginate_query` today, so there is no blast radius. I have deliberately **not** touched `main.py` to register a 400 handler for it — that file is contended by several open PRs right now and I did not want to add a conflict for a one-line registration. Happy to do it in a follow-up, or here if you would rather.

### 5. `paginate_and_respond()`

Added, because every router that uses this wants `paginate_query` immediately followed by `build_paginated_response`, and threading six positional results between them by hand is how the two halves drift apart.

---

## Testing

- [x] Tested locally
- [x] Existing tests pass
- [x] Added new tests

`backend/tests/test_keyset_pagination.py`, 39 tests. The existing `test_pagination.py` only ever asked for page 1, which is precisely why this bug survived — it is invisible until you follow a cursor. So most of the new tests walk the pages and assert on the concatenation:

- next page does not repeat the last row (the direct regression test)
- full forward walks ascending and descending return every row exactly once, including when `limit` exactly divides the row count
- rows with identical `created_at` are not duplicated across pages, and partial ties keep the overall order
- `prev_cursor` returns the immediately preceding page, in forward order, with correct `has_next`/`has_prev`
- cursor values round-trip with their type for 13 value kinds; `bool`/`int` and `datetime`/`date` are not conflated
- a datetime cursor survives a real page walk against a `DateTime` column
- malformed cursors are rejected: undecodable, no row reference, unknown direction, untagged value (the old format), value that does not match its tag
- offset mode still works, including past-the-end and negative offsets
- `total` counts the whole set on every page, empty result sets, `limit < 1`, and `paginate_and_respond` agreeing with `paginate_query`

`pytest tests/test_pagination.py tests/test_keyset_pagination.py` → 44 passed. Formatted with `black`.
