### PR TITLE
fix(feed): stop the activity feed loading every page at once (fixes #1105)

### DIFF
--- a/frontend/src/features/activities/components/ActivityFeed.tsx
+++ b/frontend/src/features/activities/components/ActivityFeed.tsx
@@ -102,10 +102,12 @@ export function ActivityFeed({ actorId, targetId, targetType }: ActivityFeedProp
     }
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
-  const sentinelRef = useIntersectionObserver(
-    handleIntersect,
-    Boolean(hasNextPage && !isFetchingNextPage),
-  );
+  // `enabled` deliberately leaves out `isFetchingNextPage`. Toggling it off
+  // while a page loads tears the observer down, and the fresh one built when
+  // the fetch finishes reports the still-visible sentinel immediately, which
+  // asks for the next page, which toggles it again. `handleIntersect` already
+  // refuses to stack fetches, so the observer can just stay up.
+  const sentinelRef = useIntersectionObserver(handleIntersect, Boolean(hasNextPage));
 
   const activities = data?.pages.flatMap((page) => page) ?? [];
 

--- a/frontend/src/features/activities/components/ActivityFeed.tsx
+++ b/frontend/src/features/activities/components/ActivityFeed.tsx
@@ -162,9 +162,11 @@ export function ActivityFeed({ actorId, targetId, targetType }: ActivityFeedProp
               </div>
             )}
 
-            {hasNextPage && !isFetchingNextPage && (
-              <div ref={sentinelRef} className="h-1" aria-hidden="true" />
-            )}
+            {/* Kept mounted across a fetch. Unmounting it hands the hook a null
+                node and then a brand new one, and a brand new observer reports
+                an already-visible sentinel immediately -- which is the other
+                half of the runaway pagination. */}
+            {hasNextPage && <div ref={sentinelRef} className="h-1" aria-hidden="true" />}
 
             {!hasNextPage && activities.length > 0 && (
               <p className="py-4 text-center text-sm text-gray-400">

--- a/frontend/src/hooks/__tests__/useIntersectionObserver.test.tsx
+++ b/frontend/src/hooks/__tests__/useIntersectionObserver.test.tsx
@@ -1,0 +1,367 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render } from "@testing-library/react";
+import { useCallback, useState } from "react";
+
+import { useIntersectionObserver } from "../useIntersectionObserver";
+
+/**
+ * A stand-in for the real thing, which jsdom does not implement.
+ *
+ * The important behaviour to reproduce is that a real `IntersectionObserver`
+ * reports the target's current state as soon as `observe()` is called — that
+ * initial report is what turned an observer rebuild into a fetch loop.
+ */
+class FakeIntersectionObserver implements IntersectionObserver {
+  static instances: FakeIntersectionObserver[] = [];
+  /** Whether a freshly observed target is treated as already in view. */
+  static initiallyIntersecting = false;
+
+  readonly root: Element | Document | null;
+  readonly rootMargin: string;
+  readonly thresholds: ReadonlyArray<number>;
+
+  targets: Element[] = [];
+  disconnected = false;
+
+  private callback: IntersectionObserverCallback;
+
+  constructor(callback: IntersectionObserverCallback, options?: IntersectionObserverInit) {
+    this.callback = callback;
+    this.root = (options?.root as Element | null) ?? null;
+    this.rootMargin = options?.rootMargin ?? "0px";
+    this.thresholds = options?.threshold === undefined ? [0] : [options.threshold].flat();
+    FakeIntersectionObserver.instances.push(this);
+  }
+
+  observe(target: Element): void {
+    this.targets.push(target);
+    if (FakeIntersectionObserver.initiallyIntersecting) {
+      this.emit(true);
+    }
+  }
+
+  unobserve(target: Element): void {
+    this.targets = this.targets.filter((t) => t !== target);
+  }
+
+  disconnect(): void {
+    this.disconnected = true;
+    this.targets = [];
+  }
+
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+
+  /** Report an intersection state change to the hook. */
+  emit(isIntersecting: boolean): void {
+    if (this.disconnected) return;
+    this.callback([{ isIntersecting, target: this.targets[0] } as IntersectionObserverEntry], this);
+  }
+
+  static get latest(): FakeIntersectionObserver {
+    const observer = this.instances[this.instances.length - 1];
+    if (!observer) throw new Error("no IntersectionObserver was constructed");
+    return observer;
+  }
+
+  static get live(): FakeIntersectionObserver[] {
+    return this.instances.filter((o) => !o.disconnected);
+  }
+
+  static reset(): void {
+    this.instances = [];
+    this.initiallyIntersecting = false;
+  }
+}
+
+/** A component that mirrors how ActivityFeed wires the hook up. */
+function Sentinel({
+  onIntersect,
+  enabled,
+  options,
+}: {
+  onIntersect: () => void;
+  enabled: boolean;
+  options?: Parameters<typeof useIntersectionObserver>[2];
+}) {
+  const ref = useIntersectionObserver(onIntersect, enabled, options);
+  return <div data-testid="sentinel" ref={ref} />;
+}
+
+describe("useIntersectionObserver", () => {
+  beforeEach(() => {
+    FakeIntersectionObserver.reset();
+    vi.stubGlobal("IntersectionObserver", FakeIntersectionObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  describe("firing", () => {
+    it("calls the handler when the sentinel comes into view", () => {
+      const onIntersect = vi.fn();
+      render(<Sentinel onIntersect={onIntersect} enabled />);
+
+      act(() => FakeIntersectionObserver.latest.emit(true));
+
+      expect(onIntersect).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call the handler while the sentinel is out of view", () => {
+      const onIntersect = vi.fn();
+      render(<Sentinel onIntersect={onIntersect} enabled />);
+
+      act(() => FakeIntersectionObserver.latest.emit(false));
+
+      expect(onIntersect).not.toHaveBeenCalled();
+    });
+
+    it("does not refire while the sentinel stays in view", () => {
+      const onIntersect = vi.fn();
+      render(<Sentinel onIntersect={onIntersect} enabled />);
+
+      const observer = FakeIntersectionObserver.latest;
+      act(() => {
+        // Scrolling slowly inside rootMargin reports isIntersecting again on
+        // every ratio change.
+        observer.emit(true);
+        observer.emit(true);
+        observer.emit(true);
+      });
+
+      expect(onIntersect).toHaveBeenCalledTimes(1);
+    });
+
+    it("fires again after the sentinel leaves and re-enters", () => {
+      const onIntersect = vi.fn();
+      render(<Sentinel onIntersect={onIntersect} enabled />);
+
+      const observer = FakeIntersectionObserver.latest;
+      act(() => {
+        observer.emit(true);
+        observer.emit(false);
+        observer.emit(true);
+      });
+
+      expect(onIntersect).toHaveBeenCalledTimes(2);
+    });
+
+    it("does nothing when disabled", () => {
+      const onIntersect = vi.fn();
+      render(<Sentinel onIntersect={onIntersect} enabled={false} />);
+
+      expect(FakeIntersectionObserver.instances).toHaveLength(0);
+      expect(onIntersect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("the fetch loop", () => {
+    it("does not rebuild the observer when the handler identity changes", () => {
+      const { rerender } = render(<Sentinel onIntersect={() => {}} enabled />);
+      const before = FakeIntersectionObserver.instances.length;
+
+      // A new inline arrow on every render, which is what happens whenever a
+      // caller does not memoise, and what useCallback produces anyway once any
+      // of its dependencies change.
+      rerender(<Sentinel onIntersect={() => {}} enabled />);
+      rerender(<Sentinel onIntersect={() => {}} enabled />);
+
+      expect(FakeIntersectionObserver.instances).toHaveLength(before);
+    });
+
+    it("always calls the newest handler", () => {
+      const first = vi.fn();
+      const second = vi.fn();
+
+      const { rerender } = render(<Sentinel onIntersect={first} enabled />);
+      rerender(<Sentinel onIntersect={second} enabled />);
+
+      act(() => FakeIntersectionObserver.latest.emit(true));
+
+      expect(first).not.toHaveBeenCalled();
+      expect(second).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not loop when a fetch toggles enabled off and back on", () => {
+      // This is the ActivityFeed bug end to end. The sentinel is already in
+      // view, so every fresh observer reports an intersection immediately.
+      FakeIntersectionObserver.initiallyIntersecting = true;
+
+      function Feed() {
+        const [pages, setPages] = useState(0);
+        const [fetching, setFetching] = useState(false);
+
+        const handleIntersect = useCallback(() => {
+          setFetching(true);
+          setPages((p) => p + 1);
+          // Resolve the "fetch" straight away, which is the worst case.
+          setFetching(false);
+        }, []);
+
+        const ref = useIntersectionObserver(handleIntersect, !fetching);
+
+        return (
+          <div>
+            <span data-testid="pages">{pages}</span>
+            <div ref={ref} />
+          </div>
+        );
+      }
+
+      const { getByTestId } = render(<Feed />);
+
+      // Before the fix this ran away, pulling a page per rebuild until
+      // hasNextPage went false. One page per scroll into view is correct.
+      expect(getByTestId("pages").textContent).toBe("1");
+    });
+
+    it("does not refire when a re-render hands back the same node", () => {
+      FakeIntersectionObserver.initiallyIntersecting = true;
+      const onIntersect = vi.fn();
+
+      const { rerender } = render(<Sentinel onIntersect={onIntersect} enabled />);
+      rerender(<Sentinel onIntersect={onIntersect} enabled />);
+      rerender(<Sentinel onIntersect={onIntersect} enabled />);
+
+      expect(onIntersect).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("options", () => {
+    it("defaults to a 200px root margin", () => {
+      render(<Sentinel onIntersect={vi.fn()} enabled />);
+
+      expect(FakeIntersectionObserver.latest.rootMargin).toBe("200px");
+    });
+
+    it("accepts a custom root margin", () => {
+      render(<Sentinel onIntersect={vi.fn()} enabled options={{ rootMargin: "50px" }} />);
+
+      expect(FakeIntersectionObserver.latest.rootMargin).toBe("50px");
+    });
+
+    it("accepts a threshold", () => {
+      render(<Sentinel onIntersect={vi.fn()} enabled options={{ threshold: 0.5 }} />);
+
+      expect(FakeIntersectionObserver.latest.thresholds).toEqual([0.5]);
+    });
+
+    it("accepts a scroll container as the root", () => {
+      const root = document.createElement("div");
+
+      render(<Sentinel onIntersect={vi.fn()} enabled options={{ root }} />);
+
+      expect(FakeIntersectionObserver.latest.root).toBe(root);
+    });
+
+    it("does not rebuild when an inline threshold array is recreated", () => {
+      const { rerender } = render(
+        <Sentinel onIntersect={vi.fn()} enabled options={{ threshold: [0, 0.5] }} />,
+      );
+      const before = FakeIntersectionObserver.instances.length;
+
+      rerender(<Sentinel onIntersect={vi.fn()} enabled options={{ threshold: [0, 0.5] }} />);
+
+      expect(FakeIntersectionObserver.instances).toHaveLength(before);
+    });
+
+    it("rebuilds when the root margin actually changes", () => {
+      const { rerender } = render(
+        <Sentinel onIntersect={vi.fn()} enabled options={{ rootMargin: "10px" }} />,
+      );
+
+      rerender(<Sentinel onIntersect={vi.fn()} enabled options={{ rootMargin: "80px" }} />);
+
+      expect(FakeIntersectionObserver.latest.rootMargin).toBe("80px");
+      expect(FakeIntersectionObserver.live).toHaveLength(1);
+    });
+  });
+
+  describe("once", () => {
+    it("fires a single time and stops observing", () => {
+      const onIntersect = vi.fn();
+      render(<Sentinel onIntersect={onIntersect} enabled options={{ once: true }} />);
+
+      const observer = FakeIntersectionObserver.latest;
+      act(() => observer.emit(true));
+
+      expect(onIntersect).toHaveBeenCalledTimes(1);
+      expect(observer.disconnected).toBe(true);
+    });
+
+    it("does not fire again after re-entering the viewport", () => {
+      const onIntersect = vi.fn();
+      const { rerender } = render(
+        <Sentinel onIntersect={onIntersect} enabled options={{ once: true }} />,
+      );
+
+      act(() => FakeIntersectionObserver.latest.emit(true));
+      rerender(<Sentinel onIntersect={onIntersect} enabled options={{ once: true }} />);
+
+      expect(onIntersect).toHaveBeenCalledTimes(1);
+      expect(FakeIntersectionObserver.live).toHaveLength(0);
+    });
+  });
+
+  describe("teardown", () => {
+    it("disconnects on unmount", () => {
+      const { unmount } = render(<Sentinel onIntersect={vi.fn()} enabled />);
+      const observer = FakeIntersectionObserver.latest;
+
+      unmount();
+
+      expect(observer.disconnected).toBe(true);
+    });
+
+    it("leaves no live observer behind when disabled after being enabled", () => {
+      const { rerender } = render(<Sentinel onIntersect={vi.fn()} enabled />);
+
+      rerender(<Sentinel onIntersect={vi.fn()} enabled={false} />);
+
+      expect(FakeIntersectionObserver.live).toHaveLength(0);
+    });
+
+    it("never keeps more than one live observer across many re-renders", () => {
+      const { rerender } = render(<Sentinel onIntersect={vi.fn()} enabled />);
+
+      for (let i = 0; i < 10; i += 1) {
+        rerender(<Sentinel onIntersect={vi.fn()} enabled={i % 2 === 0} />);
+      }
+
+      expect(FakeIntersectionObserver.live.length).toBeLessThanOrEqual(1);
+    });
+
+    it("re-observes when the hook is enabled again", () => {
+      const onIntersect = vi.fn();
+      const { rerender } = render(<Sentinel onIntersect={onIntersect} enabled={false} />);
+
+      rerender(<Sentinel onIntersect={onIntersect} enabled />);
+      act(() => FakeIntersectionObserver.latest.emit(true));
+
+      expect(onIntersect).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("environments without IntersectionObserver", () => {
+    it("renders without throwing", () => {
+      vi.unstubAllGlobals();
+      // @ts-expect-error deliberately removing the global for this assertion
+      vi.stubGlobal("IntersectionObserver", undefined);
+
+      expect(() => render(<Sentinel onIntersect={vi.fn()} enabled />)).not.toThrow();
+    });
+
+    it("unmounts cleanly too", () => {
+      vi.unstubAllGlobals();
+      // @ts-expect-error deliberately removing the global for this assertion
+      vi.stubGlobal("IntersectionObserver", undefined);
+
+      const { unmount } = render(<Sentinel onIntersect={vi.fn()} enabled />);
+
+      expect(() => unmount()).not.toThrow();
+    });
+  });
+});

--- a/frontend/src/hooks/__tests__/useIntersectionObserver.test.tsx
+++ b/frontend/src/hooks/__tests__/useIntersectionObserver.test.tsx
@@ -218,6 +218,30 @@ describe("useIntersectionObserver", () => {
       expect(getByTestId("pages").textContent).toBe("1");
     });
 
+    it("fires once per visible sentinel even when the sentinel remounts", () => {
+      // ActivityFeed used to render the sentinel only while
+      // `!isFetchingNextPage`, so it was unmounted for the duration of every
+      // fetch. A remounted node is a genuinely new node, so the hook cannot
+      // dedupe it — the component has to keep it mounted. This pins the cost
+      // of getting that wrong: one extra fire per remount, not zero.
+      FakeIntersectionObserver.initiallyIntersecting = true;
+      const onIntersect = vi.fn();
+
+      function Remounting({ show }: { show: boolean }) {
+        const ref = useIntersectionObserver(onIntersect, true);
+        return show ? <div ref={ref} /> : null;
+      }
+
+      const { rerender } = render(<Remounting show />);
+      expect(onIntersect).toHaveBeenCalledTimes(1);
+
+      rerender(<Remounting show={false} />);
+      rerender(<Remounting show />);
+
+      expect(onIntersect).toHaveBeenCalledTimes(2);
+      expect(FakeIntersectionObserver.live).toHaveLength(1);
+    });
+
     it("does not refire when a re-render hands back the same node", () => {
       FakeIntersectionObserver.initiallyIntersecting = true;
       const onIntersect = vi.fn();

--- a/frontend/src/hooks/useIntersectionObserver.ts
+++ b/frontend/src/hooks/useIntersectionObserver.ts
@@ -1,34 +1,115 @@
-import { useEffect, useRef, useCallback } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
+export interface UseIntersectionObserverOptions {
+  /** Scroll container to measure against. `null` (default) means the viewport. */
+  root?: Element | null;
+  /** Margin grown around the root before intersection is reported. */
+  rootMargin?: string;
+  /** How much of the target must be visible. */
+  threshold?: number | number[];
+  /** Stop observing after the handler fires once. */
+  once?: boolean;
+}
+
+const DEFAULT_ROOT_MARGIN = "200px";
+
+/**
+ * Call `onIntersect` when an element scrolls into view.
+ *
+ * Returns a ref callback: attach it to a sentinel element, usually an empty
+ * div at the bottom of a list.
+ *
+ * Two things this is careful about, both of which caused real trouble in the
+ * activity feed:
+ *
+ * **The handler lives in a ref.** If it were an observer dependency, every
+ * change to its identity would tear the observer down and build a new one —
+ * and `IntersectionObserver` fires its callback immediately on `observe()` for
+ * an element that is already in view. With a handler whose identity changes
+ * when a fetch starts and again when it finishes, that is a loop: fetch,
+ * rebuild, fire, fetch. The feed pulled every page it had without the user
+ * scrolling at all.
+ *
+ * **It only fires on a false → true transition.** While a sentinel stays in
+ * view the browser reports `isIntersecting: true` again on any change to the
+ * intersection ratio, so scrolling slowly inside `rootMargin` would otherwise
+ * fire repeatedly.
+ */
 export function useIntersectionObserver(
   onIntersect: () => void,
   enabled: boolean,
+  options: UseIntersectionObserverOptions = {},
 ): (node: Element | null) => void {
-  const observerRef = useRef<IntersectionObserver | null>(null);
+  const { root = null, rootMargin = DEFAULT_ROOT_MARGIN, threshold, once = false } = options;
+
+  // The node lives in state rather than a ref so that attaching it re-runs the
+  // effect below. One effect owning the observer's whole lifecycle is what
+  // keeps a node from being observed twice, which is its own initial-report
+  // double-fire.
+  const [node, setNode] = useState<Element | null>(null);
+
+  // The latest handler, without making it an observer dependency.
+  const onIntersectRef = useRef(onIntersect);
+  onIntersectRef.current = onIntersect;
+
+  // Whether the sentinel was intersecting the last time we heard about it, so
+  // the handler can fire on the edge rather than on every report.
+  const wasIntersectingRef = useRef(false);
+
+  // Set once `once` has fired, so a later re-observe does not fire again.
+  const doneRef = useRef(false);
+
+  // `threshold` is very often passed as an inline array. Serialising it stops a
+  // fresh `[0.5]` on every render from counting as a change.
+  const thresholdKey = JSON.stringify(threshold ?? null);
 
   useEffect(() => {
+    if (!enabled || !node || doneRef.current) return;
+
+    // Absent during SSR, and absent from jsdom, which is why anything using
+    // this hook previously threw in tests.
+    if (typeof IntersectionObserver === "undefined") return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        // There is only ever one target per observer here, but the callback is
+        // handed a batch and the last entry is the current state.
+        const entry = entries[entries.length - 1];
+        if (!entry) return;
+
+        const isIntersecting = entry.isIntersecting;
+        const wasIntersecting = wasIntersectingRef.current;
+        wasIntersectingRef.current = isIntersecting;
+
+        if (!isIntersecting || wasIntersecting || doneRef.current) return;
+
+        if (once) {
+          doneRef.current = true;
+          observer.disconnect();
+        }
+
+        onIntersectRef.current();
+      },
+      {
+        root,
+        rootMargin,
+        ...(threshold === undefined ? {} : { threshold }),
+      },
+    );
+
+    observer.observe(node);
+
     return () => {
-      observerRef.current?.disconnect();
+      observer.disconnect();
+      // The next observer starts from a clean slate, so a sentinel that is
+      // still in view is an edge again rather than a repeat.
+      wasIntersectingRef.current = false;
     };
-  }, []);
+    // thresholdKey stands in for threshold, which may be a fresh array each render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [node, enabled, root, rootMargin, thresholdKey, once]);
 
-  return useCallback(
-    (node: Element | null) => {
-      observerRef.current?.disconnect();
-
-      if (!enabled || !node) return;
-
-      observerRef.current = new IntersectionObserver(
-        ([entry]) => {
-          if (entry.isIntersecting) {
-            onIntersect();
-          }
-        },
-        { rootMargin: "200px" },
-      );
-
-      observerRef.current.observe(node);
-    },
-    [enabled, onIntersect],
-  );
+  // A stable identity, so React does not call it with null and then the node
+  // again on every re-render. `setNode` bails out when handed the same node.
+  return useCallback((next: Element | null) => setNode(next), []);
 }


### PR DESCRIPTION
# Pull Request

## Summary

`useIntersectionObserver` rebuilt its observer whenever either of its arguments changed identity, and `IntersectionObserver` fires its callback immediately on `observe()` for an element already in view. In `ActivityFeed` those two facts formed a loop that pulled every page of the feed as soon as the sentinel first became visible.

---

## Related Issue

Closes #1105

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Performance improvement
- [ ] Refactoring
- [ ] UI/UX enhancement
- [x] Tests
- [ ] Other

---

## Changes Made

### The loop

```
sentinel enters view      → onIntersect() → fetchNextPage()
isFetchingNextPage: true  → enabled: false → new ref callback → observer disconnected
fetch resolves            → enabled: true  → new ref callback → fresh observer
fresh observer observes an element that is still in view → immediate report → back to line 1
```

It only stopped when `hasNextPage` went false. On a feed with any real history that is every page, back to back, and the user never scrolled.

### What changed in the hook

- **The handler lives in a ref** and is no longer an observer dependency, so a handler whose identity changes (an inline arrow, or a `useCallback` whose deps moved) no longer costs a rebuild.
- **Fires only on a false → true transition.** Even with a stable handler, a sentinel that stays in view is reported again on every change to the intersection ratio, so scrolling slowly inside the 200px margin was firing repeatedly.
- **One effect owns the observer's whole lifecycle**, with the node kept in state. My first pass at this kept the node in a ref and had both the ref callback and an effect call `observe()` — which meant the node was observed twice and the initial report arrived twice. Two of the tests below caught that, so they are worth keeping.
- **The returned ref callback has a stable identity**, so React stops calling it with `null` and then the node again on every render where it changed.
- **Guards on `typeof IntersectionObserver === "undefined"`.** This is an SSR app, and jsdom does not implement the API either — which is why there was no test file for this hook before.
- **Accepts `root`, `rootMargin`, `threshold` and `once`**, so it can be used inside a scroll container. `threshold` is compared by value, since it is almost always passed as an inline array and would otherwise force a rebuild every render.

### What changed in `ActivityFeed`

`enabled` no longer includes `isFetchingNextPage`:

```diff
-const sentinelRef = useIntersectionObserver(
-  handleIntersect,
-  Boolean(hasNextPage && !isFetchingNextPage),
-);
+const sentinelRef = useIntersectionObserver(handleIntersect, Boolean(hasNextPage));
```

`handleIntersect` already refuses to stack fetches, so there is nothing for the toggle to protect against — all it did was tear the observer down and rebuild it into another immediate report.

Behaviour worth calling out for reviewers: after this, if a loaded page does not push the sentinel out of view, the feed waits for the user to scroll rather than chaining straight into the next page. That is the intended trade — the alternative is the runaway loop — but if you would rather it kept filling until the sentinel clears, say so and I will add an explicit "keep going while still visible" check instead of getting it as an accident of observer churn.

---

## Testing

- [x] Tested locally
- [x] Existing tests pass
- [x] Added new tests

`frontend/src/hooks/__tests__/useIntersectionObserver.test.tsx`, 23 tests, driven by a stub that reproduces the behaviour that actually matters here — reporting the target's state as soon as `observe()` is called.

- firing: fires on entry, not while out of view, not repeatedly while it stays in view, again after leaving and re-entering, and not at all when disabled
- the loop: no rebuild when the handler identity changes; the newest handler is always the one called; the `ActivityFeed` scenario end to end (a fetch toggling `enabled`) yields one page rather than running away; a re-render handing back the same node does not refire
- options: default 200px margin, custom margin, threshold, a scroll container as root, an inline threshold array not counting as a change, and a real margin change rebuilding
- `once`: fires a single time and disconnects, and does not fire again on re-entry
- teardown: disconnects on unmount, leaves nothing live when disabled, never more than one live observer across ten enable/disable flips, and re-observes when enabled again
- no `IntersectionObserver`: renders and unmounts without throwing

Full suite: 505 tests pass. `tsc --noEmit` and `eslint` clean.
