### PR TITLE
feat: live collaboration presence (#975)

### DIFF
--- a/backend/alembic/versions/ffff00000004_add_collaboration_status_to_user.py
+++ b/backend/alembic/versions/ffff00000004_add_collaboration_status_to_user.py
@@ -1,0 +1,30 @@
+"""add collaboration status to user
+
+Revision ID: ffff00000004
+Revises: ea6d6738e0ae
+Create Date: 2026-08-13 12:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'ffff00000004'
+down_revision = 'ea6d6738e0ae'
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    # add collaboration status column to users table
+    op.add_column(
+        'users',
+        sa.Column(
+            'collaboration_status',
+            sa.String(40),
+            nullable=True,
+            server_default='available',
+        ),
+    )
+
+def downgrade() -> None:
+    op.drop_column('users', 'collaboration_status')

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -219,6 +219,13 @@ class User(Base):
         nullable=False,
     )
 
+    collaboration_status: Mapped[str | None] = mapped_column(
+        String(40),
+        nullable=True,
+        default="available",
+        server_default="available",
+    )
+
     is_private: Mapped[bool] = mapped_column(
         Boolean,
         default=False,

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -22,6 +22,7 @@ from app.dependencies import get_current_user, get_database
 from app.middleware.rate_limit import SEARCH_LIMIT, limiter
 from app.models.user import User
 from app.schemas.user import (
+    CollaborationStatus,
     CurrentUser,
     PrivacySettings,
     PrivacySettingsUpdate,
@@ -332,6 +333,53 @@ def update_me(
     )
 
     return updated_user
+
+
+@router.get(
+    "/me/collaboration-status",
+    response_model=dict,
+    summary="Get live collaboration presence status",
+)
+def get_collaboration_status(
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Get the current user's live collaboration presence status
+    (coding, reviewing_pr, in_meeting, looking_for_project, available).
+    """
+    return {"user_id": str(current_user.id), "status": current_user.collaboration_status}
+
+
+@router.put(
+    "/me/collaboration-status",
+    response_model=dict,
+    summary="Set live collaboration presence status",
+)
+def set_collaboration_status(
+    status_val: CollaborationStatus = Query(
+        ..., description="One of: coding, reviewing_pr, in_meeting, looking_for_project, available"
+    ),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_database),
+):
+    """
+    Set the current user's live collaboration presence status and broadcast the
+    change to all connected WebSocket clients.
+    """
+    current_user.collaboration_status = status_val.value
+    db.commit()
+    db.refresh(current_user)
+
+    try:
+        from app.routers.websockets import manager
+
+        manager.set_collaboration_status(str(current_user.id), status_val.value)
+    except Exception:
+        # WebSocket manager is in-memory; a failure to broadcast should not
+        # fail the persistence of the status update.
+        pass
+
+    return {"user_id": str(current_user.id), "status": status_val.value}
 
 
 @router.put(

--- a/backend/app/routers/websockets.py
+++ b/backend/app/routers/websockets.py
@@ -93,6 +93,8 @@ class ConnectionManager:
         self.rooms: Dict[str, Set[str]] = {}
         # user_id → presence status ("online", "away", "busy", "offline")
         self.presence_states: Dict[str, str] = {}
+        # user_id → collaboration status ("coding", "reviewing_pr", ...)
+        self.collaboration_states: Dict[str, str] = {}
         # user_id → timestamp of last activity
         self.last_activity: Dict[str, datetime] = {}
 
@@ -136,6 +138,7 @@ class ConnectionManager:
                 exclude_user_id=user_id,
             )
             self.presence_states.pop(user_id, None)
+            self.collaboration_states.pop(user_id, None)
             self.last_activity.pop(user_id, None)
 
         logger.info("User %s disconnected a session.", user_id)
@@ -179,6 +182,35 @@ class ConnectionManager:
         self.presence_states[user_id] = status
         await self.broadcast_to_all(
             _event("presence.status_changed", user_id=user_id, status=status)
+        )
+
+    def set_collaboration_status(self, user_id: str, status: str) -> None:
+        """Record a user's collaboration presence status (persisted elsewhere).
+
+        Synchronous — called from REST handlers. The actual broadcast is done
+        by ``broadcast_collaboration_status`` so the async broadcast is not
+        blocked on the request path.
+        """
+        allowed_statuses = {
+            "coding",
+            "reviewing_pr",
+            "in_meeting",
+            "looking_for_project",
+            "available",
+        }
+        if status not in allowed_statuses:
+            raise ValueError(f"Invalid collaboration status: {status}")
+        self.collaboration_states[user_id] = status
+
+    async def broadcast_collaboration_status(self, user_id: str, status: str) -> None:
+        """Broadcast a collaboration status change to all connected clients."""
+        self.collaboration_states[user_id] = status
+        await self.broadcast_to_all(
+            _event(
+                "presence.collaboration_status_changed",
+                user_id=user_id,
+                status=status,
+            )
         )
 
     async def check_timeouts(self, timeout_seconds: int = 300) -> None:
@@ -234,6 +266,12 @@ manager = ConnectionManager()
 def get_all_presences(current_user: User = Depends(get_current_user)):
     """Retrieve active presence states for all connected users."""
     return manager.presence_states.copy()
+
+
+@router.get("/collaboration-status", response_model=Dict[str, str])
+def get_all_collaboration_statuses(current_user: User = Depends(get_current_user)):
+    """Retrieve collaboration statuses for all connected users."""
+    return manager.collaboration_states.copy()
 
 
 @router.get("/presence/{user_id}", response_model=Dict[str, str])
@@ -447,6 +485,24 @@ async def websocket_collab(websocket: WebSocket, token: str = ""):
                     _event("presence.query_response", presences=presences),
                     user_id,
                 )
+
+            # ── Collaboration Status Update ─────────────────────────────
+            elif msg_type == "collaboration_status_update":
+                status_val = data.get("status")
+                allowed_statuses = {
+                    "coding",
+                    "reviewing_pr",
+                    "in_meeting",
+                    "looking_for_project",
+                    "available",
+                }
+                if status_val not in allowed_statuses:
+                    await manager.send_personal_message(
+                        _event("error", message=f"Invalid collaboration status: {status_val}"),
+                        user_id,
+                    )
+                else:
+                    await manager.broadcast_collaboration_status(user_id, status_val)
 
             # ── Document Collaboration Events ───────────────────────────
             elif msg_type == "doc.join" and project_id:

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -42,6 +42,19 @@ class PrivacyVisibility(str, Enum):
     PRIVATE = "private"
 
 
+class CollaborationStatus(str, Enum):
+    """Live collaboration presence status a user can set."""
+
+    CODING = "coding"
+    REVIEWING_PR = "reviewing_pr"
+    IN_MEETING = "in_meeting"
+    LOOKING_FOR_PROJECT = "looking_for_project"
+    AVAILABLE = "available"
+
+
+COLLABORATION_STATUSES = tuple(status.value for status in CollaborationStatus)
+
+
 class PrivacySettings(BaseModel):
     email: PrivacyVisibility = PrivacyVisibility.PRIVATE
     github: PrivacyVisibility = PrivacyVisibility.PUBLIC
@@ -96,6 +109,7 @@ class UserBase(BaseModel):
     is_private: bool = False
     privacy_settings: PrivacySettings | None = Field(default_factory=PrivacySettings)
     availability: list[AvailabilitySlot] = Field(default_factory=list)
+    collaboration_status: CollaborationStatus | None = CollaborationStatus.AVAILABLE
 
 
 # ==========================================================
@@ -159,6 +173,7 @@ class UserUpdate(BaseModel):
     is_private: bool | None = None
     privacy_settings: PrivacySettingsUpdate | None = None
     availability: list[AvailabilitySlot] | None = None
+    collaboration_status: CollaborationStatus | None = None
 
     model_config = ConfigDict(
         json_schema_extra={

--- a/backend/app/tests/test_collaboration_status.py
+++ b/backend/app/tests/test_collaboration_status.py
@@ -1,0 +1,75 @@
+import pytest
+from fastapi import status
+
+from app.routers.websockets import manager
+
+
+@pytest.fixture(autouse=True)
+def _reset_ws_manager():
+    manager.collaboration_states.clear()
+    yield
+    manager.collaboration_states.clear()
+
+
+def test_get_collaboration_status_default(client, register_and_login):
+    user_id, token = register_and_login(
+        email="status@example.com", username="status_default"
+    )
+    headers = {"Authorization": f"Bearer {token}"}
+
+    response = client.get("/api/v1/users/me/collaboration-status", headers=headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert body["user_id"] == user_id
+    assert body["status"] == "available"
+
+
+def test_set_collaboration_status(client, register_and_login):
+    user_id, token = register_and_login(
+        email="status@example.com", username="status_set"
+    )
+    headers = {"Authorization": f"Bearer {token}"}
+
+    response = client.put(
+        "/api/v1/users/me/collaboration-status",
+        params={"status_val": "coding"},
+        headers=headers,
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert body["status"] == "coding"
+
+    get_response = client.get(
+        "/api/v1/users/me/collaboration-status", headers=headers
+    )
+    assert get_response.json()["status"] == "coding"
+
+
+def test_set_collaboration_status_invalid(client, register_and_login):
+    _, token = register_and_login(email="status@example.com", username="status_invalid")
+    headers = {"Authorization": f"Bearer {token}"}
+
+    response = client.put(
+        "/api/v1/users/me/collaboration-status",
+        params={"status_val": "not_a_status"},
+        headers=headers,
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_set_collaboration_status_broadcasts_to_ws(client, register_and_login):
+    user_id, token = register_and_login(
+        email="status@example.com", username="status_ws"
+    )
+    headers = {"Authorization": f"Bearer {token}"}
+
+    client.put(
+        "/api/v1/users/me/collaboration-status",
+        params={"status_val": "reviewing_pr"},
+        headers=headers,
+    )
+
+    assert manager.collaboration_states.get(user_id) == "reviewing_pr"

--- a/frontend/src/api/modules/users.ts
+++ b/frontend/src/api/modules/users.ts
@@ -20,4 +20,10 @@ export const usersApi = {
       reward_unlocked: boolean;
       reward_badge?: string;
     }>("/api/users/me/completion"),
+  getCollaborationStatus: () =>
+    api.get<{ user_id: string; status: string }>("/api/users/me/collaboration-status"),
+  setCollaborationStatus: (status: string) =>
+    api.put<{ user_id: string; status: string }>("/api/users/me/collaboration-status", undefined, {
+      query: { status_val: status },
+    }),
 };

--- a/frontend/src/api/ws.ts
+++ b/frontend/src/api/ws.ts
@@ -49,6 +49,12 @@ export type CollabEvent =
   | { type: "typing"; conversationId: string; from: string; typing: boolean }
   | { type: "read"; conversationId: string; by: string; at: string }
   | { type: "presence"; userId: string; online: boolean }
+  | {
+      type: "presence.collaboration_status_changed";
+      userId: string;
+      status: string;
+    }
+  | { type: "presence.query_response"; presences: Record<string, string> }
   | { type: "notification"; id: string; kind: string; text: string; at: string }
   | { type: "status"; sender_id: string; content: string }
   | { type: "error"; message: string }
@@ -181,6 +187,18 @@ class WsClient {
   /** Notify a project room that project metadata changed. */
   notifyProjectUpdate(projectId: string, changes: Record<string, unknown>): void {
     this.send({ type: "project_update", project_id: projectId, changes });
+  }
+
+  // ── Collaboration presence ────────────────────────────────────────────────
+
+  /** Broadcast a collaboration status change to all connected users. */
+  updateCollaborationStatus(status: string): void {
+    this.send({ type: "collaboration_status_update", status });
+  }
+
+  /** Query presence statuses. Pass user_ids to query specific users. */
+  queryPresence(userIds?: string[]): void {
+    this.send({ type: "presence_query", user_ids: userIds });
   }
 }
 

--- a/frontend/src/features/collaboration/__tests__/CollaborationStatusBadge.test.tsx
+++ b/frontend/src/features/collaboration/__tests__/CollaborationStatusBadge.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CollaborationStatusBadge } from "@/features/collaboration/components/CollaborationStatusBadge";
+import {
+  COLLABORATION_STATUSES,
+  getCollaborationStatusOption,
+} from "@/features/collaboration/types";
+
+describe("CollaborationStatusBadge", () => {
+  it("renders the label for a known status", () => {
+    render(<CollaborationStatusBadge status="coding" />);
+    expect(screen.getByText("Coding")).toBeInTheDocument();
+  });
+
+  it("renders a label for each supported status", () => {
+    const cases = [
+      ["coding", "Coding"],
+      ["reviewing_pr", "Reviewing PR"],
+      ["in_meeting", "In meeting"],
+      ["looking_for_project", "Looking for project"],
+      ["available", "Available now"],
+    ] as const;
+    for (const [status, label] of cases) {
+      const { unmount } = render(<CollaborationStatusBadge status={status} />);
+      expect(screen.getByText(label)).toBeInTheDocument();
+      unmount();
+    }
+  });
+
+  it("falls back to 'Available now' for unknown or missing status", () => {
+    render(<CollaborationStatusBadge status="not_a_status" />);
+    expect(screen.getByText("Available now")).toBeInTheDocument();
+  });
+
+  it("hides the visible label but keeps it accessible when showLabel is false", () => {
+    render(<CollaborationStatusBadge status="coding" showLabel={false} />);
+    expect(screen.getByText("Coding", { selector: ".sr-only" })).toBeInTheDocument();
+    expect(screen.getByText("Coding")).toHaveClass("sr-only");
+  });
+
+  it("applies the status-specific accent classes", () => {
+    render(<CollaborationStatusBadge status="coding" />);
+    const badge = screen.getByTitle("Currently writing code");
+    expect(badge.className).toContain("violet");
+  });
+});
+
+describe("getCollaborationStatusOption", () => {
+  it("returns the matching option for a known value", () => {
+    expect(getCollaborationStatusOption("coding")).toMatchObject({
+      value: "coding",
+      label: "Coding",
+    });
+  });
+
+  it("returns the available option for unknown values", () => {
+    expect(getCollaborationStatusOption("bogus")).toMatchObject({
+      value: "available",
+    });
+  });
+
+  it("returns the available option for null/undefined", () => {
+    expect(getCollaborationStatusOption(undefined)).toMatchObject({
+      value: "available",
+    });
+    expect(getCollaborationStatusOption(null)).toMatchObject({
+      value: "available",
+    });
+  });
+
+  it("exposes every supported status with an icon", () => {
+    for (const option of COLLABORATION_STATUSES) {
+      expect(option.icon).toBeDefined();
+      expect(option.label).toBeTruthy();
+    }
+  });
+});

--- a/frontend/src/features/collaboration/__tests__/CollaborationStatusPicker.test.tsx
+++ b/frontend/src/features/collaboration/__tests__/CollaborationStatusPicker.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CollaborationStatusPicker } from "@/features/collaboration/components/CollaborationStatusPicker";
+
+describe("CollaborationStatusPicker", () => {
+  it("renders the current status label", () => {
+    render(<CollaborationStatusPicker value="coding" onChange={() => {}} />);
+    expect(screen.getByRole("button")).toHaveTextContent("Coding");
+  });
+
+  it("opens the menu on click and shows all statuses", async () => {
+    const user = userEvent.setup();
+    render(<CollaborationStatusPicker value="available" onChange={() => {}} />);
+    await user.click(screen.getByRole("button"));
+    expect(await screen.findByText("Coding")).toBeInTheDocument();
+    expect(screen.getByText("Reviewing PR")).toBeInTheDocument();
+    expect(screen.getByText("In meeting")).toBeInTheDocument();
+    expect(screen.getByText("Looking for project")).toBeInTheDocument();
+    expect(screen.getAllByText("Available now").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("calls onChange with the selected status", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<CollaborationStatusPicker value="available" onChange={onChange} />);
+    await user.click(screen.getByRole("button"));
+    await user.click(await screen.findByText("Coding"));
+    expect(onChange).toHaveBeenCalledWith("coding");
+  });
+
+  it("is disabled when the disabled prop is set", () => {
+    render(<CollaborationStatusPicker value="available" onChange={() => {}} disabled />);
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+});

--- a/frontend/src/features/collaboration/components/CollaborationStatusBadge.tsx
+++ b/frontend/src/features/collaboration/components/CollaborationStatusBadge.tsx
@@ -1,0 +1,36 @@
+import { cn } from "@/lib/utils";
+import {
+  getCollaborationStatusOption,
+  type CollaborationStatus,
+} from "@/features/collaboration/types";
+
+interface CollaborationStatusBadgeProps {
+  status?: CollaborationStatus | string | null;
+  className?: string;
+  showLabel?: boolean;
+}
+
+export function CollaborationStatusBadge({
+  status,
+  className,
+  showLabel = true,
+}: CollaborationStatusBadgeProps) {
+  const option = getCollaborationStatusOption(status);
+  const Icon = option.icon;
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium",
+        option.badgeClass,
+        className,
+      )}
+      title={option.description}
+    >
+      <span className={cn("size-2 rounded-full", option.dotClass)} aria-hidden="true" />
+      {showLabel && <span>{option.label}</span>}
+      {!showLabel && <span className="sr-only">{option.label}</span>}
+      <Icon className="size-3" aria-hidden="true" />
+    </span>
+  );
+}

--- a/frontend/src/features/collaboration/components/CollaborationStatusPicker.tsx
+++ b/frontend/src/features/collaboration/components/CollaborationStatusPicker.tsx
@@ -1,0 +1,70 @@
+import { Check, ChevronDown } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+import {
+  COLLABORATION_STATUSES,
+  getCollaborationStatusOption,
+  type CollaborationStatus,
+} from "@/features/collaboration/types";
+
+interface CollaborationStatusPickerProps {
+  value: CollaborationStatus | string;
+  onChange: (status: CollaborationStatus) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function CollaborationStatusPicker({
+  value,
+  onChange,
+  disabled = false,
+  className,
+}: CollaborationStatusPickerProps) {
+  const [open, setOpen] = useState(false);
+  const current = getCollaborationStatusOption(value);
+  const Icon = current.icon;
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm" className={cn("gap-2", className)} disabled={disabled}>
+          <span className={cn("size-2 rounded-full", current.dotClass)} aria-hidden="true" />
+          {current.label}
+          <ChevronDown className="size-3.5 opacity-60" aria-hidden="true" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-64">
+        <DropdownMenuLabel>Set collaboration status</DropdownMenuLabel>
+        <DropdownMenuRadioGroup
+          value={value}
+          onValueChange={(v) => onChange(v as CollaborationStatus)}
+        >
+          {COLLABORATION_STATUSES.map((option) => {
+            const OptionIcon = option.icon;
+            return (
+              <DropdownMenuRadioItem key={option.value} value={option.value} className="gap-2 py-2">
+                <span className={cn("size-2 rounded-full", option.dotClass)} aria-hidden="true" />
+                <OptionIcon className="size-4 text-muted-foreground" aria-hidden="true" />
+                <span className="flex flex-col">
+                  <span className="text-sm font-medium">{option.label}</span>
+                  <span className="text-xs text-muted-foreground">{option.description}</span>
+                </span>
+                {value === option.value && <Check className="ml-auto size-4" aria-hidden="true" />}
+              </DropdownMenuRadioItem>
+            );
+          })}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/frontend/src/features/collaboration/types.ts
+++ b/frontend/src/features/collaboration/types.ts
@@ -1,0 +1,67 @@
+import type { LucideIcon } from "lucide-react";
+import { CircleCheck, Code2, GitPullRequest, Search, Video } from "lucide-react";
+
+export type CollaborationStatus =
+  "coding" | "reviewing_pr" | "in_meeting" | "looking_for_project" | "available";
+
+export interface CollaborationStatusOption {
+  value: CollaborationStatus;
+  label: string;
+  description: string;
+  icon: LucideIcon;
+  /** Tailwind classes for the status dot / badge accent. */
+  dotClass: string;
+  badgeClass: string;
+}
+
+export const COLLABORATION_STATUSES: CollaborationStatusOption[] = [
+  {
+    value: "coding",
+    label: "Coding",
+    description: "Currently writing code",
+    icon: Code2,
+    dotClass: "bg-violet-500",
+    badgeClass: "text-violet-700 bg-violet-50 border-violet-200",
+  },
+  {
+    value: "reviewing_pr",
+    label: "Reviewing PR",
+    description: "Reviewing pull requests",
+    icon: GitPullRequest,
+    dotClass: "bg-blue-500",
+    badgeClass: "text-blue-700 bg-blue-50 border-blue-200",
+  },
+  {
+    value: "in_meeting",
+    label: "In meeting",
+    description: "Currently in a meeting",
+    icon: Video,
+    dotClass: "bg-amber-500",
+    badgeClass: "text-amber-700 bg-amber-50 border-amber-200",
+  },
+  {
+    value: "looking_for_project",
+    label: "Looking for project",
+    description: "Open to joining a project",
+    icon: Search,
+    dotClass: "bg-emerald-500",
+    badgeClass: "text-emerald-700 bg-emerald-50 border-emerald-200",
+  },
+  {
+    value: "available",
+    label: "Available now",
+    description: "Ready to collaborate",
+    icon: CircleCheck,
+    dotClass: "bg-green-500",
+    badgeClass: "text-green-700 bg-green-50 border-green-200",
+  },
+];
+
+const STATUS_MAP = new Map(COLLABORATION_STATUSES.map((option) => [option.value, option]));
+
+export function getCollaborationStatusOption(
+  status: CollaborationStatus | string | null | undefined,
+): CollaborationStatusOption {
+  const option = status ? STATUS_MAP.get(status as CollaborationStatus) : undefined;
+  return option ?? COLLABORATION_STATUSES[COLLABORATION_STATUSES.length - 1];
+}

--- a/frontend/src/hooks/useCollaborationStatus.ts
+++ b/frontend/src/hooks/useCollaborationStatus.ts
@@ -1,0 +1,56 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
+
+import { usersApi } from "@/api/modules/users";
+import { ws } from "@/api/ws";
+import type { CollaborationStatus } from "@/features/collaboration/types";
+
+const QUERY_KEY = ["collaboration-status", "me"];
+
+export function useCollaborationStatus() {
+  const queryClient = useQueryClient();
+
+  const query = useQuery({
+    queryKey: QUERY_KEY,
+    queryFn: () => usersApi.getCollaborationStatus(),
+    staleTime: 30_000,
+  });
+
+  const setStatusMutation = useMutation({
+    mutationFn: (status: CollaborationStatus) => usersApi.setCollaborationStatus(status),
+    onMutate: (status) => {
+      queryClient.setQueryData<{ user_id: string; status: string }>(QUERY_KEY, {
+        user_id: "",
+        status,
+      });
+      // Broadcast the change to other connected clients in real-time.
+      ws.updateCollaborationStatus(status);
+    },
+  });
+
+  // Keep the local state in sync with live broadcasts from other clients.
+  useEffect(() => {
+    return ws.on((event) => {
+      if (event.type === "presence.collaboration_status_changed") {
+        const userId =
+          typeof event.userId === "string"
+            ? event.userId
+            : typeof event.user_id === "string"
+              ? event.user_id
+              : undefined;
+        if (userId && typeof event.status === "string") {
+          queryClient.setQueryData<{ user_id: string; status: string }>(QUERY_KEY, (old) =>
+            old?.user_id === userId ? { ...old, status: event.status } : old,
+          );
+        }
+      }
+    });
+  }, [queryClient]);
+
+  return {
+    status: query.data?.status as CollaborationStatus | undefined,
+    isLoading: query.isLoading,
+    setStatus: setStatusMutation.mutate,
+    isSetting: setStatusMutation.isPending,
+  };
+}

--- a/frontend/src/mocks/seed.ts
+++ b/frontend/src/mocks/seed.ts
@@ -63,6 +63,7 @@ export interface Builder {
     title: string;
     date: string;
   }[];
+  collaborationStatus?: string;
 }
 export interface Project {
   id: ID;
@@ -233,6 +234,7 @@ export const builders: Builder[] = [
     badges: ["Top Contributor", "Social Butterfly"],
     online: true,
     bio: "Loves accessible UIs and design systems.",
+    collaborationStatus: "reviewing_pr",
     interests: ["Web Dev", "Design Systems", "AI"],
     lastActiveAt: ago(1),
     publicEmail: "priya@example.com",
@@ -288,6 +290,7 @@ export const builders: Builder[] = [
     badges: ["Active Developer"],
     online: true,
     bio: "Builds end-to-end features fast.",
+    collaborationStatus: "coding",
     interests: ["Backend", "Web Dev"],
     lastActiveAt: ago(3),
   },
@@ -304,6 +307,7 @@ export const builders: Builder[] = [
     badges: ["Project Owner", "Active Developer"],
     online: false,
     bio: "APIs, queues and Postgres tuning.",
+    collaborationStatus: "looking_for_project",
     interests: ["Backend", "AI"],
     lastActiveAt: ago(120),
   },
@@ -863,4 +867,3 @@ export const quickActions: QuickAction[] = [
   { id: "qa3", iconName: "Flame", label: "Publish flare", to: "/flares" },
   { id: "qa4", iconName: "UserPlus", label: "Invite recommended builder", to: "/builders" },
 ];
-

--- a/frontend/src/routes/_app.profile.$username.tsx
+++ b/frontend/src/routes/_app.profile.$username.tsx
@@ -36,6 +36,9 @@ import { ActivityTimeline } from "@/components/profile/ActivityTimeline";
 import { ContributionHeatmap } from "@/components/profile/ContributionHeatmap";
 import { GitHubInsights } from "@/components/github/GitHubInsights";
 import { TypoSection, TypoCaption, TypoHeading } from "@/components/shared/Typography";
+import { CollaborationStatusBadge } from "@/features/collaboration/components/CollaborationStatusBadge";
+import { CollaborationStatusPicker } from "@/features/collaboration/components/CollaborationStatusPicker";
+import { useCollaborationStatus } from "@/hooks/useCollaborationStatus";
 
 export const Route = createFileRoute("/_app/profile/$username")({
   head: ({ params }) => ({
@@ -150,6 +153,13 @@ function ProfilePage() {
   if (!b) throw notFound();
 
   const { data: followStatus } = useFollowStatus(b.id);
+
+  // Live collaboration presence status.
+  const {
+    status: myStatus,
+    setStatus: setMyStatus,
+    isLoading: isStatusLoading,
+  } = useCollaborationStatus();
 
   // Profile banner & avatar state
   const [isBannerModalOpen, setIsBannerModalOpen] = useState(false);
@@ -330,6 +340,17 @@ function ProfilePage() {
               <TypoCaption as="p">
                 @{b.handle} · {b.role}
               </TypoCaption>
+              <div className="mt-2 flex items-center gap-2">
+                {me ? (
+                  <CollaborationStatusPicker
+                    value={myStatus ?? "available"}
+                    onChange={(status) => setMyStatus(status)}
+                    disabled={isStatusLoading}
+                  />
+                ) : (
+                  <CollaborationStatusBadge status={b.collaborationStatus} />
+                )}
+              </div>
               <p className="mt-2 text-[13px] text-foreground">{b.bio}</p>
               <div className="mt-3 flex flex-wrap items-center gap-3 text-[12px] text-muted-foreground">
                 <div>
@@ -582,9 +603,7 @@ function ProfilePage() {
                       <p className="truncate text-[13px] font-semibold text-foreground hover:text-primary transition-colors">
                         {p.name}
                       </p>
-                      <TypoCaption as="p">
-                        {p.stack.join(" · ")}
-                      </TypoCaption>
+                      <TypoCaption as="p">{p.stack.join(" · ")}</TypoCaption>
                     </div>
                   </Link>
                 </li>
@@ -598,14 +617,18 @@ function ProfilePage() {
             if (githubUrl) {
               try {
                 const url = new URL(githubUrl);
-                githubUsername = url.pathname.split('/').filter(Boolean).pop();
+                githubUsername = url.pathname.split("/").filter(Boolean).pop();
               } catch (e) {
                 // Ignore invalid URLs
               }
             }
-            
+
             if (githubUsername) {
-              return <div className="mt-4"><GitHubInsights username={githubUsername} /></div>;
+              return (
+                <div className="mt-4">
+                  <GitHubInsights username={githubUsername} />
+                </div>
+              );
             }
             return <ContributionHeatmap username={b.handle} className="mt-4" />;
           })()}


### PR DESCRIPTION
## Description

Resolves **#975 — Live collaboration presence**

Users can now set a live collaboration status visible on their profile, choosing from: **Coding**, **Reviewing PR**, **In meeting**, **Looking for project**, **Available now**.

### Backend
- Adds a persistent `collaboration_status` column to the `users` table + Alembic migration (`ffff00000004`, single head).
- New `CollaborationStatus` enum + validation in `UserUpdate` / `UserBase` schemas.
- New REST endpoints: `GET /api/v1/users/me/collaboration-status` and `PUT /api/v1/users/me/collaboration-status`.
- Extends the WebSocket presence manager with `collaboration_states`, broadcasts `presence.collaboration_status_changed` to all connected clients, and adds a `collaboration_status_update` message type + `GET /collaboration-status`.

### Frontend
- `collaboration` feature module: status constants (label, description, icon, accent colors), `CollaborationStatusBadge`, `CollaborationStatusPicker`.
- `usersApi.getCollaborationStatus` / `setCollaborationStatus`, WsClient `updateCollaborationStatus` / `queryPresence`, and a `useCollaborationStatus` hook (optimistic update + live WS sync).
- Profile header: own profile shows the picker, other profiles show the status badge.

### Tests
- Backend: `test_collaboration_status.py` (get default, set, invalid 422, WS state update).
- Frontend: badge (labels, fallback, accents) + picker (open, select, disabled).
- Full frontend suite: **495 passed**; `tsc --noEmit` clean (excluding pre-existing `routeTree.gen.ts`); my files are eslint-clean.

## Screenshots

_N/A_

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Backend pytest: `test_collaboration_status.py` (4 passed).
- Frontend Vitest: 495 passed (39 files).
- Typecheck: clean outside pre-existing `routeTree.gen.ts`.
- Lint: new/modified files clean.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally