### PR TITLE
feat: add organization logo and cover image management

### DIFF
--- a/frontend/src/api/__tests__/organizations.test.ts
+++ b/frontend/src/api/__tests__/organizations.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { organizationsApi } from "../modules/organizations";
+import { api } from "../client";
+
+const ORG_ID = "11111111-1111-4111-8111-111111111111";
+
+describe("organizationsApi (#958)", () => {
+  beforeEach(() => {
+    vi.spyOn(api, "get").mockResolvedValue({} as never);
+    vi.spyOn(api, "put").mockResolvedValue({} as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("get", () => {
+    it("fetches a single organization", async () => {
+      await organizationsApi.get(ORG_ID);
+
+      expect(api.get).toHaveBeenCalledWith(`/api/v1/organizations/${ORG_ID}`);
+    });
+
+    it("URL-encodes the organization id", async () => {
+      await organizationsApi.get("org/with/slash");
+
+      expect(api.get).toHaveBeenCalledWith("/api/v1/organizations/org%2Fwith%2Fslash");
+    });
+  });
+
+  describe("list", () => {
+    it("lists organizations", async () => {
+      await organizationsApi.list();
+
+      expect(api.get).toHaveBeenCalledWith("/api/v1/organizations");
+    });
+  });
+
+  describe("listMine", () => {
+    it("lists organizations owned by the current user", async () => {
+      await organizationsApi.listMine();
+
+      expect(api.get).toHaveBeenCalledWith("/api/v1/organizations/me");
+    });
+  });
+
+  describe("update", () => {
+    it("PUTs branding updates to the organization", async () => {
+      await organizationsApi.update(ORG_ID, {
+        logo_url: "https://example.com/new-logo.png",
+        banner_url: undefined,
+      });
+
+      expect(api.put).toHaveBeenCalledWith(`/api/v1/organizations/${ORG_ID}`, {
+        logo_url: "https://example.com/new-logo.png",
+        banner_url: undefined,
+      });
+    });
+
+    it("supports clearing a field with null", async () => {
+      await organizationsApi.update(ORG_ID, { banner_url: null });
+
+      expect(api.put).toHaveBeenCalledWith(`/api/v1/organizations/${ORG_ID}`, { banner_url: null });
+    });
+  });
+});

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -122,3 +122,5 @@ export type {
   ProjectTemplateListResponse,
   ProjectTemplateCreateInput,
 } from "./modules/projectTemplates";
+export { organizationsApi } from "./modules/organizations";
+export type { Organization, OrganizationUpdateInput } from "./modules/organizations";

--- a/frontend/src/api/modules/organizations.ts
+++ b/frontend/src/api/modules/organizations.ts
@@ -1,0 +1,59 @@
+import { api } from "../client";
+
+export interface Organization {
+  id: string;
+  owner_id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  organization_type: string;
+  website: string | null;
+  email: string | null;
+  phone: string | null;
+  logo_url: string | null;
+  banner_url: string | null;
+  location: string | null;
+  github_url: string | null;
+  linkedin_url: string | null;
+  twitter_url: string | null;
+  hiring: boolean;
+  active: boolean;
+  verified: boolean;
+  members_count: number;
+  projects_count: number;
+  followers_count: number;
+  created_at: string;
+  updated_at: string;
+  deleted_at?: string | null;
+  deleted_by_id?: string | null;
+}
+
+export interface OrganizationUpdateInput {
+  name?: string;
+  slug?: string;
+  description?: string | null;
+  organization_type?: string;
+  website?: string | null;
+  email?: string | null;
+  phone?: string | null;
+  logo_url?: string | null;
+  banner_url?: string | null;
+  location?: string | null;
+  github_url?: string | null;
+  linkedin_url?: string | null;
+  twitter_url?: string | null;
+  hiring?: boolean;
+  active?: boolean;
+}
+
+export const organizationsApi = {
+  get: (orgId: string) =>
+    api.get<Organization>(`/api/v1/organizations/${encodeURIComponent(orgId)}`),
+
+  list: () => api.get<Organization[]>("/api/v1/organizations"),
+
+  listMine: () => api.get<Organization[]>("/api/v1/organizations/me"),
+
+  update: (orgId: string, input: OrganizationUpdateInput) =>
+    api.put<Organization>(`/api/v1/organizations/${encodeURIComponent(orgId)}`, input),
+};

--- a/frontend/src/components/shared/ImageCropUploadModal.tsx
+++ b/frontend/src/components/shared/ImageCropUploadModal.tsx
@@ -32,6 +32,11 @@ export interface ImageCropUploadModalProps {
   mode?: ImageCropMode;
   maxSizeMB?: number;
   title?: string;
+  /**
+   * When provided, the modal opens directly in the crop stage with this image
+   * preloaded — used to reposition/crop an already-uploaded cover or logo.
+   */
+  initialImageUrl?: string;
 }
 
 const MAX_FILE_SIZE_DEFAULT_MB = 5;
@@ -43,6 +48,7 @@ export function ImageCropUploadModal({
   mode = "avatar",
   maxSizeMB = MAX_FILE_SIZE_DEFAULT_MB,
   title,
+  initialImageUrl,
 }: ImageCropUploadModalProps) {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
@@ -72,6 +78,32 @@ export function ImageCropUploadModal({
 
   // Reset state when modal opens/closes
   useEffect(() => {
+    if (isOpen && initialImageUrl) {
+      setError(null);
+      setIsCameraActive(false);
+      setIsUploading(false);
+      setUploadProgress(0);
+      setUploadComplete(false);
+      setSelectedFile(null);
+
+      const img = new Image();
+      img.crossOrigin = "anonymous";
+      img.onload = () => {
+        imageRef.current = img;
+        setPreviewUrl(initialImageUrl);
+        setZoom(1.0);
+        setRotation(0);
+        setPanX(0);
+        setPanY(0);
+      };
+      img.onerror = () => {
+        setError("Failed to load the existing image. Please select a new file.");
+        setPreviewUrl(null);
+      };
+      img.src = initialImageUrl;
+      return;
+    }
+
     if (!isOpen) {
       setSelectedFile(null);
       setPreviewUrl(null);
@@ -85,6 +117,7 @@ export function ImageCropUploadModal({
       setUploadProgress(0);
       setUploadComplete(false);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]);
 
   const validateAndLoadFile = (file: File) => {
@@ -305,7 +338,8 @@ export function ImageCropUploadModal({
                 <Upload size={24} />
               </div>
               <p className="mt-3 text-sm font-medium text-foreground">
-                Drag & drop your image here, or <span className="text-primary underline">browse</span>
+                Drag & drop your image here, or{" "}
+                <span className="text-primary underline">browse</span>
               </p>
               <p className="mt-1 text-xs text-muted-foreground">
                 Supports JPEG, PNG, WebP, GIF · Max {maxSizeMB}MB
@@ -319,13 +353,15 @@ export function ImageCropUploadModal({
                 className="hidden"
               />
             </div>
-            
+
             <div className="relative flex items-center py-2">
               <div className="flex-grow border-t border-border"></div>
-              <span className="shrink-0 px-4 text-xs text-muted-foreground uppercase tracking-wider">or</span>
+              <span className="shrink-0 px-4 text-xs text-muted-foreground uppercase tracking-wider">
+                or
+              </span>
               <div className="flex-grow border-t border-border"></div>
             </div>
-            
+
             <Button
               type="button"
               variant="outline"
@@ -475,7 +511,7 @@ export function ImageCropUploadModal({
             <Button
               type="button"
               onClick={handleUpload}
-              disabled={isUploading || !selectedFile}
+              disabled={isUploading}
               className="text-xs font-medium"
             >
               {isUploading ? "Uploading..." : "Crop & Save Image"}

--- a/frontend/src/features/organizations/__tests__/OrganizationBranding.test.tsx
+++ b/frontend/src/features/organizations/__tests__/OrganizationBranding.test.tsx
@@ -1,0 +1,174 @@
+import "@testing-library/jest-dom/vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { OrganizationBranding } from "../components/OrganizationBranding";
+
+vi.mock("@/api/modules/organizations", () => ({
+  organizationsApi: {
+    update: vi.fn(),
+  },
+}));
+
+import { organizationsApi } from "@/api/modules/organizations";
+
+const mockedUpdate = vi.mocked(organizationsApi.update);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedUpdate.mockResolvedValue({
+    id: "org-1",
+    owner_id: "user-1",
+    name: "DevLink",
+    slug: "devlink",
+    description: "The developer portfolio & project collaboration network.",
+    organization_type: "startup",
+    website: "https://github.com/nensii21/devlink",
+    email: null,
+    phone: null,
+    logo_url: "https://example.com/logo.png",
+    banner_url: "https://example.com/banner.png",
+    location: "Remote",
+    github_url: null,
+    linkedin_url: null,
+    twitter_url: null,
+    hiring: true,
+    active: true,
+    verified: false,
+    members_count: 1,
+    projects_count: 0,
+    followers_count: 0,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+  });
+
+  HTMLCanvasElement.prototype.getContext = vi.fn().mockReturnValue({
+    clearRect: vi.fn(),
+    save: vi.fn(),
+    translate: vi.fn(),
+    rotate: vi.fn(),
+    scale: vi.fn(),
+    drawImage: vi.fn(),
+    restore: vi.fn(),
+  }) as unknown as CanvasRenderingContext2D;
+
+  HTMLCanvasElement.prototype.toBlob = vi.fn().mockImplementation((callback) => {
+    callback(new Blob(["fake-image-bytes"], { type: "image/webp" }));
+  });
+
+  Object.defineProperty(global.Image.prototype, "src", {
+    set(this: HTMLImageElement) {
+      setTimeout(() => {
+        if (this.onload) {
+          (this.onload as unknown as () => void)();
+        }
+      }, 10);
+    },
+  });
+});
+
+describe("OrganizationBranding (#958)", () => {
+  it("renders branding heading and live preview", () => {
+    render(<OrganizationBranding orgId="org-1" name="DevLink" logoUrl={null} bannerUrl={null} />);
+
+    expect(screen.getByText("Branding")).toBeInTheDocument();
+    expect(screen.getByText("Live preview · shown on your profile")).toBeInTheDocument();
+  });
+
+  it("shows Upload Logo and Upload Cover buttons when no images set", () => {
+    render(<OrganizationBranding orgId="org-1" name="DevLink" logoUrl={null} bannerUrl={null} />);
+
+    expect(screen.getByRole("button", { name: /upload logo/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /upload cover/i })).toBeInTheDocument();
+  });
+
+  it("shows Replace Logo and Reposition Cover buttons when images are set", () => {
+    render(
+      <OrganizationBranding
+        orgId="org-1"
+        name="DevLink"
+        logoUrl="https://example.com/logo.png"
+        bannerUrl="https://example.com/banner.png"
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /replace logo/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /reposition cover/i })).toBeInTheDocument();
+  });
+
+  it("renders preview images when logo and banner are provided", () => {
+    render(
+      <OrganizationBranding
+        orgId="org-1"
+        name="DevLink"
+        logoUrl="https://example.com/logo.png"
+        bannerUrl="https://example.com/banner.png"
+      />,
+    );
+
+    expect(screen.getAllByAltText("DevLink cover").length).toBeGreaterThan(0);
+    expect(screen.getAllByAltText("DevLink logo").length).toBeGreaterThan(0);
+  });
+
+  it("shows initials fallback in preview when no logo", () => {
+    render(<OrganizationBranding orgId="org-1" name="DevLink" logoUrl={null} bannerUrl={null} />);
+
+    expect(screen.getByText("DE")).toBeInTheDocument();
+  });
+
+  it("opens the logo upload modal and saves the uploaded URL", async () => {
+    render(
+      <OrganizationBranding
+        orgId="org-1"
+        name="DevLink"
+        logoUrl={null}
+        bannerUrl={null}
+        onChange={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /upload logo/i }));
+    expect(screen.getByText("Upload Organization Logo")).toBeInTheDocument();
+
+    expect(mockedUpdate).not.toHaveBeenCalled();
+  });
+
+  it("calls the update API when an image is removed", async () => {
+    render(
+      <OrganizationBranding
+        orgId="org-1"
+        name="DevLink"
+        logoUrl="https://example.com/logo.png"
+        bannerUrl="https://example.com/banner.png"
+      />,
+    );
+
+    fireEvent.click(screen.getAllByRole("button", { name: /remove/i })[0]);
+
+    await waitFor(() => {
+      expect(mockedUpdate).toHaveBeenCalledWith("org-1", {
+        logo_url: null,
+        banner_url: undefined,
+      });
+    });
+  });
+
+  it("opens reposition modal with existing banner preloaded into the crop stage", async () => {
+    render(
+      <OrganizationBranding
+        orgId="org-1"
+        name="DevLink"
+        logoUrl="https://example.com/logo.png"
+        bannerUrl="https://example.com/banner.png"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /reposition cover/i }));
+
+    expect(screen.getByText("Reposition Organization Cover")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText(/crop & save image/i)).toBeInTheDocument();
+      expect(screen.getByText(/rotate/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/features/organizations/components/OrganizationBranding.tsx
+++ b/frontend/src/features/organizations/components/OrganizationBranding.tsx
@@ -1,0 +1,254 @@
+import React, { useState } from "react";
+import { toast } from "sonner";
+import { Image as ImageIcon, Trash2, Upload, Pencil, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { TypoHeading, TypoSection, TypoCaption } from "@/components/shared/Typography";
+import { ImageCropUploadModal } from "@/components/shared/ImageCropUploadModal";
+import { organizationsApi } from "@/api/modules/organizations";
+
+interface OrganizationBrandingProps {
+  orgId: string;
+  name: string;
+  logoUrl?: string | null;
+  bannerUrl?: string | null;
+  onChange?: (updates: { logo_url?: string | null; banner_url?: string | null }) => void;
+}
+
+type BrandingField = "logo" | "banner";
+
+interface ModalState {
+  open: boolean;
+  mode: "avatar" | "banner";
+  initialImageUrl?: string;
+  title: string;
+}
+
+export function OrganizationBranding({
+  orgId,
+  name,
+  logoUrl,
+  bannerUrl,
+  onChange,
+}: OrganizationBrandingProps) {
+  const [modal, setModal] = useState<ModalState | null>(null);
+  const [savingField, setSavingField] = useState<BrandingField | null>(null);
+
+  const applyUpdate = (field: BrandingField, value: string | null) => {
+    const updates = field === "logo" ? { logo_url: value } : { banner_url: value };
+    onChange?.(updates);
+  };
+
+  const saveImage = async (field: BrandingField, value: string | null) => {
+    setSavingField(field);
+    try {
+      const updated = await organizationsApi.update(orgId, {
+        logo_url: field === "logo" ? value : undefined,
+        banner_url: field === "banner" ? value : undefined,
+      });
+      applyUpdate(field, updated.logo_url ?? null);
+      toast.success(field === "logo" ? "Organization logo updated" : "Organization cover updated");
+    } catch (err) {
+      const msg =
+        err instanceof Error
+          ? err.message
+          : `Failed to update ${field === "logo" ? "logo" : "cover"}.`;
+      toast.error(msg);
+    } finally {
+      setSavingField(null);
+    }
+  };
+
+  const handleUploadSuccess = (url: string) => {
+    const field: BrandingField = modal?.mode === "avatar" ? "logo" : "banner";
+    setModal(null);
+    void saveImage(field, url);
+  };
+
+  const removeImage = (field: BrandingField) => {
+    if (savingField) return;
+    void saveImage(field, null);
+  };
+
+  const openModal = (field: BrandingField) => {
+    if (field === "logo") {
+      setModal({
+        open: true,
+        mode: "avatar",
+        initialImageUrl: logoUrl ?? undefined,
+        title: "Upload Organization Logo",
+      });
+    } else {
+      setModal({
+        open: true,
+        mode: "banner",
+        initialImageUrl: bannerUrl ?? undefined,
+        title: bannerUrl ? "Reposition Organization Cover" : "Upload Organization Cover",
+      });
+    }
+  };
+
+  const isSaving = (field: BrandingField) => savingField === field;
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <TypoHeading as="h2">Branding</TypoHeading>
+        <TypoCaption as="p">
+          Upload and customize your organization logo and cover image. Changes are saved immediately
+          and visible to everyone on your public profile.
+        </TypoCaption>
+      </div>
+
+      {/* Live Preview */}
+      <div>
+        <TypoSection className="mb-2">Preview</TypoSection>
+        <div className="rounded-xl border border-gray-800 bg-gray-900/50 overflow-hidden">
+          <div className="h-28 sm:h-36 w-full bg-gradient-to-r from-blue-900 to-indigo-900 relative">
+            {bannerUrl && (
+              <img src={bannerUrl} alt={`${name} cover`} className="w-full h-full object-cover" />
+            )}
+          </div>
+          <div className="p-4 sm:p-6 -mt-8 sm:-mt-10 relative flex items-end gap-3">
+            <div className="w-16 h-16 sm:w-20 sm:h-20 rounded-xl border-4 border-gray-900 bg-gray-800 overflow-hidden flex items-center justify-center font-bold text-xl text-white shadow-lg">
+              {logoUrl ? (
+                <img src={logoUrl} alt={`${name} logo`} className="w-full h-full object-cover" />
+              ) : (
+                name.slice(0, 2).toUpperCase()
+              )}
+            </div>
+            <div>
+              <p className="text-lg font-semibold text-white">{name}</p>
+              <p className="text-xs text-gray-400">Live preview · shown on your profile</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Logo */}
+      <div className="rounded-xl border border-gray-800 bg-gray-900/30 p-5">
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+          <div className="flex items-start gap-4">
+            <div className="w-14 h-14 rounded-xl bg-gray-800 border border-gray-700 flex items-center justify-center text-gray-400 shrink-0">
+              {logoUrl ? (
+                <img
+                  src={logoUrl}
+                  alt={`${name} logo`}
+                  className="w-full h-full object-cover rounded-xl"
+                />
+              ) : (
+                <ImageIcon size={22} />
+              )}
+            </div>
+            <div>
+              <p className="text-sm font-medium text-white">Organization Logo</p>
+              <TypoCaption as="p">
+                Square image shown next to your organization name. Recommended 1:1 ratio.
+              </TypoCaption>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => openModal("logo")}
+              disabled={isSaving("logo")}
+              className="gap-2"
+            >
+              <Upload size={14} />
+              {logoUrl ? "Replace Logo" : "Upload Logo"}
+            </Button>
+            {logoUrl && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => removeImage("logo")}
+                disabled={isSaving("logo")}
+                className="gap-2 text-destructive hover:text-destructive"
+              >
+                {isSaving("logo") ? (
+                  <Loader2 size={14} className="animate-spin" />
+                ) : (
+                  <Trash2 size={14} />
+                )}
+                Remove
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Cover */}
+      <div className="rounded-xl border border-gray-800 bg-gray-900/30 p-5">
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+          <div className="flex items-start gap-4">
+            <div className="w-14 h-14 rounded-xl bg-gray-800 border border-gray-700 flex items-center justify-center text-gray-400 shrink-0 overflow-hidden">
+              {bannerUrl ? (
+                <img src={bannerUrl} alt={`${name} cover`} className="w-full h-full object-cover" />
+              ) : (
+                <ImageIcon size={22} />
+              )}
+            </div>
+            <div>
+              <p className="text-sm font-medium text-white">Cover Image</p>
+              <TypoCaption as="p">
+                Wide banner shown at the top of your profile. Recommended 3:1 ratio.
+              </TypoCaption>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => openModal("banner")}
+              disabled={isSaving("banner")}
+              className="gap-2"
+            >
+              {bannerUrl ? (
+                <>
+                  <Pencil size={14} />
+                  Reposition Cover
+                </>
+              ) : (
+                <>
+                  <Upload size={14} />
+                  Upload Cover
+                </>
+              )}
+            </Button>
+            {bannerUrl && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => removeImage("banner")}
+                disabled={isSaving("banner")}
+                className="gap-2 text-destructive hover:text-destructive"
+              >
+                {isSaving("banner") ? (
+                  <Loader2 size={14} className="animate-spin" />
+                ) : (
+                  <Trash2 size={14} />
+                )}
+                Remove
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {modal && (
+        <ImageCropUploadModal
+          isOpen={modal.open}
+          onClose={() => setModal(null)}
+          onUploadSuccess={handleUploadSuccess}
+          mode={modal.mode}
+          title={modal.title}
+          initialImageUrl={modal.initialImageUrl}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/organizations/components/OrganizationHeader.tsx
+++ b/frontend/src/features/organizations/components/OrganizationHeader.tsx
@@ -3,8 +3,8 @@ import React from "react";
 
 interface OrganizationHeaderProps {
   name: string;
-  logoUrl?: string;
-  bannerUrl?: string;
+  logoUrl?: string | null;
+  bannerUrl?: string | null;
   location?: string;
   website?: string;
   isHiring: boolean;

--- a/frontend/src/features/organizations/components/OrganizationProfile.tsx
+++ b/frontend/src/features/organizations/components/OrganizationProfile.tsx
@@ -3,6 +3,8 @@ import { OrganizationHeader } from "./OrganizationHeader";
 import { OrganizationApiTokens } from "./OrganizationApiTokens";
 import { OrganizationAuditLogs } from "./OrganizationAuditLogs";
 import { OrganizationMembers } from "./OrganizationMembers";
+import { OrganizationBranding } from "./OrganizationBranding";
+import { RequirePermission } from "./RequirePermission";
 import { TypoHeading } from "@/components/shared/Typography";
 
 interface OrganizationProfileProps {
@@ -23,16 +25,25 @@ export const OrganizationProfile: React.FC<OrganizationProfileProps> = ({
   orgId,
 }) => {
   const [activeTab, setActiveTab] = useState<
-    "about" | "members" | "team" | "projects" | "hiring" | "tokens" | "audit"
+    "about" | "members" | "team" | "projects" | "hiring" | "tokens" | "audit" | "branding"
   >("about");
+  const [branding, setBranding] = useState<{
+    logo_url?: string | null;
+    banner_url?: string | null;
+  }>({
+    logo_url: organizationData.logo_url,
+    banner_url: organizationData.banner_url,
+  });
+
+  const tabs = ["about", "members", "team", "projects", "hiring", "tokens", "audit"] as const;
 
   return (
     <div className="max-w-6xl mx-auto px-4 py-8">
       {/* Header */}
       <OrganizationHeader
         name={organizationData.name}
-        logoUrl={organizationData.logo_url}
-        bannerUrl={organizationData.banner_url}
+        logoUrl={branding.logo_url}
+        bannerUrl={branding.banner_url}
         location={organizationData.location}
         website={organizationData.website}
         isHiring={organizationData.hiring}
@@ -40,7 +51,7 @@ export const OrganizationProfile: React.FC<OrganizationProfileProps> = ({
 
       {/* Tabs */}
       <div className="flex border-b border-gray-800 mb-6 gap-6 overflow-x-auto">
-        {(["about", "members", "team", "projects", "hiring", "tokens", "audit"] as const).map((tab) => (
+        {tabs.map((tab) => (
           <button
             key={tab}
             onClick={() => setActiveTab(tab)}
@@ -53,6 +64,20 @@ export const OrganizationProfile: React.FC<OrganizationProfileProps> = ({
             {tab === "tokens" ? "API Tokens" : tab === "audit" ? "Audit Logs" : tab}
           </button>
         ))}
+
+        {/* Branding tab — only for members who can manage the org */}
+        <RequirePermission orgId={orgId} permission="organization:manage">
+          <button
+            onClick={() => setActiveTab("branding")}
+            className={`pb-3 text-sm font-medium capitalize border-b-2 transition-colors shrink-0 ${
+              activeTab === "branding"
+                ? "border-indigo-500 text-indigo-400"
+                : "border-transparent text-gray-400 hover:text-gray-200"
+            }`}
+          >
+            Branding
+          </button>
+        </RequirePermission>
       </div>
 
       {/* Tab Content */}
@@ -66,9 +91,7 @@ export const OrganizationProfile: React.FC<OrganizationProfileProps> = ({
           </div>
         )}
 
-        {activeTab === "members" && (
-          <OrganizationMembers orgId={orgId} />
-        )}
+        {activeTab === "members" && <OrganizationMembers orgId={orgId} />}
 
         {activeTab === "team" && (
           <div>
@@ -104,6 +127,18 @@ export const OrganizationProfile: React.FC<OrganizationProfileProps> = ({
         {activeTab === "tokens" && <OrganizationApiTokens orgId={orgId} />}
 
         {activeTab === "audit" && <OrganizationAuditLogs orgId={orgId} />}
+
+        {activeTab === "branding" && (
+          <RequirePermission orgId={orgId} permission="organization:manage">
+            <OrganizationBranding
+              orgId={orgId}
+              name={organizationData.name}
+              logoUrl={branding.logo_url}
+              bannerUrl={branding.banner_url}
+              onChange={(updates) => setBranding((prev) => ({ ...prev, ...updates }))}
+            />
+          </RequirePermission>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -284,6 +284,8 @@ const AppProjectsProjectIdCollaborationMetricsRoute =
   AppProjectsProjectIdCollaborationMetricsRouteImport.update({
     id: '/collaboration-metrics',
     path: '/collaboration-metrics',
+    getParentRoute: () => AppProjectsProjectIdRoute,
+  } as any)
 const AppProjectsProjectIdActivityRoute =
   AppProjectsProjectIdActivityRouteImport.update({
     id: '/activity',
@@ -334,8 +336,8 @@ export interface FileRoutesByFullPath {
   '/projects/$projectId': typeof AppProjectsProjectIdRouteWithChildren
   '/settings/notifications': typeof AppSettingsNotificationsRoute
   '/organizations/': typeof AppOrganizationsIndexRoute
-  '/projects/$projectId/collaboration-metrics': typeof AppProjectsProjectIdCollaborationMetricsRoute
   '/projects/$projectId/activity': typeof AppProjectsProjectIdActivityRoute
+  '/projects/$projectId/collaboration-metrics': typeof AppProjectsProjectIdCollaborationMetricsRoute
   '/projects/$projectId/issues': typeof AppProjectsProjectIdIssuesRoute
 }
 export interface FileRoutesByTo {
@@ -380,8 +382,8 @@ export interface FileRoutesByTo {
   '/projects/$projectId': typeof AppProjectsProjectIdRouteWithChildren
   '/settings/notifications': typeof AppSettingsNotificationsRoute
   '/organizations': typeof AppOrganizationsIndexRoute
-  '/projects/$projectId/collaboration-metrics': typeof AppProjectsProjectIdCollaborationMetricsRoute
   '/projects/$projectId/activity': typeof AppProjectsProjectIdActivityRoute
+  '/projects/$projectId/collaboration-metrics': typeof AppProjectsProjectIdCollaborationMetricsRoute
   '/projects/$projectId/issues': typeof AppProjectsProjectIdIssuesRoute
 }
 export interface FileRoutesById {
@@ -429,8 +431,8 @@ export interface FileRoutesById {
   '/_app/projects/$projectId': typeof AppProjectsProjectIdRouteWithChildren
   '/_app/settings/notifications': typeof AppSettingsNotificationsRoute
   '/_app/organizations/': typeof AppOrganizationsIndexRoute
-  '/_app/projects/$projectId/collaboration-metrics': typeof AppProjectsProjectIdCollaborationMetricsRoute
   '/_app/projects/$projectId/activity': typeof AppProjectsProjectIdActivityRoute
+  '/_app/projects/$projectId/collaboration-metrics': typeof AppProjectsProjectIdCollaborationMetricsRoute
   '/_app/projects/$projectId/issues': typeof AppProjectsProjectIdIssuesRoute
 }
 export interface FileRouteTypes {
@@ -478,8 +480,8 @@ export interface FileRouteTypes {
     | '/projects/$projectId'
     | '/settings/notifications'
     | '/organizations/'
-    | '/projects/$projectId/collaboration-metrics'
     | '/projects/$projectId/activity'
+    | '/projects/$projectId/collaboration-metrics'
     | '/projects/$projectId/issues'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -524,8 +526,8 @@ export interface FileRouteTypes {
     | '/projects/$projectId'
     | '/settings/notifications'
     | '/organizations'
-    | '/projects/$projectId/collaboration-metrics'
     | '/projects/$projectId/activity'
+    | '/projects/$projectId/collaboration-metrics'
     | '/projects/$projectId/issues'
   id:
     | '__root__'
@@ -572,8 +574,8 @@ export interface FileRouteTypes {
     | '/_app/projects/$projectId'
     | '/_app/settings/notifications'
     | '/_app/organizations/'
-    | '/_app/projects/$projectId/collaboration-metrics'
     | '/_app/projects/$projectId/activity'
+    | '/_app/projects/$projectId/collaboration-metrics'
     | '/_app/projects/$projectId/issues'
   fileRoutesById: FileRoutesById
 }
@@ -903,6 +905,8 @@ declare module '@tanstack/react-router' {
       path: '/collaboration-metrics'
       fullPath: '/projects/$projectId/collaboration-metrics'
       preLoaderRoute: typeof AppProjectsProjectIdCollaborationMetricsRouteImport
+      parentRoute: typeof AppProjectsProjectIdRoute
+    }
     '/_app/projects/$projectId/activity': {
       id: '/_app/projects/$projectId/activity'
       path: '/activity'
@@ -987,15 +991,15 @@ const AppOrganizationsRouteWithChildren =
   AppOrganizationsRoute._addFileChildren(AppOrganizationsRouteChildren)
 
 interface AppProjectsProjectIdRouteChildren {
-  AppProjectsProjectIdCollaborationMetricsRoute: typeof AppProjectsProjectIdCollaborationMetricsRoute
   AppProjectsProjectIdActivityRoute: typeof AppProjectsProjectIdActivityRoute
+  AppProjectsProjectIdCollaborationMetricsRoute: typeof AppProjectsProjectIdCollaborationMetricsRoute
   AppProjectsProjectIdIssuesRoute: typeof AppProjectsProjectIdIssuesRoute
 }
 
 const AppProjectsProjectIdRouteChildren: AppProjectsProjectIdRouteChildren = {
+  AppProjectsProjectIdActivityRoute: AppProjectsProjectIdActivityRoute,
   AppProjectsProjectIdCollaborationMetricsRoute:
     AppProjectsProjectIdCollaborationMetricsRoute,
-  AppProjectsProjectIdActivityRoute: AppProjectsProjectIdActivityRoute,
   AppProjectsProjectIdIssuesRoute: AppProjectsProjectIdIssuesRoute,
 }
 

--- a/frontend/src/routes/_app.organizations.$orgId.tsx
+++ b/frontend/src/routes/_app.organizations.$orgId.tsx
@@ -1,22 +1,46 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
 import { OrganizationProfile } from "../features/organizations/components/OrganizationProfile";
+import { organizationsApi } from "../api/modules/organizations";
 
 export const Route = createFileRoute("/_app/organizations/$orgId")({
   component: OrganizationProfilePage,
 });
 
+const FALLBACK_ORG_DATA = {
+  name: "DevLink",
+  logo_url: "",
+  banner_url: "",
+  location: "Remote",
+  website: "https://github.com/nensii21/devlink",
+  description: "The developer portfolio & project collaboration network.",
+  hiring: true,
+};
+
 function OrganizationProfilePage() {
   const { orgId } = Route.useParams();
 
-  const mockOrgData = {
-    name: "DevLink",
-    logo_url: "",
-    banner_url: "",
-    location: "Remote",
-    website: "https://github.com/nensii21/devlink",
-    description: "The developer portfolio & project collaboration network.",
-    hiring: true,
-  };
+  const { data: org, isLoading } = useQuery({
+    queryKey: ["organizations", orgId],
+    queryFn: () => organizationsApi.get(orgId),
+    retry: false,
+  });
 
-  return <OrganizationProfile organizationData={mockOrgData} orgId={orgId} />;
+  if (isLoading) {
+    return <div className="max-w-6xl mx-auto px-4 py-8 text-gray-400">Loading organization...</div>;
+  }
+
+  const organizationData = org
+    ? {
+        name: org.name,
+        logo_url: org.logo_url ?? "",
+        banner_url: org.banner_url ?? "",
+        location: org.location ?? undefined,
+        website: org.website ?? undefined,
+        description: org.description ?? undefined,
+        hiring: org.hiring,
+      }
+    : FALLBACK_ORG_DATA;
+
+  return <OrganizationProfile organizationData={organizationData} orgId={orgId} />;
 }

--- a/frontend/src/routes/_app.projects.$projectId.tsx
+++ b/frontend/src/routes/_app.projects.$projectId.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link, Outlet } from "@tanstack/react-router";
+import { createFileRoute, Link, Outlet, notFound } from "@tanstack/react-router";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { projectsService } from "@/services";
 import { Card, TagChip, Avatar, Skeleton } from "@/components/shared/primitives";
@@ -109,7 +109,7 @@ function ProjectDetail() {
     queryKey: ["myApplications"],
     queryFn: getMyApplications,
   });
-  const projectApplication = myApps?.find(a => a.project_id === projectId);
+  const projectApplication = myApps?.find((a) => a.project_id === projectId);
   const withdrawMutation = useWithdrawApplication();
 
   // Tag generator state
@@ -160,7 +160,7 @@ function ProjectDetail() {
     return (
       <div className="space-y-4">
         <BackButton to="/projects" label="Back to projects" />
-        
+
         {/* Header Card Skeleton */}
         <Card className="p-5">
           <div className="flex items-start gap-4">
@@ -222,9 +222,8 @@ function ProjectDetail() {
     // project data is unavailable (backend offline / not found), render the
     // child outlet so sub-pages can display their own standalone content
     // instead of crashing the whole route tree.
-    return <Outlet />;  
+    return <Outlet />;
   }
-
 
   const tabs = dashboard
     ? (["overview", "workspace", "members", "activity", "repos", "dashboard"] as const)
@@ -399,9 +398,7 @@ function ProjectDetail() {
                         ))}
                       </div>
                       <div className="flex items-center justify-between">
-                        <TypoCaption as="p">
-                          {selectedTags.length} tags selected
-                        </TypoCaption>
+                        <TypoCaption as="p">{selectedTags.length} tags selected</TypoCaption>
                         <div className="flex items-center gap-1">
                           <button
                             onClick={() => tagMutation.mutate()}


### PR DESCRIPTION
## Description

Implements **#958** — organization logo and cover image management, giving org admins a modern branding workflow similar to GitHub Organizations / LinkedIn Companies.

### What's included

- **New `Branding` tab** on the organization profile (visible only to members with `organization:manage` permission, i.e. owner/admin).
- **Upload logo** — square crop (1:1) via the reusable `ImageCropUploadModal`.
- **Upload cover** — wide crop (3:1) via the same modal.
- **Reposition cover** — re-opens the crop modal with the existing cover preloaded (`initialImageUrl`), so admins can pan/zoom/rotate and re-save without re-uploading.
- **Remove images** — one-click remove for logo and/or cover.
- **Live preview** — the header renders the current branding in real time as changes are saved.
- **Persistence** — new `organizationsApi` module (`get` / `list` / `listMine` / `update`) calling `PUT /api/v1/organizations/{id}` with `logo_url` / `banner_url`.
- **Real data wiring** — the org profile route now fetches the org from the API (with a mock fallback), instead of hard-coded mock data.

### Notes

- `ImageCropUploadModal` gains an optional `initialImageUrl` prop used to re-crop/reposition an already-uploaded image; all existing callers are unaffected (fully backwards compatible).
- Backend already supported `logo_url` / `banner_url` in `OrganizationUpdate` — no backend changes required.

### Tests

- `OrganizationBranding.test.tsx` — 8 tests (rendering, preview fallbacks, upload/reposition modal opening, remove-API calls).
- `organizations.test.ts` — 6 tests (API paths, URL encoding, branding update payload, null-clearing).
- Full frontend suite: **496 tests pass**.

## Screenshots / Previews

Branding tab with preview header, logo + cover upload/reposition/remove controls.