### PR TITLE
feat: save search filters (#984)

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -23,6 +23,8 @@ import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { Logo } from "./Logo";
 import { SidebarSection, type SidebarSectionProps } from "./SidebarSection";
 import { UserProfile } from "./UserProfile";
+import { useSavedSearches } from "@/stores/useSavedSearches";
+import { Trash } from "lucide-react";
 
 export const SIDEBAR_SECTIONS: SidebarSectionProps[] = [
   {
@@ -154,6 +156,51 @@ export function Sidebar() {
   // On tablet (md–xl) always force icon-only regardless of toggle state
   const isTablet = useMediaQuery("(min-width: 768px) and (max-width: 1279px)");
   const collapsed = isTablet || isCollapsed;
+  const searches = useSavedSearches((s) => s.searches);
+  const deleteSearch = useSavedSearches((s) => s.deleteSearch);
+
+  const savedSearchesSection: SidebarSectionProps | null =
+    searches.length > 0
+      ? {
+          label: "Saved Searches",
+          items: searches.map((s) => ({
+            label: s.name,
+            to:
+              s.type === "Developers"
+                ? "/builders"
+                : s.type === "Projects"
+                  ? "/projects"
+                  : s.type === "Organizations"
+                    ? "/organizations"
+                    : "/hackathons",
+            search:
+              s.type === "Projects"
+                ? (s as any).filters
+                : {
+                    q: (s as any).query,
+                    tab: s.type === "Developers" ? (s as any).tab : undefined,
+                  },
+            icon: <Bookmark size={16} strokeWidth={2} />,
+            action: (
+              <button
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  deleteSearch(s.id);
+                }}
+                className="text-muted-foreground hover:text-destructive p-1 rounded-sm hover:bg-destructive/10"
+                aria-label={`Delete saved search ${s.name}`}
+              >
+                <Trash size={12} />
+              </button>
+            ),
+          })),
+        }
+      : null;
+
+  const sections = savedSearchesSection
+    ? [...SIDEBAR_SECTIONS.slice(0, 2), savedSearchesSection, ...SIDEBAR_SECTIONS.slice(2)]
+    : SIDEBAR_SECTIONS;
 
   return (
     <aside
@@ -171,7 +218,7 @@ export function Sidebar() {
         className="flex-1 overflow-y-auto px-2 pb-4 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
         aria-label="Sidebar navigation"
       >
-        {SIDEBAR_SECTIONS.map((section) => (
+        {sections.map((section) => (
           <SidebarSection key={section.label} {...section} forceCollapsed={collapsed} />
         ))}
       </nav>

--- a/frontend/src/components/layout/SidebarItem.tsx
+++ b/frontend/src/components/layout/SidebarItem.tsx
@@ -6,13 +6,15 @@ import type { ReactNode } from "react";
 export interface SidebarItemProps {
   label: string;
   to: string;
+  search?: Record<string, unknown>;
   icon: ReactNode;
   badge?: number;
+  action?: ReactNode;
   /** When true, renders icon-only regardless of sidebar context state */
   forceCollapsed?: boolean;
 }
 
-export function SidebarItem({ label, to, icon, badge, forceCollapsed }: SidebarItemProps) {
+export function SidebarItem({ label, to, search, icon, badge, action, forceCollapsed }: SidebarItemProps) {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const { isCollapsed, closeMobile } = useSidebar();
 
@@ -25,6 +27,7 @@ export function SidebarItem({ label, to, icon, badge, forceCollapsed }: SidebarI
       <li>
         <Link
           to={to.split("?")[0]}
+          search={search}
           onClick={closeMobile}
           title={label}
           aria-label={label}
@@ -64,11 +67,12 @@ export function SidebarItem({ label, to, icon, badge, forceCollapsed }: SidebarI
     <li title={undefined}>
       <Link
         to={to.split("?")[0]}
+        search={search}
         preload="intent"
         onClick={closeMobile}
         aria-current={active ? "page" : undefined}
         className={cn(
-          "relative flex items-center gap-2.5 rounded-md py-1.5 pl-4 pr-3 text-[13px] font-medium outline-none",
+          "group relative flex items-center gap-2.5 rounded-md py-1.5 pl-4 pr-3 text-[13px] font-medium outline-none",
           "transition-colors duration-150",
           "focus-visible:ring-2 focus-visible:ring-primary",
           active
@@ -87,10 +91,15 @@ export function SidebarItem({ label, to, icon, badge, forceCollapsed }: SidebarI
           {icon}
         </span>
         <span className="flex-1 truncate">{label}</span>
-        {badge !== undefined && badge > 0 && (
+        {badge !== undefined && badge > 0 && !action && (
           <span className="rounded-full bg-destructive px-1.5 text-[10px] font-semibold text-destructive-foreground">
             {badge > 9 ? "9+" : badge}
           </span>
+        )}
+        {action && (
+          <div className="opacity-0 group-hover:opacity-100 transition-opacity">
+            {action}
+          </div>
         )}
       </Link>
     </li>

--- a/frontend/src/components/projects/ProjectFilters.tsx
+++ b/frontend/src/components/projects/ProjectFilters.tsx
@@ -1,5 +1,5 @@
 import { useProjectFilters } from "@/hooks/useProjectFilters";
-import { X, Check, ChevronsUpDown } from "lucide-react";
+import { X, Check, ChevronsUpDown, Bookmark } from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Switch } from "@/components/ui/switch";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -15,6 +15,8 @@ import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import { useState } from "react";
 import { TypoSection, TypoCard } from "@/components/shared/Typography";
+import { useSavedSearches } from "@/stores/useSavedSearches";
+import { SaveSearchDialog } from "@/components/shared/SaveSearchDialog";
 
 const LANGUAGES = [
   "JavaScript",
@@ -73,20 +75,43 @@ export function ProjectFilters() {
   };
 
   const [techOpen, setTechOpen] = useState(false);
+  const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+  const saveSearch = useSavedSearches((s) => s.saveSearch);
 
   return (
     <div className="rounded-lg border border-border bg-card p-5 my-4 flex flex-col gap-6">
       <div className="flex items-center justify-between">
         <TypoSection>Filters</TypoSection>
-        {hasActiveFilters && (
+        <div className="flex items-center gap-3">
           <button
-            onClick={clearFilters}
+            onClick={() => setSaveDialogOpen(true)}
             className="inline-flex items-center gap-1.5 rounded-md text-[12px] font-medium text-muted-foreground hover:text-foreground transition-colors"
           >
-            <X size={14} /> Clear all
+            <Bookmark size={14} /> Save Search
           </button>
-        )}
+          {hasActiveFilters && (
+            <button
+              onClick={clearFilters}
+              className="inline-flex items-center gap-1.5 rounded-md text-[12px] font-medium text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <X size={14} /> Clear all
+            </button>
+          )}
+        </div>
       </div>
+
+      <SaveSearchDialog
+        open={saveDialogOpen}
+        onOpenChange={setSaveDialogOpen}
+        onSave={(name) => {
+          saveSearch({
+            name,
+            type: "Projects",
+            filters,
+            query: filters.q || "",
+          } as any);
+        }}
+      />
 
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {/* Language Filter */}

--- a/frontend/src/components/shared/SaveSearchDialog.tsx
+++ b/frontend/src/components/shared/SaveSearchDialog.tsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface SaveSearchDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSave: (name: string) => void;
+  title?: string;
+}
+
+export function SaveSearchDialog({
+  open,
+  onOpenChange,
+  onSave,
+  title = "Save Search",
+}: SaveSearchDialogProps) {
+  const [name, setName] = useState("");
+
+  const handleSave = () => {
+    const trimmed = name.trim();
+    if (trimmed) {
+      onSave(trimmed);
+      setName("");
+      onOpenChange(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>
+            Give this search a name to quickly access it from the sidebar later.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <Input
+            id="search-name"
+            placeholder="e.g. React Developers"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleSave();
+              }
+            }}
+            autoFocus
+          />
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={!name.trim()}>
+            Save Search
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/routes/_app.builders.tsx
+++ b/frontend/src/routes/_app.builders.tsx
@@ -48,7 +48,7 @@ export const Route = createFileRoute("/_app/builders")({
       },
     ],
   }),
-  validateSearch: (search: Record<string, unknown>) => {
+  validateSearch: (search: Record<string, unknown>): { tab?: string; q?: string } => {
     return {
       tab: typeof search.tab === "string" ? search.tab : undefined,
       q: typeof search.q === "string" ? search.q : undefined,
@@ -124,16 +124,16 @@ function AIMatchCard({ builder }: { builder: Builder }) {
                   <BadgeCheck
                     className={cn(
                       "shrink-0 h-5 w-5",
-                      builder.premium ? "text-amber-500 fill-amber-500/10 animate-pulse" : "text-primary"
+                      builder.premium
+                        ? "text-amber-500 fill-amber-500/10 animate-pulse"
+                        : "text-primary",
                     )}
                     aria-label={builder.premium ? "Premium Verified User" : "Verified User"}
                   />
                 )}
               </TypoSection>
             </Link>
-            <TypoCaption as="p">
-              {builder.role}
-            </TypoCaption>
+            <TypoCaption as="p">{builder.role}</TypoCaption>
           </div>
           <button
             type="button"
@@ -186,27 +186,21 @@ function AIMatchCard({ builder }: { builder: Builder }) {
               <Sparkles size={14} className="text-primary shrink-0" />
               <span>{matchPercentage}</span>
             </p>
-            <TypoCaption as="p">
-              Match
-            </TypoCaption>
+            <TypoCaption as="p">Match</TypoCaption>
           </div>
           <div className="border-x border-border/50">
             <p className="text-[14px] font-bold text-foreground flex items-center justify-center gap-0.5">
               <Briefcase size={14} className="text-primary shrink-0" />
               <span>{experienceText}</span>
             </p>
-            <TypoCaption as="p">
-              Experience
-            </TypoCaption>
+            <TypoCaption as="p">Experience</TypoCaption>
           </div>
           <div>
             <p className="text-[14px] font-bold text-foreground flex items-center justify-center gap-0.5">
               <Calendar size={14} className="text-primary shrink-0" />
               <span>{availabilityText}</span>
             </p>
-            <TypoCaption as="p">
-              Availability
-            </TypoCaption>
+            <TypoCaption as="p">Availability</TypoCaption>
           </div>
         </div>
       </div>
@@ -276,7 +270,7 @@ function BuildersPage() {
   const saveSearch = useSavedSearches((s) => s.saveSearch);
 
   useEffect(() => {
-    if (search.q !== undefined && search.q !== q) {
+    if (search.q !== undefined) {
       setQ(search.q);
     }
   }, [search.q]);
@@ -466,7 +460,9 @@ function BuildersPage() {
                         <BadgeCheck
                           className={cn(
                             "h-3.5 w-3.5 shrink-0",
-                            b.premium ? "text-amber-500 fill-amber-500/10 animate-pulse" : "text-primary"
+                            b.premium
+                              ? "text-amber-500 fill-amber-500/10 animate-pulse"
+                              : "text-primary",
                           )}
                           aria-label={b.premium ? "Premium Verified User" : "Verified User"}
                         />

--- a/frontend/src/routes/_app.builders.tsx
+++ b/frontend/src/routes/_app.builders.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/components/shared/primitives";
 import { HighlightText } from "@/components/shared/HighlightText";
 import { LastActive } from "@/components/shared/LastActive";
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { cn } from "@/lib/utils";
 
 import {
@@ -35,6 +35,8 @@ import {
 import { motion } from "framer-motion";
 import { containerVariants } from "@/lib/animations";
 import { TypoSection, TypoCaption, TypoHeading } from "@/components/shared/Typography";
+import { useSavedSearches } from "@/stores/useSavedSearches";
+import { SaveSearchDialog } from "@/components/shared/SaveSearchDialog";
 
 export const Route = createFileRoute("/_app/builders")({
   head: () => ({
@@ -46,6 +48,12 @@ export const Route = createFileRoute("/_app/builders")({
       },
     ],
   }),
+  validateSearch: (search: Record<string, unknown>) => {
+    return {
+      tab: typeof search.tab === "string" ? search.tab : undefined,
+      q: typeof search.q === "string" ? search.q : undefined,
+    };
+  },
   component: BuildersPage,
 });
 
@@ -260,10 +268,28 @@ function BuilderRecommendationsEmptyState({ onExplore }: { onExplore: () => void
 
 function BuildersPage() {
   const childMatches = useChildMatches();
-  const search = Route.useSearch() as { tab?: string };
+  const search = Route.useSearch();
   const tab = search.tab;
   const navigate = useNavigate({ from: Route.fullPath });
-  const [q, setQ] = useState("");
+  const [q, setQ] = useState(search.q || "");
+  const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+  const saveSearch = useSavedSearches((s) => s.saveSearch);
+
+  useEffect(() => {
+    if (search.q !== undefined && search.q !== q) {
+      setQ(search.q);
+    }
+  }, [search.q]);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      navigate({
+        search: (prev: any) => ({ ...prev, q: q || undefined }),
+        replace: true,
+      });
+    }, 300);
+    return () => clearTimeout(handler);
+  }, [q, navigate]);
   const { data = [], isLoading } = useQuery({
     queryKey: ["builders", tab],
     queryFn: () => (tab === "matches" ? buildersService.matches() : buildersService.list()),
@@ -325,7 +351,7 @@ function BuildersPage() {
             <button
               key={t.k}
               type="button"
-              onClick={() => navigate({ search: (prev) => ({ ...prev, tab: t.k }) })}
+              onClick={() => navigate({ search: (prev: any) => ({ ...prev, tab: t.k }) })}
               className={cn(
                 "rounded px-2.5 py-1 text-[12px] font-medium transition-colors",
                 tab === t.k
@@ -349,7 +375,27 @@ function BuildersPage() {
             className="w-full rounded-md border border-border bg-surface py-[7px] pl-9 pr-3 text-[13px] outline-none focus:border-primary focus:ring-2 focus:ring-primary/20"
           />
         </div>
+        <button
+          onClick={() => setSaveDialogOpen(true)}
+          className="inline-flex items-center gap-1.5 rounded-md border border-border bg-surface px-2.5 py-[7px] text-[12px] font-medium text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <Bookmark size={13} />
+          Save Search
+        </button>
       </div>
+
+      <SaveSearchDialog
+        open={saveDialogOpen}
+        onOpenChange={setSaveDialogOpen}
+        onSave={(name) => {
+          saveSearch({
+            name,
+            type: "Developers",
+            query: q,
+            tab,
+          } as any);
+        }}
+      />
 
       <motion.div
         className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
@@ -383,7 +429,7 @@ function BuildersPage() {
         ) : filtered.length === 0 && tab === "matches" && !q ? (
           <div className="col-span-full">
             <BuilderRecommendationsEmptyState
-              onExplore={() => navigate({ search: (prev) => ({ ...prev, tab: "discover" }) })}
+              onExplore={() => navigate({ search: (prev: any) => ({ ...prev, tab: "discover" }) })}
             />
           </div>
         ) : filtered.length === 0 ? (

--- a/frontend/src/routes/_app.hackathons.tsx
+++ b/frontend/src/routes/_app.hackathons.tsx
@@ -2,9 +2,11 @@ import { createFileRoute, Outlet, useRouterState, Link } from "@tanstack/react-r
 import { useQuery } from "@tanstack/react-query";
 import { hackathonsService } from "@/services";
 import { Card, TagChip, Skeleton } from "@/components/shared/primitives";
-import { Trophy, Users2, Clock, Plus } from "lucide-react";
-import { useState, useEffect } from "react";
+import { Trophy, Users2, Clock, Plus, Search, Bookmark } from "lucide-react";
+import { useState, useEffect, useMemo } from "react";
 import { CreateHackathonDialog } from "@/components/hackathons/CreateHackathonDialog";
+import { useSavedSearches } from "@/stores/useSavedSearches";
+import { SaveSearchDialog } from "@/components/shared/SaveSearchDialog";
 import { cn } from "@/lib/utils";
 import { z } from "zod";
 import { TypoCaption, TypoHeading } from "@/components/shared/Typography";
@@ -18,6 +20,7 @@ export const Route = createFileRoute("/_app/hackathons")({
   }),
   validateSearch: z.object({
     create: z.boolean().optional(),
+    q: z.string().optional(),
   }),
   component: HackathonsPage,
 });
@@ -27,13 +30,16 @@ function HackathonsPage() {
   const navigate = Route.useNavigate();
   const search = Route.useSearch();
   const [createOpen, setCreateOpen] = useState(false);
+  const [q, setQ] = useState(search.q || "");
+  const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+  const saveSearch = useSavedSearches((s) => s.saveSearch);
 
   useEffect(() => {
     if (search.create) {
       setCreateOpen(true);
       // Remove query param to keep the URL clean
       navigate({
-        search: (prev) => {
+        search: (prev: any) => {
           const next = { ...prev };
           delete next.create;
           return next;
@@ -51,6 +57,31 @@ function HackathonsPage() {
   if (pathname !== "/hackathons" && pathname !== "/hackathons/") {
     return <Outlet />;
   }
+
+  useEffect(() => {
+    if (search.q !== undefined && search.q !== q) {
+      setQ(search.q);
+    }
+  }, [search.q]);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      navigate({
+        search: (prev: any) => ({ ...prev, q: q || undefined }),
+        replace: true,
+      });
+    }, 300);
+    return () => clearTimeout(handler);
+  }, [q, navigate]);
+
+  const filteredData = useMemo(() => {
+    const query = q.toLowerCase();
+    return data.filter((h) =>
+      h.name.toLowerCase().includes(query) ||
+      h.description.toLowerCase().includes(query) ||
+      (h.theme && h.theme.toLowerCase().includes(query))
+    );
+  }, [data, q]);
 
   const formatDate = (d: string) =>
     new Date(d).toLocaleDateString("en-US", { month: "short", day: "numeric" });
@@ -72,6 +103,37 @@ function HackathonsPage() {
         </button>
         <CreateHackathonDialog open={createOpen} onOpenChange={setCreateOpen} />
       </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="relative min-w-0 flex-1">
+          <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
+          <input
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Search hackathons..."
+            className="w-full rounded-md border border-border bg-surface py-[7px] pl-9 pr-3 text-[13px] outline-none focus:border-primary focus:ring-2 focus:ring-primary/20"
+          />
+        </div>
+        <button
+          onClick={() => setSaveDialogOpen(true)}
+          className="inline-flex items-center gap-1.5 rounded-md border border-border bg-surface px-2.5 py-[7px] text-[12px] font-medium text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <Bookmark size={13} />
+          Save Search
+        </button>
+      </div>
+
+      <SaveSearchDialog
+        open={saveDialogOpen}
+        onOpenChange={setSaveDialogOpen}
+        onSave={(name) => {
+          saveSearch({
+            name,
+            type: "Hackathons",
+            query: q,
+          } as any);
+        }}
+      />
 
       {isLoading ? (
         <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
@@ -97,7 +159,7 @@ function HackathonsPage() {
             </Card>
           ))}
         </div>
-      ) : data.length === 0 ? (
+      ) : filteredData.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-12 text-center">
           <div className="mb-3 grid h-12 w-12 place-items-center rounded-full bg-muted text-muted-foreground">
             🏆
@@ -113,7 +175,7 @@ function HackathonsPage() {
         </div>
       ) : (
         <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
-          {data.map((h) => (
+          {filteredData.map((h) => (
             <Link
               key={h.id}
               to="/hackathons/$hackathonId"

--- a/frontend/src/routes/_app.hackathons.tsx
+++ b/frontend/src/routes/_app.hackathons.tsx
@@ -47,19 +47,15 @@ function HackathonsPage() {
         replace: true,
       });
     }
-  }, [search.create]);
+  }, [search.create, navigate]);
 
   const { data = [], isLoading } = useQuery({
     queryKey: ["hackathons"],
     queryFn: hackathonsService.list,
   });
 
-  if (pathname !== "/hackathons" && pathname !== "/hackathons/") {
-    return <Outlet />;
-  }
-
   useEffect(() => {
-    if (search.q !== undefined && search.q !== q) {
+    if (search.q !== undefined) {
       setQ(search.q);
     }
   }, [search.q]);
@@ -76,12 +72,17 @@ function HackathonsPage() {
 
   const filteredData = useMemo(() => {
     const query = q.toLowerCase();
-    return data.filter((h) =>
-      h.name.toLowerCase().includes(query) ||
-      h.description.toLowerCase().includes(query) ||
-      (h.theme && h.theme.toLowerCase().includes(query))
+    return data.filter(
+      (h) =>
+        h.name.toLowerCase().includes(query) ||
+        h.description.toLowerCase().includes(query) ||
+        (h.theme && h.theme.toLowerCase().includes(query)),
     );
   }, [data, q]);
+
+  if (pathname !== "/hackathons" && pathname !== "/hackathons/") {
+    return <Outlet />;
+  }
 
   const formatDate = (d: string) =>
     new Date(d).toLocaleDateString("en-US", { month: "short", day: "numeric" });
@@ -91,9 +92,7 @@ function HackathonsPage() {
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <TypoHeading as="h1">Hackathons</TypoHeading>
-          <TypoCaption as="p">
-            Join a jam, build a team, ship something new.
-          </TypoCaption>
+          <TypoCaption as="p">Join a jam, build a team, ship something new.</TypoCaption>
         </div>
         <button
           onClick={() => setCreateOpen(true)}
@@ -106,7 +105,10 @@ function HackathonsPage() {
 
       <div className="flex flex-wrap items-center gap-2">
         <div className="relative min-w-0 flex-1">
-          <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
+          <Search
+            size={14}
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+          />
           <input
             value={q}
             onChange={(e) => setQ(e.target.value)}
@@ -189,9 +191,7 @@ function HackathonsPage() {
                   </span>
                   <div className="min-w-0 flex-1">
                     <p className="truncate text-[14px] font-semibold text-foreground">{h.name}</p>
-                    <TypoCaption as="p">
-                      {h.description}
-                    </TypoCaption>
+                    <TypoCaption as="p">{h.description}</TypoCaption>
                   </div>
                 </div>
                 <div className="mt-3 flex flex-wrap gap-1">

--- a/frontend/src/routes/_app.organizations.index.tsx
+++ b/frontend/src/routes/_app.organizations.index.tsx
@@ -1,7 +1,14 @@
+import { useState, useMemo, useEffect } from "react";
 import { TypoHeading } from "@/components/shared/Typography";
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { Search, Bookmark } from "lucide-react";
+import { useSavedSearches } from "@/stores/useSavedSearches";
+import { SaveSearchDialog } from "@/components/shared/SaveSearchDialog";
 
 export const Route = createFileRoute("/_app/organizations/")({
+  validateSearch: (search: Record<string, unknown>) => ({
+    q: typeof search.q === "string" ? search.q : undefined,
+  }),
   component: OrganizationsListPage,
 });
 
@@ -17,6 +24,33 @@ function OrganizationsListPage() {
     },
   ];
 
+  const search = Route.useSearch();
+  const navigate = useNavigate({ from: Route.fullPath });
+  const [q, setQ] = useState(search.q || "");
+  const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+  const saveSearch = useSavedSearches((s) => s.saveSearch);
+
+  useEffect(() => {
+    if (search.q !== undefined && search.q !== q) {
+      setQ(search.q);
+    }
+  }, [search.q]);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      navigate({
+        search: (prev: any) => ({ ...prev, q: q || undefined }),
+        replace: true,
+      });
+    }, 300);
+    return () => clearTimeout(handler);
+  }, [q, navigate]);
+
+  const filteredOrgs = useMemo(() => {
+    const query = q.toLowerCase();
+    return mockOrgs.filter((org) => org.name.toLowerCase().includes(query) || org.description.toLowerCase().includes(query));
+  }, [q, mockOrgs]);
+
   return (
     <div className="max-w-6xl mx-auto px-4 py-8">
       <div className="flex justify-between items-center mb-8">
@@ -28,8 +62,39 @@ function OrganizationsListPage() {
         </div>
       </div>
 
+      <div className="flex flex-wrap items-center gap-2 mb-6">
+        <div className="relative min-w-0 flex-1">
+          <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500" />
+          <input
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Search organizations..."
+            className="w-full rounded-md border border-gray-800 bg-gray-900/40 py-[7px] pl-9 pr-3 text-[13px] text-gray-100 outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500/50"
+          />
+        </div>
+        <button
+          onClick={() => setSaveDialogOpen(true)}
+          className="inline-flex items-center gap-1.5 rounded-md border border-gray-800 bg-gray-900/40 px-2.5 py-[7px] text-[12px] font-medium text-gray-400 transition-colors hover:text-gray-100 hover:border-gray-700"
+        >
+          <Bookmark size={13} />
+          Save Search
+        </button>
+      </div>
+
+      <SaveSearchDialog
+        open={saveDialogOpen}
+        onOpenChange={setSaveDialogOpen}
+        onSave={(name) => {
+          saveSearch({
+            name,
+            type: "Organizations",
+            query: q,
+          } as any);
+        }}
+      />
+
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        {mockOrgs.map((org) => (
+        {filteredOrgs.map((org) => (
           <Link
             key={org.id}
             to="/organizations/$orgId"

--- a/frontend/src/routes/_app.organizations.index.tsx
+++ b/frontend/src/routes/_app.organizations.index.tsx
@@ -6,24 +6,24 @@ import { useSavedSearches } from "@/stores/useSavedSearches";
 import { SaveSearchDialog } from "@/components/shared/SaveSearchDialog";
 
 export const Route = createFileRoute("/_app/organizations/")({
-  validateSearch: (search: Record<string, unknown>) => ({
+  validateSearch: (search: Record<string, unknown>): { q?: string } => ({
     q: typeof search.q === "string" ? search.q : undefined,
   }),
   component: OrganizationsListPage,
 });
 
-function OrganizationsListPage() {
-  const mockOrgs = [
-    {
-      id: "devlink-org",
-      name: "DevLink",
-      description: "The developer portfolio & project collaboration network.",
-      hiring: true,
-      members_count: 12,
-      projects_count: 5,
-    },
-  ];
+const mockOrgs = [
+  {
+    id: "devlink-org",
+    name: "DevLink",
+    description: "The developer portfolio & project collaboration network.",
+    hiring: true,
+    members_count: 12,
+    projects_count: 5,
+  },
+];
 
+function OrganizationsListPage() {
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
   const [q, setQ] = useState(search.q || "");
@@ -31,7 +31,7 @@ function OrganizationsListPage() {
   const saveSearch = useSavedSearches((s) => s.saveSearch);
 
   useEffect(() => {
-    if (search.q !== undefined && search.q !== q) {
+    if (search.q !== undefined) {
       setQ(search.q);
     }
   }, [search.q]);
@@ -48,8 +48,11 @@ function OrganizationsListPage() {
 
   const filteredOrgs = useMemo(() => {
     const query = q.toLowerCase();
-    return mockOrgs.filter((org) => org.name.toLowerCase().includes(query) || org.description.toLowerCase().includes(query));
-  }, [q, mockOrgs]);
+    return mockOrgs.filter(
+      (org) =>
+        org.name.toLowerCase().includes(query) || org.description.toLowerCase().includes(query),
+    );
+  }, [q]);
 
   return (
     <div className="max-w-6xl mx-auto px-4 py-8">
@@ -102,9 +105,7 @@ function OrganizationsListPage() {
             className="block p-6 rounded-xl border border-gray-800 bg-gray-900/40 hover:border-indigo-500/50 hover:bg-gray-800/40 transition-all cursor-pointer"
           >
             <div className="flex justify-between items-start mb-3">
-              <TypoHeading as="h2">
-                {org.name}
-              </TypoHeading>
+              <TypoHeading as="h2">{org.name}</TypoHeading>
               {org.hiring && (
                 <span className="text-xs px-2.5 py-1 rounded-full bg-emerald-500/10 text-emerald-400 border border-emerald-500/20 font-medium">
                   Hiring

--- a/frontend/src/stores/useSavedSearches.ts
+++ b/frontend/src/stores/useSavedSearches.ts
@@ -1,0 +1,71 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { z } from "zod";
+import type { projectSearchSchema } from "@/routes/_app.projects";
+
+export type SearchType = "Developers" | "Projects" | "Organizations" | "Hackathons";
+
+export interface SavedSearchBase {
+  id: string;
+  name: string;
+  type: SearchType;
+  createdAt: string;
+}
+
+export interface SavedSearchDevelopers extends SavedSearchBase {
+  type: "Developers";
+  query: string;
+  tab?: string;
+}
+
+export interface SavedSearchProjects extends SavedSearchBase {
+  type: "Projects";
+  filters: z.infer<typeof projectSearchSchema>;
+}
+
+export interface SavedSearchOrganizations extends SavedSearchBase {
+  type: "Organizations";
+  query: string;
+}
+
+export interface SavedSearchHackathons extends SavedSearchBase {
+  type: "Hackathons";
+  query: string;
+}
+
+export type SavedSearch =
+  | SavedSearchDevelopers
+  | SavedSearchProjects
+  | SavedSearchOrganizations
+  | SavedSearchHackathons;
+
+interface SavedSearchesState {
+  searches: SavedSearch[];
+  saveSearch: (search: Omit<SavedSearch, "id" | "createdAt">) => void;
+  deleteSearch: (id: string) => void;
+  getSearchesByType: (type: SearchType) => SavedSearch[];
+}
+
+export const useSavedSearches = create<SavedSearchesState>()(
+  persist(
+    (set, get) => ({
+      searches: [],
+      saveSearch: (searchPayload) => {
+        const newSearch: SavedSearch = {
+          ...searchPayload,
+          id: crypto.randomUUID(),
+          createdAt: new Date().toISOString(),
+        } as SavedSearch;
+        set((state) => ({ searches: [...state.searches, newSearch] }));
+      },
+      deleteSearch: (id) =>
+        set((state) => ({
+          searches: state.searches.filter((s) => s.id !== id),
+        })),
+      getSearchesByType: (type) => get().searches.filter((s) => s.type === type),
+    }),
+    {
+      name: "devlink:saved-searches",
+    },
+  ),
+);


### PR DESCRIPTION
## Summary

- Add saved searches for Developers, Projects, Organizations, and Hackathons.
- Persist saved searches with Zustand + localStorage.
- Add Save Search dialog and quick access from the sidebar.
- Restore saved queries/filters through TanStack Router URL state.
- Add delete actions for saved searches in the sidebar.
- Add search UI and URL synchronization for Organizations and Hackathons.
- Fix optional search parameter typing and React hook issues introduced by the new URL-synced search state.

## Validation

- `npm run test` — 482/482 tests passed
- `npm run build` — passed
- `git diff --check` — passed
- Saved-search-related TypeScript/ESLint issues resolved.

## Note

During validation, an existing unrelated TypeScript error was identified in:

`frontend/src/routes/_app.projects.$projectId.tsx`

The error is related to `notFound()` and is outside the scope of #984, so that file was intentionally not included in this PR.

Closes #984 