### PR TITLE
fix(security): pin link preview fetches to the address that passed validation (fixes #1104)

### DIFF
--- a/backend/app/services/link_preview_service.py
+++ b/backend/app/services/link_preview_service.py
@@ -11,6 +11,8 @@ The rules this module enforces on every fetch:
 * the destination is validated before we connect (see ``utils.url_safety``),
   and re-validated at every redirect hop -- following redirects automatically
   would let a public URL bounce us to ``169.254.169.254``
+* the connection is pinned to the address that validation approved, so DNS
+  cannot answer differently between the check and the connect
 * the body is streamed and abandoned once it exceeds a byte cap, so a hostile
   server cannot make us buffer a gigabyte
 * only HTML content types are parsed
@@ -34,8 +36,10 @@ import httpx
 from app.core.cache import cache_manager
 from app.core.config import settings
 from app.utils.url_safety import (
+    SafeTarget,
     UnsafeURL,
     normalise_url,
+    pin_target,
     validate_outbound_url,
 )
 
@@ -127,7 +131,7 @@ class LinkPreviewService:
             if cached is not None:
                 return LinkPreview(**cached)
 
-        fetched = self._fetch_html(target.url)
+        fetched = self._fetch_html(target)
         if fetched is None:
             cache_manager.set(
                 cache_key,
@@ -169,15 +173,26 @@ class LinkPreviewService:
     # Fetching
     # ------------------------------------------------------------------
 
-    def _fetch_html(self, url: str) -> Optional[tuple[str, str]]:
+    def _fetch_html(self, target: SafeTarget) -> Optional[tuple[str, str]]:
         """
-        Fetch a URL and return ``(body, final_url)``, or ``None`` on failure.
+        Fetch a validated target and return ``(body, final_url)``, or ``None``.
 
-        Redirects are followed by hand so that every hop goes back through
-        :func:`validate_outbound_url`. ``httpx``'s own redirect following would
-        happily walk us onto the metadata service.
+        Two things happen by hand here rather than being left to ``httpx``:
+
+        * **Redirects.** Every hop goes back through
+          :func:`validate_outbound_url`. ``httpx``'s own redirect following
+          would happily walk us onto the metadata service.
+        * **Address resolution.** Each hop connects to the address that hop's
+          validation actually approved, via :func:`pin_target`. Handing the
+          hostname to ``httpx`` would let it resolve a second time, and a
+          short-TTL record that answers public-then-private turns the whole
+          guard into decoration.
+
+        ``final_url`` is the logical URL, not the pinned one -- the IP is a
+        transport detail and has no business ending up in a preview card.
         """
-        current = url
+        current_target = target
+        current_url = target.url
 
         try:
             with httpx.Client(
@@ -191,17 +206,27 @@ class LinkPreviewService:
                 },
             ) as client:
                 for _ in range(self.max_redirects + 1):
-                    with client.stream("GET", current) as response:
+                    pinned = pin_target(current_target)
+
+                    with client.stream(
+                        "GET",
+                        pinned.url,
+                        headers=pinned.headers,
+                        extensions=pinned.extensions,
+                    ) as response:
                         if response.is_redirect:
                             location = response.headers.get("location")
                             if not location:
                                 return None
 
-                            # Relative redirects are legal and common.
-                            current = urljoin(current, location)
+                            # Relative redirects are legal and common, and must
+                            # resolve against the logical URL rather than the
+                            # pinned one, or they would inherit the IP.
+                            current_url = urljoin(current_url, location)
 
-                            # The whole point of doing this by hand.
-                            validate_outbound_url(current)
+                            # The whole point of doing this by hand: re-check
+                            # and re-pin, so hop two cannot be 169.254.169.254.
+                            current_target = validate_outbound_url(current_url)
                             continue
 
                         if response.status_code >= 400:
@@ -215,19 +240,19 @@ class LinkPreviewService:
                             return None
 
                         body = self._read_capped(response)
-                        return body, str(response.url)
+                        return body, current_url
 
         except UnsafeURL:
             # A redirect walked somewhere we will not follow. Treat it as an
             # absent preview rather than an error: the user pasted a URL that
             # was fine, and what happened after that is not their fault.
-            logger.info("Link preview redirect rejected for %s", url)
+            logger.info("Link preview redirect rejected for %s", target.url)
             return None
         except httpx.HTTPError as exc:
-            logger.info("Link preview fetch failed for %s: %s", url, exc)
+            logger.info("Link preview fetch failed for %s: %s", target.url, exc)
             return None
         except Exception as exc:  # pragma: no cover - defensive
-            logger.warning("Unexpected link preview error for %s: %s", url, exc)
+            logger.warning("Unexpected link preview error for %s: %s", target.url, exc)
             return None
 
         # Ran out of redirect budget.

--- a/backend/app/utils/url_safety.py
+++ b/backend/app/utils/url_safety.py
@@ -12,7 +12,7 @@ prove is a public destination, because the cost of a false negative is a
 credential leak and the cost of a false positive is one link that does not get
 a preview card.
 
-Two things it does that the obvious implementation does not:
+Three things it does that the obvious implementation does not:
 
 * It resolves the hostname and inspects the **resolved addresses**, not the
   hostname string. ``127.0.0.1.nip.io`` is a perfectly ordinary public name
@@ -20,6 +20,12 @@ Two things it does that the obvious implementation does not:
 * It exposes the resolved addresses to the caller, so a fetch can be re-checked
   at every redirect hop. A URL that passes on hop one and 302s to
   ``http://169.254.169.254/`` must fail on hop two.
+* It gives the caller everything needed to connect to *the address it just
+  checked* (see :func:`pin_target`). Validating a hostname and then handing the
+  hostname to an HTTP client leaves a gap in which DNS is free to answer
+  differently the second time, and that gap is the whole of the DNS-rebinding
+  attack. A check is only worth something if the socket goes to the address
+  that passed it.
 """
 
 from __future__ import annotations
@@ -28,7 +34,7 @@ import ipaddress
 import socket
 from dataclasses import dataclass
 from typing import Iterable, Optional
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 # Only these two ever make sense for a link somebody pasted into a message.
 # `file:` reads our disk, `gopher:` and `dict:` are classic SSRF gadgets for
@@ -65,6 +71,86 @@ class SafeTarget:
     host: str
     port: int
     addresses: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class PinnedRequest:
+    """
+    How to issue a request that lands on an address we verified.
+
+    ``url`` has the literal IP in place of the hostname, so the client does not
+    get a second bite at DNS. ``headers`` restores the original ``Host`` so
+    virtual hosting still works, and ``extensions`` carries the SNI hostname so
+    TLS still presents and validates the right certificate. Pass all three to
+    ``httpx`` and the connection is pinned without breaking name-based routing.
+    """
+
+    url: str
+    headers: dict[str, str]
+    extensions: dict[str, str]
+    address: str
+
+
+def format_host_for_url(host: str) -> str:
+    """
+    A host as it should appear in a URL's authority.
+
+    IPv6 literals need square brackets. Without them ``::1`` and the port
+    separator are indistinguishable and the result does not parse at all.
+    """
+    try:
+        parsed = ipaddress.ip_address(host)
+    except ValueError:
+        return host
+
+    return f"[{host}]" if isinstance(parsed, ipaddress.IPv6Address) else host
+
+
+def pin_target(target: SafeTarget, address: Optional[str] = None) -> PinnedRequest:
+    """
+    Turn a validated target into a request that cannot be re-resolved.
+
+    ``address`` picks which of the verified addresses to use; it must be one of
+    ``target.addresses``, and defaults to the first. Passing an address that
+    was not verified is a programming error and raises, rather than quietly
+    connecting somewhere unchecked.
+    """
+    if not target.addresses:
+        raise UnsafeURL("That host did not resolve to any address.")
+
+    chosen = address if address is not None else target.addresses[0]
+    if chosen not in target.addresses:
+        raise UnsafeURL("That address was not one of the verified addresses.")
+
+    parsed = urlparse(target.url)
+
+    # The Host header keeps the port when it is not the scheme default, which
+    # is what a browser would send and what virtual hosts key on.
+    host_header = target.host
+    if target.port != DEFAULT_PORTS.get(target.scheme):
+        host_header = f"{format_host_for_url(target.host)}:{target.port}"
+
+    authority = f"{format_host_for_url(chosen)}:{target.port}"
+    pinned_url = urlunparse(
+        (
+            target.scheme,
+            authority,
+            parsed.path or "/",
+            parsed.params,
+            parsed.query,
+            "",
+        )
+    )
+
+    return PinnedRequest(
+        url=pinned_url,
+        headers={"Host": host_header},
+        # httpx reads sni_hostname from request extensions. Without it the TLS
+        # handshake would use the IP as the server name and every certificate
+        # would fail to verify.
+        extensions={"sni_hostname": target.host},
+        address=chosen,
+    )
 
 
 def _is_public_address(address: str) -> bool:
@@ -200,22 +286,38 @@ def normalise_url(url: str) -> str:
     A stable spelling of a URL, for use as a cache key.
 
     Lowercases the scheme and host, drops a redundant explicit port and an
-    empty query or fragment. Two links that differ only in these respects
-    describe the same page and should share one cache entry.
+    empty fragment, brackets an IPv6 literal, and sorts the query. Two links
+    that differ only in these respects describe the same page and should share
+    one cache entry -- and a cache miss here is a real outbound fetch and a
+    rate-limit slot, so the sorting is not cosmetic.
     """
     parsed = urlparse(url.strip())
     scheme = parsed.scheme.lower()
     host = (parsed.hostname or "").lower()
 
-    netloc = host
+    # `parsed.hostname` strips the brackets from an IPv6 literal. Putting the
+    # bare address back into an authority produces `http://::1:8080/x`, which
+    # does not parse -- `urlparse` reports no hostname at all for it.
+    netloc = format_host_for_url(host)
     if parsed.port and parsed.port != DEFAULT_PORTS.get(scheme):
-        netloc = f"{host}:{parsed.port}"
+        netloc = f"{netloc}:{parsed.port}"
 
     path = parsed.path or "/"
 
+    # `?b=2&a=1` and `?a=1&b=2` are the same request. Sorting makes them the
+    # same cache key too.
+    #
+    # Sorting by the key alone, not by the whole pair: Python's sort is stable,
+    # so repeated keys keep their relative order. `?tag=a&tag=b` is not
+    # necessarily the same request as `?tag=b&tag=a` -- plenty of APIs treat
+    # repeated parameters as an ordered list -- and collapsing the two would be
+    # a cache collision between two different pages.
+    pairs = parse_qsl(parsed.query, keep_blank_values=True)
+    query = urlencode(sorted(pairs, key=lambda pair: pair[0]))
+
     # The fragment is a client-side concern; the server returns the same
     # document either way.
-    return urlunparse((scheme, netloc, path, parsed.params, parsed.query, ""))
+    return urlunparse((scheme, netloc, path, parsed.params, query, ""))
 
 
 def filter_safe_urls(urls: Iterable[str], *, resolver=_resolve) -> list[str]:

--- a/backend/tests/test_url_pinning.py
+++ b/backend/tests/test_url_pinning.py
@@ -1,0 +1,424 @@
+"""
+Tests for address pinning, and for the URL normalisation the cache key uses.
+
+The SSRF guard already resolved a hostname and checked every address it got
+back. What it did not do was make the *connection* go to one of those
+addresses -- it handed the hostname to ``httpx``, which resolved it again. That
+second lookup is a second chance for DNS to answer differently, which is the
+whole of the rebinding attack.
+
+These tests do not do DNS. They inject a resolver and a transport, and assert
+on what the HTTP client was actually asked to connect to.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from app.services import link_preview_service as lps
+from app.utils import url_safety
+from app.utils.url_safety import (
+    UnsafeURL,
+    format_host_for_url,
+    normalise_url,
+    pin_target,
+    validate_outbound_url,
+)
+
+PUBLIC_V4 = "93.184.216.34"
+OTHER_V4 = "93.184.216.35"
+PUBLIC_V6 = "2606:2800:220:1:248:1893:25c8:1946"
+
+
+def resolver_for(mapping):
+    """A fake DNS resolver backed by a dict of host -> addresses."""
+
+    def _resolve(host):
+        if host not in mapping:
+            raise UnsafeURL(f"Could not resolve host: {host}")
+        return tuple(mapping[host])
+
+    return _resolve
+
+
+PUBLIC = resolver_for({"example.com": [PUBLIC_V4]})
+
+
+# ----------------------------------------------------------------------
+# format_host_for_url
+# ----------------------------------------------------------------------
+
+
+class TestFormatHost:
+    def test_leaves_a_hostname_alone(self):
+        assert format_host_for_url("example.com") == "example.com"
+
+    def test_leaves_ipv4_alone(self):
+        assert format_host_for_url(PUBLIC_V4) == PUBLIC_V4
+
+    def test_brackets_ipv6(self):
+        assert format_host_for_url("::1") == "[::1]"
+        assert format_host_for_url(PUBLIC_V6) == f"[{PUBLIC_V6}]"
+
+    def test_does_not_double_bracket(self):
+        # Already-bracketed input is not a valid IP literal, so it falls
+        # through the hostname path unchanged rather than becoming [[::1]].
+        assert format_host_for_url("[::1]") == "[::1]"
+
+
+# ----------------------------------------------------------------------
+# pin_target
+# ----------------------------------------------------------------------
+
+
+class TestPinTarget:
+    def test_url_carries_the_address_not_the_hostname(self):
+        target = validate_outbound_url("https://example.com/post", resolver=PUBLIC)
+        pinned = pin_target(target)
+
+        assert pinned.address == PUBLIC_V4
+        assert f"//{PUBLIC_V4}:443/" in pinned.url
+        assert "example.com" not in pinned.url
+
+    def test_host_header_preserves_virtual_hosting(self):
+        target = validate_outbound_url("https://example.com/post", resolver=PUBLIC)
+        pinned = pin_target(target)
+
+        # Without this, name-based virtual hosts serve the wrong site (or a 421).
+        assert pinned.headers["Host"] == "example.com"
+
+    def test_sni_hostname_preserves_certificate_validation(self):
+        target = validate_outbound_url("https://example.com/post", resolver=PUBLIC)
+        pinned = pin_target(target)
+
+        # Without this, TLS uses the IP as the server name and every
+        # certificate on the internet fails to verify.
+        assert pinned.extensions["sni_hostname"] == "example.com"
+
+    def test_path_and_query_survive(self):
+        target = validate_outbound_url(
+            "https://example.com/a/b?x=1&y=2", resolver=PUBLIC
+        )
+        pinned = pin_target(target)
+
+        assert "/a/b" in pinned.url
+        assert "x=1" in pinned.url
+        assert "y=2" in pinned.url
+
+    def test_a_pathless_url_pins_to_root(self):
+        target = validate_outbound_url("https://example.com", resolver=PUBLIC)
+        pinned = pin_target(target)
+
+        assert pinned.url == f"https://{PUBLIC_V4}:443/"
+
+    def test_non_default_port_appears_in_the_host_header(self):
+        resolver = resolver_for({"example.com": [PUBLIC_V4]})
+        target = validate_outbound_url("http://example.com:8080/x", resolver=resolver)
+        pinned = pin_target(target)
+
+        assert pinned.headers["Host"] == "example.com:8080"
+        assert f"//{PUBLIC_V4}:8080/" in pinned.url
+
+    def test_default_port_is_left_out_of_the_host_header(self):
+        target = validate_outbound_url("https://example.com/x", resolver=PUBLIC)
+
+        assert pin_target(target).headers["Host"] == "example.com"
+
+    def test_ipv6_address_is_bracketed_in_the_pinned_url(self):
+        resolver = resolver_for({"example.com": [PUBLIC_V6]})
+        target = validate_outbound_url("https://example.com/x", resolver=resolver)
+        pinned = pin_target(target)
+
+        assert f"[{PUBLIC_V6}]:443" in pinned.url
+        # And the result has to be a URL httpx can actually parse.
+        assert httpx.URL(pinned.url).host == PUBLIC_V6
+
+    def test_a_specific_verified_address_can_be_chosen(self):
+        resolver = resolver_for({"example.com": [PUBLIC_V4, OTHER_V4]})
+        target = validate_outbound_url("https://example.com/x", resolver=resolver)
+
+        assert pin_target(target, OTHER_V4).address == OTHER_V4
+
+    def test_an_unverified_address_is_refused(self):
+        target = validate_outbound_url("https://example.com/x", resolver=PUBLIC)
+
+        # Pinning to an address that was never checked would defeat the point.
+        with pytest.raises(UnsafeURL):
+            pin_target(target, "169.254.169.254")
+
+    def test_choosing_is_deterministic(self):
+        resolver = resolver_for({"example.com": [OTHER_V4, PUBLIC_V4]})
+        target = validate_outbound_url("https://example.com/x", resolver=resolver)
+
+        assert pin_target(target).address == pin_target(target).address
+
+
+# ----------------------------------------------------------------------
+# The fetch path
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture
+def pinned_fetch(monkeypatch):
+    """
+    Drive `_fetch_html` with an injected resolver and transport.
+
+    Returns a callable `(url, mapping, handler) -> (result, requests)` where
+    `requests` is every request the transport saw, so a test can assert on
+    where the client was actually pointed.
+    """
+
+    def run(url, mapping, handler):
+        resolver = resolver_for(mapping)
+        monkeypatch.setattr(
+            lps,
+            "validate_outbound_url",
+            lambda u: url_safety.validate_outbound_url(u, resolver=resolver),
+        )
+
+        seen: list[httpx.Request] = []
+
+        def recording_handler(request: httpx.Request) -> httpx.Response:
+            seen.append(request)
+            return handler(request)
+
+        real_client = httpx.Client
+
+        def factory(**kwargs):
+            kwargs.pop("transport", None)
+            return real_client(
+                transport=httpx.MockTransport(recording_handler), **kwargs
+            )
+
+        monkeypatch.setattr(httpx, "Client", factory)
+
+        service = lps.LinkPreviewService(
+            timeout=1.0, max_bytes=100_000, max_redirects=3
+        )
+        target = url_safety.validate_outbound_url(url, resolver=resolver)
+        return service._fetch_html(target), seen
+
+    return run
+
+
+def html_response(body: str = "<html><head><title>Hi</title></head></html>"):
+    return httpx.Response(200, text=body, headers={"content-type": "text/html"})
+
+
+class TestFetchPinning:
+    def test_the_client_connects_to_the_verified_address(self, pinned_fetch):
+        result, seen = pinned_fetch(
+            "https://example.com/post",
+            {"example.com": [PUBLIC_V4]},
+            lambda _r: html_response(),
+        )
+
+        assert result is not None
+        assert len(seen) == 1
+        # This is the fix: httpx was previously given "example.com" and got to
+        # resolve it a second time.
+        assert seen[0].url.host == PUBLIC_V4
+        assert seen[0].headers["Host"] == "example.com"
+
+    def test_tls_still_gets_the_right_server_name(self, pinned_fetch):
+        _result, seen = pinned_fetch(
+            "https://example.com/post",
+            {"example.com": [PUBLIC_V4]},
+            lambda _r: html_response(),
+        )
+
+        assert seen[0].extensions["sni_hostname"] == "example.com"
+
+    def test_rebinding_between_check_and_connect_cannot_reach_metadata(self):
+        """
+        A record whose answer changes between lookups.
+
+        This is the attack the pinning exists for. The resolver hands out a
+        public address the first time it is asked and the cloud metadata
+        address every time after, which is what a hostile record with a 0-second
+        TTL does. Validation sees the public answer and passes.
+
+        Before, the hostname went to httpx, httpx resolved it again, got
+        169.254.169.254, and fetched it. Now the address validation approved is
+        baked into the request, so there is no second lookup to poison.
+        """
+        lookups = []
+
+        def rebinding_resolver(host):
+            lookups.append(host)
+            return (PUBLIC_V4,) if len(lookups) == 1 else ("169.254.169.254",)
+
+        target = validate_outbound_url(
+            "https://example.com/post", resolver=rebinding_resolver
+        )
+        pinned = pin_target(target)
+
+        assert len(lookups) == 1
+        assert pinned.address == PUBLIC_V4
+        assert "169.254.169.254" not in pinned.url
+        # And the second answer, had anyone asked for it, would have been
+        # refused outright.
+        assert rebinding_resolver("example.com") == ("169.254.169.254",)
+        with pytest.raises(UnsafeURL):
+            validate_outbound_url(
+                "https://example.com/post", resolver=lambda _h: ("169.254.169.254",)
+            )
+
+    def test_each_redirect_hop_is_pinned_to_its_own_address(self, pinned_fetch):
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.host == PUBLIC_V4:
+                return httpx.Response(
+                    302, headers={"location": "https://other.test/final"}
+                )
+            return html_response()
+
+        result, seen = pinned_fetch(
+            "https://example.com/start",
+            {"example.com": [PUBLIC_V4], "other.test": [OTHER_V4]},
+            handler,
+        )
+
+        assert result is not None
+        assert [r.url.host for r in seen] == [PUBLIC_V4, OTHER_V4]
+        assert [r.headers["Host"] for r in seen] == ["example.com", "other.test"]
+
+    def test_a_redirect_to_a_private_address_is_still_refused(self, pinned_fetch):
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                302, headers={"location": "http://metadata.test/latest/meta-data/"}
+            )
+
+        result, seen = pinned_fetch(
+            "https://example.com/start",
+            {"example.com": [PUBLIC_V4], "metadata.test": ["169.254.169.254"]},
+            handler,
+        )
+
+        assert result is None
+        # We connected once, saw the redirect, and refused to take it.
+        assert len(seen) == 1
+
+    def test_relative_redirects_resolve_against_the_logical_url(self, pinned_fetch):
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/start":
+                return httpx.Response(302, headers={"location": "/moved"})
+            return html_response()
+
+        result, seen = pinned_fetch(
+            "https://example.com/start",
+            {"example.com": [PUBLIC_V4]},
+            handler,
+        )
+
+        assert result is not None
+        assert [r.url.path for r in seen] == ["/start", "/moved"]
+
+    def test_final_url_is_the_logical_url_not_the_pinned_one(self, pinned_fetch):
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/start":
+                return httpx.Response(
+                    302, headers={"location": "https://other.test/end"}
+                )
+            return html_response()
+
+        result, _seen = pinned_fetch(
+            "https://example.com/start",
+            {"example.com": [PUBLIC_V4], "other.test": [OTHER_V4]},
+            handler,
+        )
+
+        assert result is not None
+        _body, final_url = result
+        # An IP has no business showing up in a preview card.
+        assert final_url == "https://other.test/end"
+        assert OTHER_V4 not in final_url
+
+    def test_a_non_html_content_type_is_not_parsed(self, pinned_fetch):
+        result, _seen = pinned_fetch(
+            "https://example.com/file.zip",
+            {"example.com": [PUBLIC_V4]},
+            lambda _r: httpx.Response(
+                200, content=b"PK\x03\x04", headers={"content-type": "application/zip"}
+            ),
+        )
+
+        assert result is None
+
+    def test_the_redirect_budget_is_bounded(self, pinned_fetch):
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                302, headers={"location": "https://example.com/again"}
+            )
+
+        result, seen = pinned_fetch(
+            "https://example.com/start",
+            {"example.com": [PUBLIC_V4]},
+            handler,
+        )
+
+        assert result is None
+        assert len(seen) == 4  # max_redirects=3, so four attempts
+
+
+# ----------------------------------------------------------------------
+# normalise_url
+# ----------------------------------------------------------------------
+
+
+class TestNormaliseUrl:
+    def test_lowercases_scheme_and_host(self):
+        assert normalise_url("HTTPS://Example.COM/Path") == "https://example.com/Path"
+
+    def test_drops_a_redundant_default_port(self):
+        assert normalise_url("https://example.com:443/x") == "https://example.com/x"
+
+    def test_keeps_a_meaningful_port(self):
+        assert normalise_url("http://example.com:8080/x") == "http://example.com:8080/x"
+
+    def test_drops_the_fragment(self):
+        assert normalise_url("https://example.com/x#section") == "https://example.com/x"
+
+    def test_supplies_a_root_path(self):
+        assert normalise_url("https://example.com") == "https://example.com/"
+
+    def test_ipv6_host_keeps_its_brackets(self):
+        # Previously this produced "http://::1:8080/x", which does not parse --
+        # urlparse reports no hostname at all for it.
+        result = normalise_url("http://[::1]:8080/x")
+
+        assert result == "http://[::1]:8080/x"
+        assert httpx.URL(result).host == "::1"
+
+    def test_ipv6_host_on_the_default_port(self):
+        result = normalise_url(f"https://[{PUBLIC_V6}]/x")
+
+        assert result == f"https://[{PUBLIC_V6}]/x"
+        assert httpx.URL(result).host == PUBLIC_V6
+
+    def test_query_order_does_not_change_the_key(self):
+        # Two spellings of the same request should not be two cache entries,
+        # two outbound fetches and two rate-limit slots.
+        assert normalise_url("https://example.com/x?b=2&a=1") == normalise_url(
+            "https://example.com/x?a=1&b=2"
+        )
+
+    def test_repeated_keys_keep_their_relative_order(self):
+        # ?tag=a&tag=b is not necessarily the same request as ?tag=b&tag=a.
+        assert normalise_url("https://example.com/x?tag=a&tag=b") != normalise_url(
+            "https://example.com/x?tag=b&tag=a"
+        )
+
+    def test_blank_values_are_preserved(self):
+        assert (
+            normalise_url("https://example.com/x?flag=")
+            == "https://example.com/x?flag="
+        )
+
+    def test_an_empty_query_leaves_no_question_mark(self):
+        assert normalise_url("https://example.com/x?") == "https://example.com/x"
+
+    def test_is_idempotent(self):
+        once = normalise_url("HTTPS://Example.com:443/x?b=2&a=1#frag")
+
+        assert normalise_url(once) == once


### PR DESCRIPTION
# Pull Request

## Summary

The SSRF guard resolved a hostname and checked every address it got back, then handed the *hostname* to `httpx`, which resolved it again. Nothing tied the connection to the address that passed validation, which leaves the guard open to DNS rebinding. This pins each fetch to a verified address, and fixes two `normalise_url` bugs found along the way.

---

## Related Issue

Closes #1104

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [ ] UI/UX enhancement
- [x] Tests
- [ ] Other

---

## Changes Made

### 1. Pin the connection to the verified address

`SafeTarget` already carried `addresses`, and the module docstring already said they were exposed so a fetch could be re-checked — but nothing consumed them:

```python
target = validate_outbound_url(url)
...
fetched = self._fetch_html(target.url)   # only the URL string survives
```

The attack is textbook rebinding. An attacker serves `evil.example.com` with a 0-second TTL:

1. `getaddrinfo("evil.example.com")` → `203.0.113.10`. Public, passes.
2. `httpx` resolves the same name a few milliseconds later → `169.254.169.254`.
3. The metadata response gets rendered into a preview card.

No precise timing needed — alternating answers round-robin and retrying the paste gets there eventually.

Added `pin_target()`, which turns a validated target into three things:

- a **URL with the literal IP** in place of the hostname, so there is no second lookup to poison
- a **`Host` header** carrying the original hostname (with the port when it is not the scheme default), so name-based virtual hosting still resolves to the right site rather than a 421
- an **`sni_hostname` extension**, so TLS still presents and validates the right certificate — without it the handshake uses the IP as the server name and every certificate on the internet fails to verify

`pin_target` refuses an address that is not in `target.addresses`, so pinning somewhere unverified is an error rather than a quiet hole.

`_fetch_html` now pins **every hop**, not just the first. Redirects were already re-validated by hand; they are now re-pinned too, so hop two cannot be the metadata service either. Relative redirects resolve against the logical URL rather than the pinned one, and the reported `final_url` stays logical — an IP has no business appearing in a preview card.

### 2. `normalise_url` corrupted IPv6 hosts

`urlparse` strips the brackets from an IPv6 literal in `.hostname`, and they were never put back:

```
>>> normalise_url("http://[::1]:8080/x")
'http://::1:8080/x'
>>> urlparse('http://::1:8080/x').hostname
None
```

Not a parseable URL. Since `normalise_url` builds the link-preview cache key, every IPv6 URL produced a mangled key. Added `format_host_for_url()`, which brackets IPv6 and leaves everything else alone.

### 3. `normalise_url` produced order-sensitive cache keys

It is documented as "a stable spelling of a URL, for use as a cache key" but passed `parsed.query` through untouched, so `?a=1&b=2` and `?b=2&a=1` were two entries, two outbound fetches, and two rate-limit slots for the same page.

Parameters are now sorted — **by key only, with a stable sort**, so repeated keys keep their relative order. `?tag=a&tag=b` stays distinct from `?tag=b&tag=a`, since plenty of APIs treat repeated parameters as an ordered list and collapsing them would be a cache collision between two different pages.

---

## Testing

- [x] Tested locally
- [x] Existing tests pass
- [x] Added new tests

`backend/tests/test_url_pinning.py`, 36 tests. No DNS and no network — the resolver and the transport are both injected, and the tests assert on what the HTTP client was actually asked to connect to.

- `pin_target`: URL carries the address not the hostname; `Host` header and SNI preserved; path/query survive; pathless URL pins to root; non-default port lands in both URL and `Host`; IPv6 bracketed and parseable by `httpx.URL`; a specific verified address can be chosen; an unverified address raises; choice is deterministic
- the fetch path: the client connects to the verified address with the right `Host` and SNI; the rebinding resolver (public on the first lookup, metadata on every one after) never gets a second bite; each redirect hop is pinned to its own address; a redirect to a private address is still refused after exactly one connection; relative redirects resolve against the logical URL; `final_url` is logical, not pinned; non-HTML content types are not parsed; the redirect budget is bounded
- `normalise_url`: scheme/host lowercasing, default-port dropping, fragment dropping, root path, IPv6 brackets on both default and explicit ports, query-order insensitivity, repeated-key order preservation, blank values, empty query, idempotence

Worth flagging: `_fetch_html` had **no** test coverage before this, so the hand-rolled redirect handling was untested as well. That is now covered.

`pytest tests/test_url_pinning.py tests/test_link_previews.py` → 83 passed (47 of those pre-existing). Formatted with `black`.
