### PR TITLE
fix(moderation): stop blocking posts that contain long numbers (fixes #1106)

### DIFF
--- a/frontend/src/lib/validation/__tests__/spamDetection.test.ts
+++ b/frontend/src/lib/validation/__tests__/spamDetection.test.ts
@@ -1,0 +1,332 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SPAM_THRESHOLD,
+  analyzeSpam,
+  collapseSpacedLetters,
+  decodeLeetspeak,
+  normalizeForMatching,
+} from "../spamDetection";
+
+/** `analyzeSpam` gates posting, so "blocked" is the thing worth asserting on. */
+function isBlocked(text: string): boolean {
+  return analyzeSpam(text).isSpam;
+}
+
+function signalIds(text: string): string[] {
+  return analyzeSpam(text).signals.map((s) => s.id);
+}
+
+describe("normalizeForMatching", () => {
+  it("folds fullwidth characters to ASCII", () => {
+    expect(normalizeForMatching("ＢＵＹ ＮＯＷ")).toBe("buy now");
+  });
+
+  it("folds mathematical alphanumerics to ASCII", () => {
+    expect(normalizeForMatching("𝐛𝐮𝐲 𝐧𝐨𝐰")).toBe("buy now");
+  });
+
+  it("strips zero-width characters", () => {
+    expect(normalizeForMatching("buy​now")).toBe("buynow");
+  });
+
+  it("strips soft hyphens", () => {
+    expect(normalizeForMatching("buy­now")).toBe("buynow");
+  });
+
+  it("strips combining marks", () => {
+    expect(normalizeForMatching("b̶u̶y̶")).toBe("buy");
+  });
+
+  it("maps a one-dot leader to a full stop", () => {
+    expect(normalizeForMatching("t․me")).toBe("t.me");
+  });
+
+  it("maps cyrillic lookalikes to latin", () => {
+    // Cyrillic es, a and o in place of the latin c, a and o.
+    expect(normalizeForMatching("саsinо")).toBe("casino");
+  });
+
+  it("leaves ordinary text alone apart from casing", () => {
+    expect(normalizeForMatching("Hello World")).toBe("hello world");
+  });
+});
+
+describe("decodeLeetspeak", () => {
+  it("decodes digits inside words", () => {
+    expect(decodeLeetspeak("fr33 m0n3y")).toBe("free money");
+  });
+
+  it("decodes symbol substitutions", () => {
+    expect(decodeLeetspeak("c@sino")).toBe("casino");
+  });
+
+  it("leaves a pure number alone", () => {
+    // The whole reason to scope this: a timestamp must not become a word.
+    expect(decodeLeetspeak("1754985600")).toBe("1754985600");
+  });
+
+  it("leaves a word with no substitutions alone", () => {
+    expect(decodeLeetspeak("hello world")).toBe("hello world");
+  });
+
+  it("does not touch numbers next to words", () => {
+    expect(decodeLeetspeak("issue 1234567890 is open")).toContain("1234567890");
+  });
+
+  it("leaves a trailing exclamation mark as punctuation", () => {
+    // Decoding `!` to `i` turns "free money!" into "free moneyi", which then
+    // matches no keyword at all — it loses far more than it catches.
+    expect(decodeLeetspeak("free money!")).toBe("free money!");
+  });
+
+  it("leaves a trailing dollar sign as a currency symbol", () => {
+    expect(decodeLeetspeak("price$")).toBe("price$");
+  });
+
+  it("leaves a leading at sign as a mention", () => {
+    expect(decodeLeetspeak("@alice")).toBe("@alice");
+  });
+
+  it("still decodes a symbol in the middle of a word", () => {
+    expect(decodeLeetspeak("ca$ino")).toBe("casino");
+  });
+});
+
+describe("collapseSpacedLetters", () => {
+  it("closes up a spelled-out word", () => {
+    expect(collapseSpacedLetters("b u y  n o w")).toBe("buy now");
+  });
+
+  it("leaves short sequences alone", () => {
+    // Two single letters is ordinary prose, not obfuscation.
+    expect(collapseSpacedLetters("a b test")).toBe("a b test");
+  });
+
+  it("leaves normal words alone", () => {
+    expect(collapseSpacedLetters("this is a normal sentence")).toBe("this is a normal sentence");
+  });
+
+  it("treats a wider gap as a word break", () => {
+    // Collapsing across the double space would give "buynow", which matches
+    // nothing. The gap is what tells the two spelled-out words apart.
+    expect(collapseSpacedLetters("b u y  n o w")).not.toBe("buynow");
+  });
+});
+
+describe("analyzeSpam — legitimate posts are not blocked", () => {
+  const legitimate: [string, string][] = [
+    [
+      "a unix timestamp",
+      "Reproduced this at epoch 1754985600 — the token expiry is off by an hour.",
+    ],
+    [
+      "a long numeric id",
+      "The job id is 483920184720 and it has been stuck in queued for two hours now.",
+    ],
+    [
+      "a version and a checksum",
+      "Pinned to 1.2.30 after the sha 8891234567890 landed. Anyone else seeing this?",
+    ],
+    [
+      "screaming constants",
+      "Set MAX_RETRIES=3 and API_BASE_URL correctly, otherwise CI fails with ETIMEDOUT every time.",
+    ],
+    [
+      "a fenced code block",
+      "Try this:\n```\nSELECT id FROM users WHERE id = id AND id = id AND id = id;\n```\nDoes that help?",
+    ],
+    [
+      "a stack trace",
+      "Getting `NullPointerException` at `com.example.Foo.bar(Foo.java:42)` — full trace:\n    at com.example.Foo.bar\n    at com.example.Foo.baz\n    at com.example.Foo.qux",
+    ],
+    [
+      "a well-sourced write-up",
+      `I spent the week benchmarking our query layer and wanted to write up what I found, because a few
+       of the results surprised me and I think they change how we should be thinking about the read
+       path. The short version is that the index we added last quarter is doing much less work than we
+       assumed, and most of the latency is coming from somewhere else entirely. References:
+       https://example.com/a https://example.com/b https://example.com/c https://example.com/d
+       https://example.com/e`,
+    ],
+    ["a plain question", "Has anyone got the dev container working on an M1 Mac?"],
+    ["a single marketing-ish word", "We finally shipped the discount code feature for the store."],
+    ["an empty string", ""],
+    ["whitespace only", "   \n  "],
+  ];
+
+  it.each(legitimate)("does not block %s", (_label, text) => {
+    expect(isBlocked(text)).toBe(false);
+  });
+
+  it("does not flag a bare ten-digit run as a phone number", () => {
+    // The old pattern was /\+?[0-9]{10,12}/, which fired on all of these.
+    expect(signalIds("epoch 1754985600")).not.toContain("phone-number");
+    expect(signalIds("id 483920184720")).not.toContain("phone-number");
+  });
+
+  it("does not fire a keyword inside a longer word", () => {
+    expect(signalIds("We use bettingham as our staging host name")).not.toContain("keywords");
+  });
+
+  it("does not treat a link whose path mentions t.me as a chat invite", () => {
+    expect(signalIds("See https://example.com/blog/t.me-considered-harmful")).not.toContain(
+      "suspicious-hosts",
+    );
+  });
+
+  it("does not count repeated identifiers in code as repetitive words", () => {
+    const text =
+      "```\nconst a = a; const a = a; const a = a; const a = a; const a = a; const a = a;\n```";
+
+    expect(signalIds(text)).not.toContain("repeated-words");
+  });
+});
+
+describe("analyzeSpam — obvious spam is blocked", () => {
+  const spam: [string, string][] = [
+    ["a plain advert", "BUY NOW for guaranteed profit, click here!"],
+    ["a chat invite", "Free money every day, join our telegram group: https://t.me/scamchannel"],
+    ["a shortener plus keywords", "Crypto giveaway! Click here https://bit.ly/xyz to earn fast."],
+    [
+      "a contact number plus keywords",
+      "Unlimited followers, cheap price. DM for info or call +1 555 867 5309.",
+    ],
+  ];
+
+  it.each(spam)("blocks %s", (_label, text) => {
+    expect(isBlocked(text)).toBe(true);
+  });
+});
+
+describe("analyzeSpam — obfuscation no longer gets through", () => {
+  const evasions: [string, string][] = [
+    ["leetspeak", "fr33 m0n3y here, cl1ck h3r3 for a crypt0 giv3away!"],
+    ["spaced-out letters", "b u y  n o w and get f r e e  m o n e y today"],
+    ["zero-width separators", "buy​ now and get free​ money right away"],
+    ["fullwidth characters", "ＢＵＹ ＮＯＷ for ＦＲＥＥ ＭＯＮＥＹ"],
+    ["mathematical bold", "𝐛𝐮𝐲 𝐧𝐨𝐰 for 𝐟𝐫𝐞𝐞 𝐦𝐨𝐧𝐞𝐲"],
+    ["strikethrough combining marks", "b̶u̶y̶ n̶o̶w̶ — free money!"],
+  ];
+
+  it.each(evasions)("catches %s", (_label, text) => {
+    expect(isBlocked(text)).toBe(true);
+  });
+
+  it("catches a homoglyph shortener host", () => {
+    // U+2024 instead of a full stop, which renders identically.
+    expect(signalIds("Join now https://t․me/scamchannel")).toContain("suspicious-hosts");
+  });
+});
+
+describe("analyzeSpam — phone numbers", () => {
+  it("recognises an international number", () => {
+    expect(signalIds("call +1 555 867 5309")).toContain("phone-number");
+  });
+
+  it("recognises a grouped number", () => {
+    expect(signalIds("reach me on 555-867-5309")).toContain("phone-number");
+  });
+
+  it("recognises a number with parentheses", () => {
+    expect(signalIds("reach me on (555) 867-5309")).toContain("phone-number");
+  });
+
+  it("does not recognise a semver string", () => {
+    expect(signalIds("upgraded to 10.2.30 last night")).not.toContain("phone-number");
+  });
+
+  it("does not recognise a bare digit run", () => {
+    expect(signalIds("the id is 5558675309")).not.toContain("phone-number");
+  });
+
+  it("is not enough on its own to block a post", () => {
+    // Sharing a phone number is not spam by itself; plenty of legitimate posts
+    // do it. It only matters alongside something else.
+    expect(isBlocked("You can reach me on +1 555 867 5309 if that is easier.")).toBe(false);
+  });
+});
+
+describe("analyzeSpam — scoring", () => {
+  it("caps the keyword signal so three phrases cannot max the score", () => {
+    const result = analyzeSpam("buy now, click here, cheap price");
+    const keywords = result.signals.find((s) => s.id === "keywords");
+
+    expect(keywords?.weight).toBeLessThanOrEqual(0.6);
+  });
+
+  it("never exceeds 1", () => {
+    const result = analyzeSpam(
+      "BUY NOW!!! free money, click here, cheap price, casino, betting, " +
+        "guaranteed profit, https://bit.ly/a https://t.me/b https://wa.me/c " +
+        "https://cutt.ly/d call +1 555 867 5309 aaaaaaaaaa",
+    );
+
+    expect(result.score).toBeLessThanOrEqual(1);
+    expect(result.isSpam).toBe(true);
+  });
+
+  it("never goes below 0", () => {
+    expect(analyzeSpam("A perfectly ordinary sentence about work.").score).toBeGreaterThanOrEqual(
+      0,
+    );
+  });
+
+  it("agrees with the exported threshold", () => {
+    const result = analyzeSpam("BUY NOW for guaranteed profit, click here!");
+
+    expect(result.isSpam).toBe(result.score >= SPAM_THRESHOLD);
+  });
+
+  it("reports one reason per signal", () => {
+    const result = analyzeSpam("Free money! Join https://t.me/scam now.");
+
+    expect(result.reasons).toHaveLength(result.signals.length);
+    expect(result.reasons.every((r) => r.length > 0)).toBe(true);
+  });
+
+  it("exposes the normalised text that was matched against", () => {
+    const result = analyzeSpam("fr33 m0n3y");
+
+    // So a disputed block can be explained rather than argued about.
+    expect(result.normalizedText).toContain("free money");
+  });
+
+  it("scores an empty post at zero with no signals", () => {
+    const result = analyzeSpam("");
+
+    expect(result).toMatchObject({ isSpam: false, score: 0, reasons: [], signals: [] });
+  });
+});
+
+describe("analyzeSpam — shape rules", () => {
+  it("flags shouting in prose", () => {
+    expect(signalIds("THIS IS AN ENORMOUS ANNOUNCEMENT AND YOU MUST ALL READ IT NOW")).toContain(
+      "shouting",
+    );
+  });
+
+  it("does not flag shouting in something that reads like code", () => {
+    expect(
+      signalIds("MAX_RETRIES = 3; API_BASE_URL = ENV_PROD; TIMEOUT_MS = 500; RETRY_CAP = 8;"),
+    ).not.toContain("shouting");
+  });
+
+  it("does not flag a short all-caps phrase", () => {
+    expect(signalIds("LGTM")).not.toContain("shouting");
+  });
+
+  it("flags stretched-out characters", () => {
+    expect(signalIds("looooooook at this")).toContain("repeated-characters");
+  });
+
+  it("flags genuinely repetitive prose", () => {
+    expect(signalIds("free free free free free free free free free free free free free")).toContain(
+      "repeated-words",
+    );
+  });
+
+  it("does not flag repetition in a short post", () => {
+    expect(signalIds("free free free")).not.toContain("repeated-words");
+  });
+});

--- a/frontend/src/lib/validation/spamDetection.ts
+++ b/frontend/src/lib/validation/spamDetection.ts
@@ -1,8 +1,46 @@
+/**
+ * Heuristic spam scoring for user-submitted text.
+ *
+ * This is a hard gate: `postsApi.create` and `postsApi.comment` both throw
+ * before the request is sent, so a false positive does not warn anybody, it
+ * stops them posting. Two consequences shape everything below.
+ *
+ * **Match on normalised text, not raw text.** Every check used to run against
+ * the raw string, so `fr33 m0n3y`, `b u y  n o w`, `ＢＵＹ ＮＯＷ` and
+ * `t․me/foo` (with a one-dot leader instead of a full stop) all scored zero.
+ * Normalising first — Unicode folding, homoglyph mapping, invisible-character
+ * stripping, leetspeak decoding, spaced-out-letter collapsing — costs one pass
+ * and closes all of them at once.
+ *
+ * **Be reluctant to fire on a developer network.** Posts here are full of
+ * stack traces, SQL, `SCREAMING_CONSTANTS`, config blocks and long numeric
+ * ids. Code spans are removed before the shape-based checks run, the
+ * phone-number check wants something that actually looks like a phone number
+ * rather than any ten digits in a row, and every signal is capped so no single
+ * one can carry a post over the line on its own.
+ */
+
+export interface SpamSignal {
+  /** Stable identifier, useful for tuning without parsing prose. */
+  id: string;
+  /** Human-readable explanation, shown to the person who was blocked. */
+  reason: string;
+  /** This signal's contribution to the final score, after capping. */
+  weight: number;
+}
+
 export interface SpamCheckResult {
   isSpam: boolean;
   score: number; // 0 to 1 (higher = more likely spam)
   reasons: string[];
+  /** What the checks actually ran against, for debugging a disputed block. */
+  normalizedText: string;
+  /** Per-signal breakdown, so a reviewer can see which rule fired. */
+  signals: SpamSignal[];
 }
+
+/** A post scoring at or above this is refused. */
+export const SPAM_THRESHOLD = 0.5;
 
 const SPAM_KEYWORDS = [
   "buy now",
@@ -19,78 +57,343 @@ const SPAM_KEYWORDS = [
   "betting",
   "unlimited followers",
   "dm for info",
-  "work from home $",
-];
-
-const PHISHING_PATTERNS = [
-  /bit\.ly\//i,
-  /tinyurl\.com\//i,
-  /t\.me\//i,
-  /wa\.me\//i,
-  /\+?[0-9]{10,12}/, // Raw phone numbers
+  "work from home",
 ];
 
 /**
- * Analyzes text for spam markers using keyword analysis, link density,
- * repetitive character/word detection, and casing rules.
+ * Link shorteners and chat-invite hosts.
+ *
+ * Matched as hosts rather than as raw substrings, so a link to an article
+ * whose path happens to contain "t.me" is not a hit.
+ */
+const SUSPICIOUS_HOSTS = [
+  "bit.ly",
+  "tinyurl.com",
+  "t.me",
+  "wa.me",
+  "is.gd",
+  "cutt.ly",
+  "rb.gy",
+  "shorturl.at",
+  "rebrand.ly",
+  "discord.gg",
+  "buff.ly",
+  "ow.ly",
+  "shorte.st",
+  "adf.ly",
+];
+
+/**
+ * Characters that render like ASCII punctuation or letters but are not.
+ *
+ * These are the cheap way past any pattern written in ASCII: `t․me` with a
+ * U+2024 one-dot leader looks identical to `t.me` in every font we ship.
+ */
+const HOMOGLYPHS: Record<string, string> = {
+  "․": ".", // one dot leader
+  "。": ".", // ideographic full stop
+  "．": ".", // fullwidth full stop
+  "⁄": "/", // fraction slash
+  "∕": "/", // division slash
+  "／": "/", // fullwidth solidus
+  "：": ":", // fullwidth colon
+  а: "a", // cyrillic a
+  е: "e", // cyrillic ie
+  о: "o", // cyrillic o
+  р: "p", // cyrillic er
+  с: "c", // cyrillic es
+  х: "x", // cyrillic ha
+  у: "y", // cyrillic u
+  і: "i", // cyrillic byelorussian-ukrainian i
+  ο: "o", // greek omicron
+  ѕ: "s", // cyrillic dze
+};
+
+/**
+ * Digits and symbols commonly substituted for letters.
+ *
+ * `!` is deliberately absent even though `!` for `i` is a real substitution.
+ * It is punctuation far more often than it is a letter, and decoding it turns
+ * every `free money!` into `free moneyi`, which then matches nothing — a
+ * false-negative generator worth more than the handful of `cl!ck` it catches.
+ */
+const LEET: Record<string, string> = {
+  "0": "o",
+  "1": "i",
+  "3": "e",
+  "4": "a",
+  "5": "s",
+  "7": "t",
+  "@": "a",
+  $: "s",
+};
+
+/** Symbols in `LEET` that are also ordinary punctuation at a word's edge. */
+const EDGE_SENSITIVE = new Set(["@", "$"]);
+
+// Zero-width and other invisible characters used to break up a word without
+// changing how it looks. Written as escapes on purpose -- as literals they are
+// invisible in the source too, which is not something to leave in a regex.
+// Soft hyphen, ZWSP/ZWNJ/ZWJ, bidi marks, word joiner, isolates, BOM.
+const INVISIBLE = /[\u00AD\u200B-\u200F\u2060\u2066-\u2069\uFEFF]/g;
+
+const URL_PATTERN = /https?:\/\/[^\s<>"')]+/gi;
+
+// Fenced blocks, indented blocks and inline spans. Removed before the checks
+// that reason about the *shape* of the text rather than its content.
+const FENCED_CODE = /```[\s\S]*?```|~~~[\s\S]*?~~~/g;
+const INLINE_CODE = /`[^`\n]+`/g;
+const INDENTED_CODE = /^(?: {4}|\t).*$/gm;
+
+/**
+ * Something that looks like a phone number, rather than any run of digits.
+ *
+ * The old pattern was `/\+?[0-9]{10,12}/`, which is every Unix timestamp, id,
+ * checksum and large numeric literal anybody has ever pasted into a bug
+ * report. A real phone number in a spam post is almost always either written
+ * with a country code or grouped with separators, so that is what we ask for.
+ */
+const PHONE_WITH_COUNTRY_CODE = /(?<![\d+])\+\d[\d\s().-]{7,17}\d(?![\d])/g;
+const PHONE_GROUPED = /(?<![\d.-])(?:\(\d{2,4}\)|\d{2,4})[\s.-]\d{2,4}[\s.-]\d{2,5}(?![\d])/g;
+
+/** Per-signal ceilings, so no single rule can carry a post over the line. */
+const CAPS = {
+  keywords: 0.6,
+  hosts: 0.5,
+  phone: 0.3,
+  links: 0.3,
+  shouting: 0.2,
+  repeatedChars: 0.2,
+  repeatedWords: 0.25,
+} as const;
+
+/**
+ * Fold a string down to something the patterns can be written against in
+ * plain ASCII.
+ *
+ * Order matters: decompose and strip combining marks first (so `b̷u̷y̷` loses
+ * its strikethrough), then recompose under NFKC (so fullwidth and
+ * mathematical alphanumerics become ASCII), then map the homoglyphs that
+ * Unicode does not consider equivalent.
+ */
+export function normalizeForMatching(text: string): string {
+  const withoutMarks = text.normalize("NFKD").replace(/\p{M}/gu, "").normalize("NFKC");
+
+  const mapped = Array.from(withoutMarks)
+    .map((char) => HOMOGLYPHS[char] ?? char)
+    .join("");
+
+  return mapped.replace(INVISIBLE, "").toLowerCase();
+}
+
+/**
+ * Undo leetspeak, but only inside tokens that already contain a letter.
+ *
+ * `fr33` becomes `free`; `1754985600` is left exactly as it is. Decoding
+ * pure-numeric tokens would turn timestamps into nonsense words and is how a
+ * naive substitution pass invents matches that were never there.
+ */
+export function decodeLeetspeak(text: string): string {
+  return text.replace(/[\p{L}\p{N}@$]+/gu, (token) => {
+    if (!/\p{L}/u.test(token)) return token;
+    if (!/[0-9@$]/.test(token)) return token;
+
+    const chars = Array.from(token);
+    return chars
+      .map((char, index) => {
+        // A trailing `$` is a price, not an `s`; a leading `@` is a mention.
+        if (EDGE_SENSITIVE.has(char) && (index === 0 || index === chars.length - 1)) {
+          return char;
+        }
+        return LEET[char] ?? char;
+      })
+      .join("");
+  });
+}
+
+/**
+ * Close up words that were split one character at a time.
+ *
+ * `b u y  n o w` becomes `buy now`. Two details matter:
+ *
+ * * only runs of three or more single characters are collapsed, so ordinary
+ *   prose (`a b test`, `I am 5 ft`) is left alone
+ * * the separator is a *single* space, so the wider gap between the two
+ *   spelled-out words still reads as a word break and does not get swallowed
+ *
+ * Runs of whitespace are then collapsed to one, so the result is comparable
+ * against a keyword list written with single spaces.
+ */
+export function collapseSpacedLetters(text: string): string {
+  return text
+    .replace(/(?<![\p{L}\p{N}])(?:[\p{L}\p{N}][ \t]){2,}[\p{L}\p{N}](?![\p{L}\p{N}])/gu, (run) =>
+      run.replace(/[ \t]/g, ""),
+    )
+    .replace(/[ \t]{2,}/g, " ");
+}
+
+/** Everything that is not prose, removed, for the shape-based checks. */
+export function stripCode(text: string): string {
+  return text
+    .replace(FENCED_CODE, " ")
+    .replace(INDENTED_CODE, " ")
+    .replace(INLINE_CODE, " ")
+    .replace(URL_PATTERN, " ");
+}
+
+/**
+ * Whether a stretch of text reads more like code than like shouting.
+ *
+ * A snippet of `MAX_RETRIES`, `SELECT ... FROM`, or a Java stack trace is
+ * mostly capitals and mostly repeated tokens, which is exactly what the
+ * shouting and repetition rules look for.
+ */
+function looksLikeCode(text: string): boolean {
+  const codeish = /[_{}();]|::|=>|\/\*|\$\{|<\/?\w+>/;
+  return codeish.test(text);
+}
+
+function hostOf(url: string): string | null {
+  try {
+    return new URL(url).hostname.toLowerCase().replace(/^www\./, "");
+  } catch {
+    return null;
+  }
+}
+
+/** Whether `host` is, or is a subdomain of, `suspect`. */
+function hostMatches(host: string, suspect: string): boolean {
+  return host === suspect || host.endsWith(`.${suspect}`);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Analyse text for spam markers.
+ *
+ * Returns a score in `[0, 1]`; `isSpam` is `score >= SPAM_THRESHOLD`.
  */
 export function analyzeSpam(text: string): SpamCheckResult {
-  const reasons: string[] = [];
-  let score = 0;
-  const lowerText = text.toLowerCase();
+  const empty: SpamCheckResult = {
+    isSpam: false,
+    score: 0,
+    reasons: [],
+    normalizedText: "",
+    signals: [],
+  };
 
-  if (!text || text.trim().length === 0) {
-    return { isSpam: false, score: 0, reasons: [] };
-  }
+  if (!text || text.trim().length === 0) return empty;
 
-  // 1. Check for spam keywords
-  const matchedKeywords = SPAM_KEYWORDS.filter((keyword) => lowerText.includes(keyword));
+  const normalized = normalizeForMatching(text);
+  const matchable = collapseSpacedLetters(decodeLeetspeak(normalized));
+
+  // Shape-based checks run against prose only. Code and URLs skew both the
+  // capitalisation ratio and the token-repetition ratio, and this is a
+  // developer network — posts are full of both.
+  const prose = stripCode(matchable).trim();
+  const proseWords = prose.split(/\s+/).filter(Boolean);
+
+  // The capitalisation check is the one thing that cannot use `matchable`,
+  // since normalising lowercases everything. It gets the original text with
+  // code and links removed.
+  const casedProse = stripCode(text).trim();
+
+  const signals: SpamSignal[] = [];
+
+  const add = (id: string, reason: string, weight: number) => {
+    if (weight > 0) signals.push({ id, reason, weight });
+  };
+
+  // 1. Keyword phrases, on word boundaries so "casino" does not fire inside a
+  //    longer word.
+  const matchedKeywords = SPAM_KEYWORDS.filter((keyword) =>
+    new RegExp(`(?<![\\p{L}\\p{N}])${escapeRegExp(keyword)}(?![\\p{L}\\p{N}])`, "u").test(
+      matchable,
+    ),
+  );
   if (matchedKeywords.length > 0) {
-    score += matchedKeywords.length * 0.35;
-    reasons.push(`Contains potential spam phrasing: "${matchedKeywords.join('", "')}"`);
+    add(
+      "keywords",
+      `Contains potential spam phrasing: "${matchedKeywords.join('", "')}"`,
+      Math.min(matchedKeywords.length * 0.3, CAPS.keywords),
+    );
   }
 
-  // 2. Check for suspicious shortened links or phone numbers
-  const matchedPhishing = PHISHING_PATTERNS.filter((pattern) => pattern.test(text));
-  if (matchedPhishing.length > 0) {
-    score += matchedPhishing.length * 0.4;
-    reasons.push("Contains suspicious link shorteners or contact numbers");
+  // 2. Link shorteners and chat-invite hosts, matched as hosts.
+  const urls = matchable.match(URL_PATTERN) ?? [];
+  const hosts = urls.map(hostOf).filter((h): h is string => h !== null);
+  const flaggedHosts = [
+    ...new Set(
+      hosts.filter((host) => SUSPICIOUS_HOSTS.some((suspect) => hostMatches(host, suspect))),
+    ),
+  ];
+  if (flaggedHosts.length > 0) {
+    add(
+      "suspicious-hosts",
+      `Links to a shortener or chat invite: ${flaggedHosts.join(", ")}`,
+      Math.min(flaggedHosts.length * 0.35, CAPS.hosts),
+    );
   }
 
-  // 3. Link density check
-  const urls = text.match(/https?:\/\/[^\s]+/g) || [];
+  // 3. Contact numbers. Only things shaped like phone numbers count; a bare
+  //    run of digits is an id, not a number to call.
+  const phoneMatches = [
+    ...(normalized.match(PHONE_WITH_COUNTRY_CODE) ?? []),
+    ...(normalized.match(PHONE_GROUPED) ?? []),
+  ];
+  if (phoneMatches.length > 0) {
+    add("phone-number", "Contains what looks like a contact phone number", CAPS.phone);
+  }
+
+  // 4. Link density, as a ratio rather than an absolute count — a well-sourced
+  //    long write-up should not be penalised for having references.
   if (urls.length > 3) {
-    score += 0.3;
-    reasons.push("Excessive number of external links");
-  }
-
-  // 4. ALL CAPS check (for longer content)
-  if (text.length > 20) {
-    const capsCount = (text.match(/[A-Z]/g) || []).length;
-    const letterCount = (text.match(/[a-zA-Z]/g) || []).length;
-    if (letterCount > 0 && capsCount / letterCount > 0.6) {
-      score += 0.25;
-      reasons.push("Excessive use of capital letters");
+    const wordsPerLink = proseWords.length / urls.length;
+    if (wordsPerLink < 25) {
+      add(
+        "link-density",
+        "Mostly links with very little text around them",
+        Math.min(0.15 + (urls.length - 3) * 0.05, CAPS.links),
+      );
     }
   }
 
-  // 5. Repeated character/word check (e.g. "aaaaa" or "buy buy buy")
-  if (/(.)\1{5,}/.test(text)) {
-    score += 0.3;
-    reasons.push("Repeated character patterns detected");
+  // 5. Shouting. Skipped for anything that reads like code, where a high
+  //    capital ratio is just constant names.
+  if (casedProse.length > 40 && !looksLikeCode(casedProse)) {
+    const letters = casedProse.match(/\p{L}/gu) ?? [];
+    const capitals = casedProse.match(/\p{Lu}/gu) ?? [];
+    if (letters.length > 0 && capitals.length / letters.length > 0.6) {
+      add("shouting", "Excessive use of capital letters", CAPS.shouting);
+    }
   }
 
-  const words = lowerText.split(/\s+/);
-  const wordSet = new Set(words);
-  if (words.length > 8 && wordSet.size / words.length < 0.4) {
-    score += 0.3;
-    reasons.push("High degree of repetitive words");
+  // 6. Runs of a single repeated character ("looooook at thiiiiis").
+  if (/(.)\1{5,}/.test(prose)) {
+    add("repeated-characters", "Repeated character patterns detected", CAPS.repeatedChars);
   }
 
-  const finalScore = Math.min(score, 1);
+  // 7. Token repetition, again skipped for code, and needing enough words to
+  //    be meaningful.
+  if (proseWords.length > 12 && !looksLikeCode(prose)) {
+    const unique = new Set(proseWords);
+    if (unique.size / proseWords.length < 0.4) {
+      add("repeated-words", "High degree of repetitive words", CAPS.repeatedWords);
+    }
+  }
+
+  const score = Math.min(
+    signals.reduce((total, signal) => total + signal.weight, 0),
+    1,
+  );
+
   return {
-    isSpam: finalScore >= 0.5,
-    score: finalScore,
-    reasons,
+    isSpam: score >= SPAM_THRESHOLD,
+    score,
+    reasons: signals.map((signal) => signal.reason),
+    normalizedText: matchable,
+    signals,
   };
 }


### PR DESCRIPTION
# Pull Request

## Summary

`analyzeSpam` gates posting — `postsApi.create` and `postsApi.comment` both throw before the request is sent — so a false positive does not warn anyone, it stops them posting. The phone-number pattern was `/\+?[0-9]{10,12}/`, which fires on any Unix timestamp or long id, while every check ran against the raw string so the cheapest obfuscation scored zero. This fixes both directions.

---

## Related Issue

Closes #1106

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [ ] UI/UX enhancement
- [x] Tests
- [ ] Other

---

## Changes Made

### Fewer false positives

**Phone numbers.** `/\+?[0-9]{10,12}/` is unanchored and has no boundary, so it matched ten to twelve digits *inside* a longer run too — a Unix timestamp (`1754985600`), a job id, a checksum, a large numeric literal in a snippet. On its own that is `+0.4`; one keyword match on top and the post is refused at `0.75`. Detection now wants a country code or separator grouping, which is how a spam post actually writes a number. A number on its own also no longer blocks a post — plenty of legitimate posts share one.

**Keywords** match on word boundaries, so `betting` no longer fires inside `bettingham`.

**Shortener hosts** are matched as hosts (and subdomains), so an article whose *path* mentions `t.me` is not treated as a chat invite.

**Code is removed before the shape checks.** Fenced blocks, indented blocks, inline spans and URLs are stripped, and both the shouting and repetition rules additionally skip anything that reads like code. `MAX_RETRIES = 3; API_BASE_URL = ...` was being flagged as shouting, and a snippet with repeated identifiers as repetitive prose. This is a developer network; posts are full of both.

**Link density is a ratio**, not `urls.length > 3`, so a 2000-word write-up with five references is not scored like a five-line link dump.

**Every signal is capped**, so no single rule can carry a post over the line alone. Three keyword hits used to be `3 × 0.35 = 1.05` regardless of context or length.

### Fewer false negatives

Matching now runs after a normalisation pass — NFKD, combining marks stripped, NFKC recompose, homoglyphs mapped, invisible characters removed, leetspeak decoded, spelled-o-u-t words closed up. That closes all six evasions from the issue in one place:

| Input | Before | After |
| --- | --- | --- |
| `fr33 m0n3y` | 0 | caught |
| `b u y  n o w` | 0 | caught |
| `buy<ZWSP>now` | 0 | caught |
| `ＢＵＹ ＮＯＷ` | 0 | caught |
| `𝐛𝐮𝐲 𝐧𝐨𝐰` | 0 | caught |
| `t․me/foo` (U+2024) | 0 | caught |

The shortener list also picked up the hosts that actually turn up — `is.gd`, `cutt.ly`, `rb.gy`, `shorturl.at`, `rebrand.ly`, `discord.gg` and friends.

### Two things the tests caught while writing this

Both are the kind of thing that looks obviously right and is not, so they have named regression tests:

- **Decoding `!` as `i`** turns `free money!` into `free moneyi`, which then matches *nothing*. It loses far more than the handful of `cl!ck` it catches, so `!` is out of the substitution map entirely, and `@`/`$` are only decoded away from a token's edges (`price$` is a price, `@alice` is a mention).
- **Collapsing spaced-out letters has to treat a wider gap as a word break.** Collapsing greedily turns `b u y  n o w` into `buynow`, which matches nothing either. The separator is a single space, and the double space survives as the word break.

### Result shape

`SpamCheckResult` gained `normalizedText` and a `signals` array (`id`, `reason`, `weight`), so a disputed block can be explained rather than argued about. `reasons` is unchanged, so `postsApi`'s error message still works as-is. `SPAM_THRESHOLD` is exported rather than being a bare `0.5` in the middle of the function.

---

## Testing

- [x] Tested locally
- [x] Existing tests pass
- [x] Added new tests

`frontend/src/lib/validation/__tests__/spamDetection.test.ts`, 70 tests, in a module that had none — which is uncomfortable for something that can silently stop people posting.

- **normalisation helpers**: fullwidth, mathematical alphanumerics, zero-width, soft hyphens, combining marks, one-dot leader, Cyrillic lookalikes; leetspeak decoding scoped to mixed tokens with the edge cases above; spaced-letter collapsing and its word-break behaviour
- **legitimate posts are not blocked**, as a table: a Unix timestamp, a long numeric id, a version plus checksum, screaming constants, a fenced code block, a stack trace, a well-sourced long write-up with five links, a plain question, a single marketing-ish word, empty and whitespace-only
- **obvious spam is blocked**: plain advert, chat invite, shortener plus keywords, contact number plus keywords
- **each of the six obfuscations** from the issue
- **phone numbers**: international, grouped, parenthesised; *not* a semver string or a bare digit run; and not enough on its own to block
- **scoring**: keyword cap, never above 1, never below 0, agreement with `SPAM_THRESHOLD`, one reason per signal, normalised text exposed, empty input
- **shape rules**: shouting flagged in prose but not in code and not for a short `LGTM`; stretched characters; repetition flagged in prose but not in a short post

Full suite: 548 tests pass. `tsc --noEmit` and `eslint` clean.

---

## Notes for reviewers

The keyword list, the host list and the weights are all judgement calls, and I have kept them close to the originals rather than expanding scope — the point of this PR is the matching and the scoring, not the vocabulary. If any threshold looks wrong, `CAPS` and `SPAM_THRESHOLD` are now in one place at the top of the file and the `signals` breakdown makes it easy to see what a given post actually scored.

Worth a second opinion on one judgement in particular: I made a phone number on its own non-blocking. That is a deliberate loosening — sharing a number is not spam by itself — but if moderation would rather keep it strict, it is a one-line change to `CAPS.phone`.
