### PR TITLE
feat: add voice introduction URL to users

### DIFF
--- a/backend/alembic/versions/add_voice_introduction_url.py
+++ b/backend/alembic/versions/add_voice_introduction_url.py
@@ -1,0 +1,28 @@
+﻿"""add voice introduction url to users
+
+Revision ID: voice_intro_url_001
+Revises: ea6d6738e0ae
+Create Date: 2026-08-14
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "voice_intro_url_001"
+down_revision: Union[str, Sequence[str], None] = "ea6d6738e0ae"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("voice_introduction_url", sa.String(length=500), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "voice_introduction_url")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -159,6 +159,11 @@ class User(Base):
         nullable=True,
     )
 
+    voice_introduction_url: Mapped[str | None] = mapped_column(
+        String(500),
+        nullable=True,
+    )
+
     portfolio_url: Mapped[str | None] = mapped_column(
         String(255),
         nullable=True,
@@ -445,3 +450,5 @@ class User(Base):
 
     def __repr__(self) -> str:
         return f"<User(username='{self.username}', email='{self.email}')>"
+
+

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -41,8 +41,10 @@ from app.services.user_service import UserService
 from app.utils.uploads import (
     save_image_upload,
     save_resume_upload,
+    save_voice_introduction_upload,
     validate_image_upload,
     validate_resume_upload,
+    validate_voice_introduction_upload,
 )
 from app.utils.validators import validate_username
 
@@ -387,7 +389,7 @@ async def parse_resume(
     db: Session = Depends(get_database),
 ):
     from app.services.resume_parser_service import ResumeParserService
-    
+
     if not file.filename:
         raise HTTPException(status_code=400, detail="No file provided")
 
@@ -398,7 +400,6 @@ async def parse_resume(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     return ResumeParserService.parse_resume(contents, file.filename)
-
 
 
 @router.post(
@@ -432,6 +433,43 @@ async def upload_avatar(
     full_avatar_url = str(request.base_url).rstrip("/") + str(saved["image_url"])
     return UserService.update_profile_image(db, current_user, full_avatar_url)
 
+@router.post(
+    "/me/voice-introduction",
+    response_model=UserResponse,
+    summary="Upload user voice introduction",
+)
+async def upload_voice_introduction(
+    request: Request,
+    file: UploadFile = File(...),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_database),
+):
+    if not file.filename:
+        raise HTTPException(status_code=400, detail="No file provided")
+
+    contents = await file.read()
+
+    try:
+        validate_voice_introduction_upload(
+            file.filename,
+            file.content_type,
+            len(contents),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    voice_url = save_voice_introduction_upload(
+        contents,
+        file.filename,
+        current_user.id,
+    )
+    full_voice_url = str(request.base_url).rstrip("/") + voice_url
+
+    return UserService.update_voice_introduction_url(
+        db,
+        current_user,
+        full_voice_url,
+    )
 
 @router.delete(
     "/me",

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -80,6 +80,7 @@ class UserBase(BaseModel):
 
     website: ValidURL | None = None
     resume_url: ValidURL | None = None
+      voice_introduction_url: ValidURL | None = None
     portfolio_url: ValidURL | None = None
     github_url: ValidURL | None = None
     linkedin_url: ValidURL | None = None
@@ -145,6 +146,7 @@ class UserUpdate(BaseModel):
 
     website: ValidURL | None = None
     resume_url: ValidURL | None = None
+      voice_introduction_url: ValidURL | None = None
     portfolio_url: ValidURL | None = None
     github_url: ValidURL | None = None
     linkedin_url: ValidURL | None = None

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -516,6 +516,19 @@ class UserService:
         return user
 
     @staticmethod
+    def update_voice_introduction_url(
+        db: Session,
+        user: User,
+        voice_introduction_url: str,
+    ) -> User:
+        user.voice_introduction_url = voice_introduction_url
+
+        db.commit()
+        db.refresh(user)
+
+        return user
+
+    @staticmethod
     def create_user_report(
         db: Session,
         reporter_id: uuid.UUID,

--- a/backend/app/utils/uploads.py
+++ b/backend/app/utils/uploads.py
@@ -17,6 +17,16 @@ ALLOWED_IMAGE_MIME_TYPES: Final[set[str]] = set(
     ct.strip().lower() for ct in settings.ALLOWED_IMAGE_TYPES.split(",") if ct.strip()
 )
 
+ALLOWED_VOICE_MIME_TYPES: Final[set[str]] = {
+    "audio/mpeg",
+    "audio/mp3",
+    "audio/wav",
+    "audio/x-wav",
+    "audio/webm",
+    "audio/ogg",
+}
+
+MAX_VOICE_SIZE_BYTES: Final[int] = 10 * 1024 * 1024
 
 def scan_file_for_malware(contents: bytes, filename: str) -> None:
     """
@@ -62,6 +72,48 @@ def save_resume_upload(contents: bytes, filename: str, user_id: uuid.UUID | str)
 
     return f"/uploads/resumes/{safe_name}"
 
+def validate_voice_introduction_upload(
+    filename: str | None, content_type: str | None, size_bytes: int
+) -> None:
+    if not filename:
+        raise ValueError("Please upload an audio file.")
+
+    ext = Path(filename).suffix.lower()
+    allowed_exts = {".mp3", ".wav", ".webm", ".ogg"}
+
+    if ext not in allowed_exts:
+        raise ValueError(
+            "Unsupported audio format. Allowed: MP3, WAV, WebM, OGG."
+        )
+
+    normalized_content_type = (content_type or "").lower()
+
+    if normalized_content_type not in ALLOWED_VOICE_MIME_TYPES:
+        raise ValueError(
+            "Please upload a valid audio file."
+        )
+
+    if size_bytes > MAX_VOICE_SIZE_BYTES:
+        raise ValueError("Voice introduction must be smaller than 10MB.")
+
+
+def save_voice_introduction_upload(
+    contents: bytes,
+    filename: str,
+    user_id: uuid.UUID | str,
+) -> str:
+    scan_file_for_malware(contents, filename)
+
+    upload_dir = Path(settings.UPLOAD_DIR) / "voice_introductions"
+    upload_dir.mkdir(parents=True, exist_ok=True)
+
+    extension = Path(filename).suffix.lower()
+    safe_name = f"{user_id}-{uuid.uuid4().hex}{extension}"
+
+    destination = upload_dir / safe_name
+    destination.write_bytes(contents)
+
+    return f"/uploads/voice_introductions/{safe_name}"
 
 def validate_image_upload(
     filename: str | None, content_type: str | None, size_bytes: int


### PR DESCRIPTION
## Description

Adds support for storing a user's voice introduction URL in the User model.

This provides the backend data-layer support required for users to have an optional voice introduction associated with their profile.

Fixes #977

## Changes Made

- Added `voice_introduction_url` field to the `User` model.
- Added the corresponding field to the user schema.
- Added an Alembic migration to create the `voice_introduction_url` column in the `users` table.
- Kept the field optional (`nullable=True`) to maintain compatibility with existing users.

## Database Migration

Added migration:

`add_voice_introduction_url.py`

The migration adds:

```text
voice_introduction_url VARCHAR(500) NULL