### PR TITLE
fix(auth): reject non-access tokens as bearer credentials

### DIFF
--- a/backend/app/core/__init__.py
+++ b/backend/app/core/__init__.py
@@ -1,12 +1,15 @@
 from .config import settings
 from .logging import get_logger, logger
 from .security import (
+    InvalidTokenType,
+    TokenType,
     hash_password,
     verify_password,
     create_access_token,
     create_refresh_token,
     create_verification_token,
     is_verification_token,
+    decode_access_token,
     decode_token,
 )
 
@@ -20,5 +23,8 @@ __all__ = [
     "create_refresh_token",
     "create_verification_token",
     "is_verification_token",
+    "decode_access_token",
     "decode_token",
+    "InvalidTokenType",
+    "TokenType",
 ]

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional
 
@@ -63,8 +64,63 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
 
 
 # ------------------------------------------------------------------
+# JWT Token Types
+# ------------------------------------------------------------------
+#
+# Every token this module mints carries a `type` claim saying what it is for.
+# The claim is only worth something if the code consuming a token checks it,
+# which is what `decode_token(..., expected_type=...)` below is for.
+#
+# The distinction matters most for the pair that is deliberately asymmetric:
+# an access token is short-lived and travels on every request, a refresh token
+# is long-lived and sits in browser storage. That trade only holds while the
+# long-lived one cannot be presented as the short-lived one.
+
+
+class TokenType:
+    """The `type` claim values in use. String constants, not an Enum, so they
+    compare directly against the decoded claim without unwrapping."""
+
+    ACCESS = "access"
+    REFRESH = "refresh"
+    VERIFICATION = "verification"
+    RESET_PASSWORD = "reset_password"
+    MFA_PENDING = "mfa_pending"
+
+
+#: Historic aliases. `reset` predates `reset_password` and still appears in
+#: tokens that were issued before the rename, so it stays accepted for the
+#: password-reset flow only.
+_TOKEN_TYPE_ALIASES: Dict[str, frozenset] = {
+    TokenType.RESET_PASSWORD: frozenset({"reset_password", "reset"}),
+}
+
+
+class InvalidTokenType(ValueError):
+    """
+    Raised when a token is well-formed and correctly signed but is not the
+    kind of token the caller asked for.
+
+    Subclasses :class:`ValueError` because that is what :func:`decode_token`
+    has always raised for a token it will not accept, and every existing
+    caller either catches ``ValueError`` or catches ``Exception``. Having its
+    own type lets the places that care tell "this token is junk" apart from
+    "this is a real token, but the wrong one".
+    """
+
+
+def _accepted_types(expected_type: str) -> frozenset:
+    """The set of `type` claim values that satisfy ``expected_type``."""
+    return _TOKEN_TYPE_ALIASES.get(expected_type, frozenset({expected_type}))
+
+
+# ------------------------------------------------------------------
 # JWT Tokens
 # ------------------------------------------------------------------
+
+
+#: Claims that identify the token and may not be supplied through ``extra``.
+_RESERVED_CLAIMS = frozenset({"sub", "type", "iat", "exp"})
 
 
 def _create_token(
@@ -75,9 +131,25 @@ def _create_token(
 ) -> str:
     """
     Internal JWT token creator.
+
+    ``extra`` carries additional claims, and cannot overwrite the four the
+    creator sets itself. It previously could -- ``payload.update(extra)`` ran
+    last -- so ``create_access_token(uid, {"type": "mfa_pending"})`` was how
+    the MFA flow minted its token. Convenient, but it also meant any caller
+    could stamp ``"type": "access"`` onto a token from a flow that had no
+    business issuing one, which is precisely the confusion the type claim
+    exists to prevent. Callers that want a different type ask for it here.
     """
 
     now = datetime.now(timezone.utc)
+
+    if extra:
+        conflicting = _RESERVED_CLAIMS.intersection(extra)
+        if conflicting:
+            raise ValueError(
+                "extra may not overwrite reserved claims: "
+                + ", ".join(sorted(conflicting))
+            )
 
     payload: Dict[str, Any] = {
         "sub": subject,
@@ -107,12 +179,9 @@ def create_access_token(
     return _create_token(
         subject=user_id,
         expires_delta=timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES),
-        token_type="access",
+        token_type=TokenType.ACCESS,
         extra=extra,
     )
-
-
-import uuid
 
 
 def create_refresh_token(
@@ -125,7 +194,7 @@ def create_refresh_token(
     return _create_token(
         subject=user_id,
         expires_delta=timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS),
-        token_type="refresh",
+        token_type=TokenType.REFRESH,
         extra={"jti": str(uuid.uuid4())},
     )
 
@@ -140,18 +209,8 @@ def create_verification_token(
     return _create_token(
         subject=user_id,
         expires_delta=timedelta(hours=settings.EMAIL_VERIFICATION_TOKEN_EXPIRE_HOURS),
-        token_type="verification",
+        token_type=TokenType.VERIFICATION,
     )
-
-
-def is_verification_token(token: str) -> bool:
-    """
-    Check if token is an email verification token.
-    """
-
-    payload = decode_token(token)
-
-    return payload.get("type") == "verification"
 
 
 # ------------------------------------------------------------------
@@ -159,9 +218,34 @@ def is_verification_token(token: str) -> bool:
 # ------------------------------------------------------------------
 
 
-def decode_token(token: str) -> Dict[str, Any]:
+def decode_token(
+    token: str,
+    expected_type: Optional[str] = None,
+) -> Dict[str, Any]:
     """
-    Decode and validate JWT token.
+    Decode and validate a JWT.
+
+    Verifies the signature and expiry, and -- when ``expected_type`` is given
+    -- that the token's ``type`` claim is the kind of token the caller asked
+    for.
+
+    ``expected_type`` defaults to ``None``, meaning "any type", because a
+    handful of callers legitimately want the payload before they know what
+    they are holding (``/api/auth/refresh`` reads the claim itself, the
+    logging middleware only wants ``sub`` for attribution). Every caller that
+    is making an *authorisation* decision must pass it. Leaving it off there
+    is what let a refresh, verification or password-reset token authenticate
+    as an access token.
+
+    A token with no ``type`` claim at all is rejected whenever a type is
+    expected. Tokens predating the claim would be indistinguishable from an
+    access token otherwise, and treating an unknown token as the most
+    privileged kind is the wrong default -- worst case those tokens are
+    already past their expiry, and the recovery path is to sign in again.
+
+    Raises:
+        InvalidTokenType: correctly signed, but not ``expected_type``.
+        ValueError: malformed, expired, or not signed by us.
     """
 
     try:
@@ -171,10 +255,29 @@ def decode_token(token: str) -> Dict[str, Any]:
             algorithms=[settings.JWT_ALGORITHM],
         )
 
-        return payload
-
     except JWTError as exc:
         raise ValueError("Invalid or expired token") from exc
+
+    if expected_type is not None:
+        actual = payload.get("type")
+        if actual not in _accepted_types(expected_type):
+            raise InvalidTokenType(
+                f"Expected a {expected_type} token, got {actual or 'an untyped token'}."
+            )
+
+    return payload
+
+
+def decode_access_token(token: str) -> Dict[str, Any]:
+    """
+    Decode a token that must be an access token.
+
+    The one to reach for in an authentication dependency: it is shorter than
+    passing the constant every time, and it cannot be called without the check
+    the way ``decode_token`` can.
+    """
+
+    return decode_token(token, expected_type=TokenType.ACCESS)
 
 
 # ------------------------------------------------------------------
@@ -185,6 +288,10 @@ def decode_token(token: str) -> Dict[str, Any]:
 def get_user_id(token: str) -> Optional[str]:
     """
     Extract user ID from token.
+
+    Does not check the token type -- callers that care should decode with an
+    ``expected_type`` instead of reading the subject out of an arbitrary
+    token.
     """
 
     payload = decode_token(token)
@@ -192,14 +299,30 @@ def get_user_id(token: str) -> Optional[str]:
     return payload.get("sub")
 
 
+def _is_token_of_type(token: str, expected_type: str) -> bool:
+    """
+    Whether ``token`` is a valid token of ``expected_type``.
+
+    Returns ``False`` for a token that is expired, forged or malformed rather
+    than raising. A predicate named ``is_...`` that throws instead of
+    answering forces every call site into a try/except, and the ones that
+    forgot are the interesting ones.
+    """
+
+    try:
+        decode_token(token, expected_type=expected_type)
+    except ValueError:
+        return False
+
+    return True
+
+
 def is_access_token(token: str) -> bool:
     """
     Check if token is an access token.
     """
 
-    payload = decode_token(token)
-
-    return payload.get("type") == "access"
+    return _is_token_of_type(token, TokenType.ACCESS)
 
 
 def is_refresh_token(token: str) -> bool:
@@ -207,9 +330,15 @@ def is_refresh_token(token: str) -> bool:
     Check if token is a refresh token.
     """
 
-    payload = decode_token(token)
+    return _is_token_of_type(token, TokenType.REFRESH)
 
-    return payload.get("type") == "refresh"
+
+def is_verification_token(token: str) -> bool:
+    """
+    Check if token is an email verification token.
+    """
+
+    return _is_token_of_type(token, TokenType.VERIFICATION)
 
 
 # ------------------------------------------------------------------

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -12,7 +12,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 # pyrefly: ignore [missing-import]
 from sqlalchemy.orm import Session
 
-from app.core.security import decode_token
+from app.core.security import decode_access_token
 from app.database.session import get_db
 from app.models.user import User
 from app.services.auth_service import AuthService
@@ -34,29 +34,82 @@ def get_database():
     yield from get_db()
 
 
-def get_optional_current_user(
-    credentials: HTTPAuthorizationCredentials | None = Depends(optional_security),
-    db: Session = Depends(get_database),
-) -> User | None:
+# ---------------------------------------------------------------------
+# Credential resolution
+# ---------------------------------------------------------------------
+#
+# Two credential kinds reach these dependencies:
+#
+#   * a user's JWT access token, and
+#   * a workspace API token, which is not a JWT at all.
+#
+# Both resolve to a `User`, so the lookup is shared here rather than
+# duplicated across the required and optional variants -- the two used to be
+# near-copies of each other, and the copies had already drifted.
+
+
+def _user_from_access_token(db: Session, token: str) -> User | None:
     """
-    Returns the currently authenticated user if token is valid, else None.
+    The user behind a JWT access token, or ``None`` if this is not one.
+
+    The token type is checked, so a refresh, verification, password-reset or
+    MFA-pending token does not authenticate here. Those are all correctly
+    signed for the same subject, which is exactly why the signature check on
+    its own was not enough: without the type check, the long-lived refresh
+    token sitting in browser storage was usable as a bearer credential on
+    every endpoint, and an emailed verification or reset link was too.
     """
-    if not credentials:
+
+    try:
+        payload = decode_access_token(token)
+    except ValueError:
+        # Wrong type, expired, or not signed by us. All three mean "this is
+        # not a usable access token"; the caller decides what to do next.
+        return None
+
+    user_id = payload.get("sub")
+    if not user_id:
         return None
 
     try:
-        payload = decode_token(credentials.credentials)
-        user_id = payload.get("sub")
-        if not user_id:
-            return None
-        user_uuid = UUID(user_id)
-        auth_service = AuthService(db)
-        return auth_service.get_current_user(user_uuid)
-    except Exception:
+        user_uuid = UUID(str(user_id))
+    except (ValueError, AttributeError, TypeError):
         return None
 
+    return AuthService(db).get_current_user(user_uuid)
 
-get_current_user_optional = get_optional_current_user
+
+def _user_from_workspace_api_token(db: Session, token: str) -> User | None:
+    """
+    The user behind a workspace API token, with its scopes attached.
+
+    The scope and organisation attributes are read back by
+    ``require_org_permission`` and ``require_project_permission`` below.
+    """
+
+    from app.services.workspace_api_token_service import WorkspaceApiTokenService
+
+    token_info = WorkspaceApiTokenService.authenticate_api_token(db, token)
+    if not token_info:
+        return None
+
+    user = AuthService(db).get_current_user(token_info.created_by_id)
+    if not user:
+        return None
+
+    user._authenticated_via_token = True
+    user._token_organization_id = token_info.organization_id
+    user._token_scopes = [s.strip() for s in token_info.scopes.split(",") if s.strip()]
+
+    return user
+
+
+def _resolve_user(db: Session, token: str) -> User | None:
+    """A JWT access token first, then a workspace API token."""
+
+    return _user_from_access_token(db, token) or _user_from_workspace_api_token(
+        db, token
+    )
 
 
 # ---------------------------------------------------------------------
@@ -72,64 +125,19 @@ def get_current_user(
     Returns the currently authenticated user.
 
     Raises:
-        401 Unauthorized if token is invalid.
+        401 Unauthorized if the credential is not a valid access token or
+        workspace API token, or if it does not resolve to a user.
     """
 
-    try:
-        payload = decode_token(credentials.credentials)
+    user = _resolve_user(db, credentials.credentials)
 
-        user_id = payload.get("sub")
-
-        if not user_id:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Invalid authentication token.",
-            )
-
-        user_id = UUID(user_id)
-
-    except Exception:
-        # Try authenticating as a workspace API Token
-        from app.services.workspace_api_token_service import WorkspaceApiTokenService
-
-        token_info = WorkspaceApiTokenService.authenticate_api_token(
-            db, credentials.credentials
-        )
-        if token_info:
-            auth_service = AuthService(db)
-            user = auth_service.get_current_user(token_info.created_by_id)
-            if user:
-                user._authenticated_via_token = True
-                user._token_organization_id = token_info.organization_id
-                user._token_scopes = [
-                    s.strip() for s in token_info.scopes.split(",") if s.strip()
-                ]
-                return user
+    if not user:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Could not validate credentials.",
         )
 
-    auth_service = AuthService(db)
-
-    user = auth_service.get_current_user(user_id)
-
-    if not user:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="User not found.",
-        )
-
     return user
-
-
-def get_current_user_id(
-    current_user: User = Depends(get_current_user),
-) -> UUID:
-    """
-    Returns UUID of the currently authenticated user.
-    """
-    return current_user.id
 
 
 def get_optional_current_user(
@@ -137,35 +145,17 @@ def get_optional_current_user(
     db: Session = Depends(get_database),
 ) -> User | None:
     """
-    Returns currently authenticated user if token present, or None if unauthenticated.
+    Returns the currently authenticated user, or ``None`` when the request is
+    unauthenticated or the credential does not check out.
     """
+
     if not credentials:
         return None
-    try:
-        payload = decode_token(credentials.credentials)
-        user_id = payload.get("sub")
-        if not user_id:
-            return None
-        auth_service = AuthService(db)
-        return auth_service.get_current_user(UUID(user_id))
-    except Exception:
-        # Try authenticating as a workspace API Token
-        from app.services.workspace_api_token_service import WorkspaceApiTokenService
 
-        token_info = WorkspaceApiTokenService.authenticate_api_token(
-            db, credentials.credentials
-        )
-        if token_info:
-            auth_service = AuthService(db)
-            user = auth_service.get_current_user(token_info.created_by_id)
-            if user:
-                user._authenticated_via_token = True
-                user._token_organization_id = token_info.organization_id
-                user._token_scopes = [
-                    s.strip() for s in token_info.scopes.split(",") if s.strip()
-                ]
-                return user
-        return None
+    return _resolve_user(db, credentials.credentials)
+
+
+get_current_user_optional = get_optional_current_user
 
 
 # ---------------------------------------------------------------------
@@ -176,6 +166,12 @@ def get_optional_current_user(
 def get_current_user_id(current_user: User = Depends(get_current_user)) -> str:
     """
     Returns the currently authenticated user's ID as a string.
+
+    This used to be declared twice in this module with different return types
+    -- one annotated ``-> UUID`` returning ``current_user.id``, one annotated
+    ``-> str`` returning ``str(current_user.id)``. The second silently won, so
+    a router annotating its parameter as ``UUID`` was handed a ``str``. Every
+    call site in the tree annotates ``str``, so that is what it returns.
     """
     return str(current_user.id)
 

--- a/backend/app/middleware/activity.py
+++ b/backend/app/middleware/activity.py
@@ -39,14 +39,17 @@ class ActivityTrackingMiddleware(BaseHTTPMiddleware):
             return response
 
         # Lazy import to avoid circular imports at module level
-        from app.core.security import decode_token
+        from app.core.security import decode_access_token
 
+        # Only an access token counts as activity. A refresh call carries a
+        # refresh token, and refreshing in a background tab is not the user
+        # doing something.
         try:
-            payload = decode_token(token)
+            payload = decode_access_token(token)
             user_id = payload.get("sub")
             if not user_id:
                 return response
-        except Exception:
+        except ValueError:
             return response
 
         try:

--- a/backend/app/middleware/maintenance.py
+++ b/backend/app/middleware/maintenance.py
@@ -9,7 +9,7 @@ from cachetools import TTLCache
 
 from app.models.maintenance import MaintenanceWindow
 from app.models.user import UserRole
-from app.core.security import decode_token
+from app.core.security import decode_access_token
 
 # Cache the maintenance window state for 30 seconds
 maintenance_cache = TTLCache(maxsize=1, ttl=30)
@@ -74,11 +74,13 @@ class MaintenanceMiddleware(BaseHTTPMiddleware):
             auth_header = request.headers.get("authorization", "")
             if auth_header.startswith("Bearer "):
                 token = auth_header[7:]
+                # This is an authorisation decision -- it decides who gets past
+                # a maintenance lockout -- so the token type is checked.
                 try:
-                    payload = decode_token(token)
+                    payload = decode_access_token(token)
                     if payload and payload.get("role") == UserRole.ADMIN:
                         is_admin = True
-                except Exception:
+                except ValueError:
                     pass
 
             # If not admin, return 503

--- a/backend/app/middleware/request_logging.py
+++ b/backend/app/middleware/request_logging.py
@@ -66,12 +66,15 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         user_id = None
         auth_header = request.headers.get("authorization", "")
         if auth_header.startswith("Bearer "):
-            from app.core.security import decode_token
+            from app.core.security import decode_access_token
 
+            # Attribution only, but still access-token-only: a request bearing
+            # anything else is not an authenticated request, and logging it as
+            # one makes the request log disagree with what actually happened.
             try:
-                payload = decode_token(auth_header[7:])
+                payload = decode_access_token(auth_header[7:])
                 user_id = payload.get("sub")
-            except Exception:
+            except ValueError:
                 user_id = None
 
         try:

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -15,9 +15,10 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 import httpx
 from app.core.config import settings
 from app.core.security import (
-    decode_token,
-    is_refresh_token,
+    TokenType,
     create_verification_token,
+    decode_access_token,
+    decode_token,
 )
 
 # pyrefly: ignore [missing-import]
@@ -152,15 +153,21 @@ def get_current_user_id(
     credentials: HTTPAuthorizationCredentials = Depends(security),
 ) -> str:
     """
-    Extract the current user's ID from the JWT.
+    Extract the current user's ID from the JWT access token.
+
+    Only an access token is accepted. This dependency previously decoded
+    without checking the ``type`` claim, so a refresh token -- or the token
+    from a verification or password-reset email -- authenticated here,
+    including on the endpoints below that change the password and revoke
+    sessions.
     """
 
     try:
-        payload = decode_token(credentials.credentials)
+        payload = decode_access_token(credentials.credentials)
 
         return payload["sub"]
 
-    except Exception:
+    except (ValueError, KeyError):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid authentication credentials.",
@@ -476,16 +483,13 @@ def refresh(
     db: Session = Depends(get_database),
 ):
 
+    # Decoding with the expected type folds the signature, expiry and type
+    # checks into one pass. Previously this decoded once and then called
+    # `is_refresh_token`, which decoded the same token a second time.
     try:
-        token_payload = decode_token(payload.refresh_token)
+        decode_token(payload.refresh_token, expected_type=TokenType.REFRESH)
 
-    except Exception:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid refresh token.",
-        )
-
-    if not is_refresh_token(payload.refresh_token):
+    except ValueError:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid refresh token.",
@@ -793,11 +797,11 @@ def verify_email(
 ):
 
     try:
-        token_payload = decode_token(payload.token)
-        if token_payload.get("type") != "verification":
-            raise ValueError("Invalid verification token type.")
+        token_payload = decode_token(
+            payload.token, expected_type=TokenType.VERIFICATION
+        )
 
-    except Exception:
+    except ValueError:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid verification token.",

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -28,6 +28,8 @@ from sqlalchemy.orm import Session
 
 from app.core.events import event_bus
 from app.core.security import (
+    InvalidTokenType,
+    TokenType,
     create_access_token,
     create_refresh_token,
     hash_password,
@@ -289,9 +291,15 @@ class AuthService:
         self.db.flush()
 
         if user.mfa_enabled:
-            mfa_token = create_access_token(
-                str(user.id),
-                {"type": "mfa_pending"},
+            # Not an access token: this only gets the caller as far as
+            # `/api/auth/mfa/verify`. It used to be minted by
+            # `create_access_token` with `extra={"type": "mfa_pending"}`,
+            # relying on `extra` overwriting the type the creator had just
+            # set -- which now raises. Same lifetime, stated outright.
+            mfa_token = _create_token(
+                subject=str(user.id),
+                expires_delta=timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES),
+                token_type=TokenType.MFA_PENDING,
             )
             self.db.commit()
             return {
@@ -343,15 +351,9 @@ class AuthService:
         ip_address: Optional[str] = None,
     ):
         try:
-            payload = decode_token(mfa_token)
-            if payload.get("type") != "mfa_pending":
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="Invalid MFA session token.",
-                )
-            user_id_str = payload.get("sub")
-            user_id = UUID(user_id_str)
-        except Exception:
+            payload = decode_token(mfa_token, expected_type=TokenType.MFA_PENDING)
+            user_id = UUID(payload.get("sub"))
+        except (ValueError, TypeError):
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Invalid or expired MFA session token.",
@@ -1148,13 +1150,13 @@ class AuthService:
         from app.models.password_reset_token import PasswordResetToken
 
         try:
-            payload = decode_token(token)
-            if payload.get("type") not in ("reset", "reset_password"):
-                return {"valid": False, "message": "Invalid token type."}
+            payload = decode_token(token, expected_type=TokenType.RESET_PASSWORD)
             user_id = payload.get("sub")
             jti = payload.get("jti")
             hash_frag = payload.get("hash_frag")
-        except Exception:
+        except InvalidTokenType:
+            return {"valid": False, "message": "Invalid token type."}
+        except ValueError:
             return {"valid": False, "message": "Invalid or expired recovery token."}
 
         user = self.db.get(User, UUID(user_id)) if user_id else None
@@ -1189,13 +1191,11 @@ class AuthService:
         from app.models.password_reset_token import PasswordResetToken
 
         try:
-            payload = decode_token(token)
-            if payload.get("type") not in ("reset", "reset_password"):
-                raise ValueError("Invalid token type")
+            payload = decode_token(token, expected_type=TokenType.RESET_PASSWORD)
             user_id = payload.get("sub")
             jti = payload.get("jti")
             hash_frag = payload.get("hash_frag")
-        except Exception:
+        except ValueError:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Invalid or expired reset token.",

--- a/backend/tests/test_token_type_enforcement.py
+++ b/backend/tests/test_token_type_enforcement.py
@@ -1,0 +1,340 @@
+"""
+Token type enforcement.
+
+Every JWT this application mints carries a ``type`` claim. These tests pin
+down the thing that makes the claim worth having: that a token minted for one
+purpose cannot be presented for another.
+
+The case that matters most is the refresh token. It is deliberately
+long-lived and it lives in browser storage, and that trade is only acceptable
+while it cannot be used as a bearer credential. The same argument applies to
+the verification and password-reset tokens, both of which travel by email --
+to an address that, in the verification case, has not yet been proven to
+belong to the account holder.
+"""
+
+from datetime import timedelta
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from app.core.security import (
+    InvalidTokenType,
+    TokenType,
+    _create_token,
+    create_access_token,
+    create_refresh_token,
+    create_verification_token,
+    decode_access_token,
+    decode_token,
+    is_access_token,
+    is_refresh_token,
+    is_verification_token,
+)
+
+USER_ID = "3f1d9f5e-6a2c-4f7b-9c1e-2b8a7d4e5f60"
+
+
+def _reset_password_token(user_id: str = USER_ID) -> str:
+    return _create_token(
+        subject=user_id,
+        expires_delta=timedelta(minutes=15),
+        token_type=TokenType.RESET_PASSWORD,
+    )
+
+
+def _mfa_pending_token(user_id: str = USER_ID) -> str:
+    return _create_token(
+        subject=user_id,
+        expires_delta=timedelta(minutes=5),
+        token_type=TokenType.MFA_PENDING,
+    )
+
+
+#: Every token type that is *not* an access token, with the flow that mints it.
+NON_ACCESS_TOKENS = [
+    pytest.param(create_refresh_token, id="refresh"),
+    pytest.param(create_verification_token, id="verification"),
+    pytest.param(_reset_password_token, id="reset_password"),
+    pytest.param(_mfa_pending_token, id="mfa_pending"),
+]
+
+
+# ---------------------------------------------------------------------------
+# decode_token
+# ---------------------------------------------------------------------------
+
+
+def test_decode_token_without_expected_type_accepts_any_type():
+    """The permissive form still exists, for callers that read the claim."""
+    payload = decode_token(create_refresh_token(USER_ID))
+
+    assert payload["type"] == TokenType.REFRESH
+    assert payload["sub"] == USER_ID
+
+
+def test_decode_token_accepts_the_matching_type():
+    payload = decode_token(create_access_token(USER_ID), expected_type=TokenType.ACCESS)
+
+    assert payload["sub"] == USER_ID
+
+
+@pytest.mark.parametrize("mint", NON_ACCESS_TOKENS)
+def test_decode_access_token_rejects_every_other_type(mint):
+    """The regression this file exists for."""
+    with pytest.raises(InvalidTokenType):
+        decode_access_token(mint(USER_ID))
+
+
+def test_invalid_token_type_is_a_value_error():
+    """
+    Callers that predate the distinction catch ``ValueError``; they must keep
+    working without being changed.
+    """
+    assert issubclass(InvalidTokenType, ValueError)
+
+    with pytest.raises(ValueError):
+        decode_access_token(create_refresh_token(USER_ID))
+
+
+def test_untyped_token_is_rejected_when_a_type_is_expected():
+    """
+    A token with no ``type`` claim must not be assumed to be an access token.
+    Treating an unrecognised token as the most privileged kind is the wrong
+    way round.
+    """
+    untyped = _create_token(
+        subject=USER_ID,
+        expires_delta=timedelta(minutes=5),
+        token_type=TokenType.ACCESS,
+    )
+    # Strip the claim the way a pre-`type` token would have looked.
+    from jose import jwt
+
+    from app.core.config import settings
+
+    payload = jwt.decode(untyped, settings.SECRET_KEY, algorithms=[settings.JWT_ALGORITHM])
+    payload.pop("type")
+    stripped = jwt.encode(payload, settings.SECRET_KEY, algorithm=settings.JWT_ALGORITHM)
+
+    with pytest.raises(InvalidTokenType):
+        decode_access_token(stripped)
+
+    # ...and is still readable by the callers that do not assert a type.
+    assert decode_token(stripped)["sub"] == USER_ID
+
+
+def test_expired_token_still_raises_value_error_not_invalid_type():
+    """An expired access token is expired, not the wrong type."""
+    expired = _create_token(
+        subject=USER_ID,
+        expires_delta=timedelta(seconds=-30),
+        token_type=TokenType.ACCESS,
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        decode_access_token(expired)
+
+    assert not isinstance(excinfo.value, InvalidTokenType)
+
+
+def test_garbage_is_rejected():
+    with pytest.raises(ValueError):
+        decode_token("not-a-jwt", expected_type=TokenType.ACCESS)
+
+
+def test_reset_token_accepts_the_legacy_alias():
+    """
+    ``reset`` predates ``reset_password``. Tokens carrying the old spelling
+    are still in flight for up to 15 minutes after a deploy.
+    """
+    legacy = _create_token(
+        subject=USER_ID,
+        expires_delta=timedelta(minutes=15),
+        token_type="reset",
+    )
+
+    assert decode_token(legacy, expected_type=TokenType.RESET_PASSWORD)["sub"] == USER_ID
+
+    # The alias is one-directional: a reset token is not an access token.
+    with pytest.raises(InvalidTokenType):
+        decode_access_token(legacy)
+
+
+# ---------------------------------------------------------------------------
+# Reserved claims
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("claim", ["type", "sub", "exp", "iat"])
+def test_extra_cannot_overwrite_a_reserved_claim(claim):
+    """
+    Otherwise any flow could stamp ``"type": "access"`` onto its token and
+    walk straight past the check above.
+    """
+    with pytest.raises(ValueError, match="reserved claims"):
+        _create_token(
+            subject=USER_ID,
+            expires_delta=timedelta(minutes=5),
+            token_type=TokenType.VERIFICATION,
+            extra={claim: "access"},
+        )
+
+
+def test_extra_still_carries_ordinary_claims():
+    token = create_access_token(USER_ID, extra={"email": "dev@example.com"})
+    payload = decode_access_token(token)
+
+    assert payload["email"] == "dev@example.com"
+    assert payload["type"] == TokenType.ACCESS
+
+
+# ---------------------------------------------------------------------------
+# Predicates
+# ---------------------------------------------------------------------------
+
+
+def test_predicates_agree_with_the_minting_function():
+    access = create_access_token(USER_ID)
+    refresh = create_refresh_token(USER_ID)
+    verification = create_verification_token(USER_ID)
+
+    assert is_access_token(access) is True
+    assert is_refresh_token(access) is False
+    assert is_verification_token(access) is False
+
+    assert is_refresh_token(refresh) is True
+    assert is_access_token(refresh) is False
+
+    assert is_verification_token(verification) is True
+    assert is_access_token(verification) is False
+
+
+def test_predicates_answer_false_for_junk_rather_than_raising():
+    """
+    A predicate that throws instead of answering forces a try/except at every
+    call site, and the sites that forget are the ones that matter.
+    """
+    assert is_access_token("not-a-jwt") is False
+    assert is_refresh_token("") is False
+    assert is_verification_token("a.b.c") is False
+
+
+# ---------------------------------------------------------------------------
+# The authentication dependency
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def stored_user(db):
+    """A persisted user for the token subject to point at."""
+    from app.models.user import User
+
+    user = User(
+        first_name="Ada",
+        last_name="Lovelace",
+        username="ada_tokentype",
+        email="ada.tokentype@example.com",
+        password_hash="irrelevant_hashed",
+        is_active=True,
+        is_verified=True,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    return user
+
+
+@pytest.fixture
+def guarded_client(db):
+    """
+    A minimal app with one endpoint behind ``get_current_user``.
+
+    Mounted standalone rather than reusing the real app so the assertion is
+    about the dependency itself and not about whichever router happened to be
+    picked as a sample.
+    """
+    from app.dependencies import get_current_user, get_database
+    from app.models.user import User
+
+    app = FastAPI()
+
+    @app.get("/whoami")
+    def whoami(current_user: User = Depends(get_current_user)):
+        return {"id": str(current_user.id)}
+
+    app.dependency_overrides[get_database] = lambda: db
+
+    with TestClient(app) as client:
+        yield client
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_access_token_authenticates(guarded_client, stored_user):
+    response = guarded_client.get(
+        "/whoami", headers=_auth(create_access_token(str(stored_user.id)))
+    )
+
+    assert response.status_code == 200
+    assert response.json()["id"] == str(stored_user.id)
+
+
+@pytest.mark.parametrize("mint", NON_ACCESS_TOKENS)
+def test_non_access_tokens_do_not_authenticate(guarded_client, stored_user, mint):
+    """
+    The bug: all four of these are correctly signed for a real user, and all
+    four used to authenticate on every endpoint in the application.
+    """
+    response = guarded_client.get("/whoami", headers=_auth(mint(str(stored_user.id))))
+
+    assert response.status_code == 401
+
+
+def test_missing_credentials_are_rejected(guarded_client):
+    assert guarded_client.get("/whoami").status_code == 401
+
+
+def test_optional_user_dependency_also_rejects_non_access_tokens(db, stored_user):
+    from app.dependencies import get_database, get_optional_current_user
+    from app.models.user import User
+
+    app = FastAPI()
+
+    @app.get("/maybe")
+    def maybe(current_user: User | None = Depends(get_optional_current_user)):
+        return {"id": str(current_user.id) if current_user else None}
+
+    app.dependency_overrides[get_database] = lambda: db
+
+    with TestClient(app) as client:
+        signed_in = client.get(
+            "/maybe", headers=_auth(create_access_token(str(stored_user.id)))
+        )
+        assert signed_in.json()["id"] == str(stored_user.id)
+
+        with_refresh = client.get(
+            "/maybe", headers=_auth(create_refresh_token(str(stored_user.id)))
+        )
+        assert with_refresh.status_code == 200
+        assert with_refresh.json()["id"] is None
+
+
+def test_get_current_user_id_is_defined_once_and_returns_a_string():
+    """
+    This module used to define ``get_current_user_id`` twice, annotated
+    ``-> UUID`` and ``-> str``, with the second silently winning. Every call
+    site in the tree annotates ``str``.
+    """
+    import inspect
+
+    import app.dependencies as dependencies
+
+    source = inspect.getsource(dependencies)
+
+    assert source.count("def get_current_user_id(") == 1
+    assert source.count("def get_optional_current_user(") == 1


### PR DESCRIPTION
# Pull Request

## Summary

`get_current_user` decoded the bearer token and read `sub` without ever looking at the `type` claim. Every JWT the server signs for a user therefore authenticated on every endpoint — the refresh token, the emailed verification token, the password-reset token and the MFA-pending token.

This adds the check, in one place, and removes the two duplicated dependency definitions in the same module that were shadowing each other.

---

## Related Issue

Closes #1168

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [ ] UI/UX enhancement
- [x] Tests
- [ ] Other

---

## Changes Made

**`app/core/security.py`**

- `TokenType` constants for the five `type` values in use, so the claim is not spelled out as a bare string at each call site.
- `decode_token(token, expected_type=None)` — verifies the type when asked. `expected_type` stays optional because a few callers legitimately read the claim themselves (`/api/auth/refresh` did already), but every caller making an *authorisation* decision now passes it.
- `decode_access_token(token)` — the short form for the authentication path. It cannot be called without the check, which an optional argument can.
- `InvalidTokenType(ValueError)` — subclasses `ValueError` because that is what `decode_token` already raised for a token it would not accept, so callers catching `ValueError` keep working unchanged. Having its own type lets the reset-password flow tell "wrong kind of token" apart from "expired or forged" and report each accurately.
- A token with **no** `type` claim is rejected wherever a type is expected. Assuming an untyped token is an access token is the wrong way round; worst case those tokens are already past expiry and the recovery path is to sign in again.
- `extra=` can no longer overwrite `sub` / `type` / `iat` / `exp`.
- `is_access_token` / `is_refresh_token` / `is_verification_token` answer `False` for a junk token instead of raising. A predicate that throws instead of answering forces a `try/except` at every call site, and the sites that forget are the interesting ones.
- `reset` is kept as an accepted alias for `reset_password` — the rename predates this change and tokens with the old spelling stay in flight for 15 minutes after a deploy.

**`app/dependencies.py`**

- `get_current_user` and `get_optional_current_user` accept only `type == "access"`.
- `get_optional_current_user` and `get_current_user_id` were each **defined twice**. The second definition silently won, and the two `get_current_user_id` bodies disagreed on their return type — one annotated `-> UUID` returning `current_user.id`, one annotated `-> str` returning `str(current_user.id)`. All eight call sites in the tree annotate `str`, so that is what survives; no runtime behaviour changes.
- The JWT-then-API-token lookup that both variants had half-copied is now shared in `_resolve_user`, so the two cannot drift again.

**`app/services/auth_service.py`**

- The MFA-pending token was minted as `create_access_token(uid, {"type": "mfa_pending"})`, relying on `extra` overwriting the type the creator had just set. It now asks `_create_token` for the type it wants — same lifetime, stated outright.
- The three hand-rolled `payload.get("type") != ...` checks use the shared mechanism.

**`app/routers/auth.py`**

- The router-local `get_current_user_id` (a third copy) checks the type. It guards the endpoints that change the password and revoke sessions.
- `/refresh` decoded the token and then called `is_refresh_token`, which decoded the same token a second time. One pass now.

**Middleware**

- `maintenance.py` grants an admin bypass during a lockout — an authorisation decision, so the type is checked.
- `activity.py` and `request_logging.py` attribute a request to a user; both now count only access tokens. Refreshing in a background tab is not the user doing something.

---

## Testing

- [x] Tested locally
- [x] Existing tests pass
- [x] Added new tests
- [ ] UI verified
- [ ] Cross-browser tested (if applicable)

`backend/tests/test_token_type_enforcement.py` — 26 tests:

- each of the four non-access token types is rejected by `decode_access_token` **and** by a live endpoint behind `get_current_user` (mounted standalone, so the assertion is about the dependency and not about whichever router got picked as a sample)
- a genuine access token still authenticates
- `get_optional_current_user` returns `None` for a refresh token rather than the user
- an untyped token is rejected; an expired token raises plain `ValueError`, not `InvalidTokenType`
- `extra` cannot overwrite any reserved claim
- the predicates return `False` for junk instead of raising
- the legacy `reset` alias is accepted for password reset but not as an access token
- a guard asserting the duplicated definitions do not come back

Full backend suite before and after this branch: **the same 86 failures, an identical set** — all pre-existing on `main` (`test_rbac`, `test_websockets`, `test_tech_stack`, `test_utc_time` and others), none introduced here.

```
backend $ python -m pytest tests/test_token_type_enforcement.py tests/test_security.py tests/test_auth.py -q
45 passed
```

---

## Checklist

- [x] My code follows the project's coding standards.
- [x] I have tested my changes locally.
- [x] I have updated the documentation where necessary.
- [x] My changes do not introduce new warnings or errors.
- [x] I have reviewed my own code.
- [x] This pull request focuses on a single feature or fix.
- [x] I have linked the related issue.

---

## Additional Notes

**Behavioural change worth calling out:** any client currently sending a refresh token on a normal API call will start getting `401`. That is the point of the change, and I could not find a caller in this repo doing it — `frontend/src/api/client.ts` attaches `tokenStore.getAccess()` and only sends the refresh token to `/api/auth/refresh`. Worth a mention in release notes for anyone running an out-of-tree client.

Existing sessions are unaffected: access tokens already carry `"type": "access"`, so they keep working.
