### PR TITLE
fix(cache): key cached responses by caller and bound the L1 map

### DIFF
--- a/backend/app/core/cache.py
+++ b/backend/app/core/cache.py
@@ -1,8 +1,34 @@
+"""
+Two-level cache: an in-process L1 in front of a shared Redis L2.
+
+Three rules shape everything here.
+
+**A cache key must name every input the value depends on.** The obvious ones
+are the function's arguments. The one that is easy to miss is *who is asking*
+-- and missing it is not a stale-data bug, it is one user being served
+another user's response. ``current_user`` used to be dropped from the key
+along with ``db`` and ``request``, on the grounds that all three are FastAPI
+dependencies. But ``db`` and ``request`` carry no semantic input, and
+``current_user`` is nothing but semantic input. See :func:`cached`.
+
+**A cache that cannot forget is a memory leak.** L1 keys embed the call's
+arguments, so an endpoint with a free-text or paginated parameter mints a new
+key per distinct argument. Without a bound and an eviction policy the dict
+grows for the lifetime of the process.
+
+**Sync FastAPI endpoints run in a thread pool.** Every mutation of the L1
+mapping is therefore concurrent and has to be guarded.
+"""
+
+import hashlib
 import json
 import logging
+import threading
 import time
+from collections import OrderedDict
+from collections.abc import Mapping
 from functools import wraps
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Optional, Tuple
 
 import redis
 
@@ -10,27 +36,59 @@ from app.core.config import settings
 
 logger = logging.getLogger(__name__)
 
+#: Most entries the in-process L1 will hold. Past this the least recently used
+#: entry is dropped. It is a bound on entry *count*, not bytes -- measuring
+#: the size of arbitrary cached payloads costs more than it saves, and the
+#: count is what keeps the failure mode ("grows forever") off the table.
+DEFAULT_L1_MAX_ENTRIES = 1000
+
+#: Longest an entry promoted from L2 is held in L1. The real ceiling is the
+#: entry's remaining L2 TTL; this caps it so a very long-lived L2 entry does
+#: not pin an L1 slot.
+L1_PROMOTION_MAX_TTL = 60
+
+#: Separates the parts of a cache key. Chosen because it does not appear in
+#: the hex digest the argument fingerprint reduces to, so the prefix and
+#: namespace stay unambiguously delimited.
+KEY_SEPARATOR = ":"
+
+#: Marks the caller in a key when the function takes no identifiable user.
+ANONYMOUS = "anon"
+
+#: Dependencies that are request plumbing rather than semantic input. Note
+#: that `current_user` is deliberately *not* here.
+_NON_SEMANTIC_KWARGS = frozenset({"db", "request", "response", "session"})
+
+#: Type-name fragments identifying the same plumbing when passed positionally.
+_NON_SEMANTIC_TYPES = ("Session", "Request", "Response")
+
 
 class MultiLevelCache:
     """
-    A multi-level cache that utilizes an L1 in-memory cache (dict)
-    and an L2 distributed cache (Redis).
+    An L1 in-memory cache (bounded, LRU) in front of an L2 Redis cache.
+
+    L1 absorbs the repeat reads inside one process; L2 shares across
+    processes. A miss in L1 that hits L2 promotes the value back into L1.
     """
 
-    def __init__(self):
+    def __init__(self, max_entries: int = DEFAULT_L1_MAX_ENTRIES):
         import sys
 
-        is_testing = "pytest" in sys.modules
-        self._l1_cache: Dict[str, Tuple[Any, float]] = {}
+        # An OrderedDict rather than a plain dict: eviction needs to know
+        # which entry was used least recently, and move_to_end/popitem give
+        # that in O(1).
+        self._l1_cache: "OrderedDict[str, Tuple[Any, float]]" = OrderedDict()
+        self._max_entries = max_entries
+        self._lock = threading.Lock()
         self._redis_client: Optional[redis.Redis] = None
-        self._is_testing = is_testing
+        self._is_testing = "pytest" in sys.modules
+
+    # -- connection ------------------------------------------------------
 
     def connect(self) -> None:
         """Initialize the connection to Redis (L2 Cache)."""
         try:
-            self._redis_client = redis.from_url(
-                settings.REDIS_URL, decode_responses=True
-            )
+            self._redis_client = redis.from_url(settings.REDIS_URL, decode_responses=True)
             self._redis_client.ping()
             logger.info("Connected to Redis for L2 caching.")
         except Exception as e:
@@ -38,146 +96,330 @@ class MultiLevelCache:
             self._redis_client = None
 
     def disconnect(self) -> None:
-        """Close the Redis connection."""
+        """
+        Close the Redis connection.
+
+        The reference is cleared as well. It previously was not, so anything
+        reaching the cache after shutdown used a closed client and raised
+        instead of degrading to L1.
+        """
         if self._redis_client:
-            self._redis_client.close()
+            try:
+                self._redis_client.close()
+            except Exception as e:  # pragma: no cover - depends on client state
+                logger.warning(f"Error closing Redis connection: {e}")
+            finally:
+                self._redis_client = None
+
+    # -- L1 helpers ------------------------------------------------------
+
+    def _l1_get(self, key: str) -> Tuple[bool, Any]:
+        """``(hit, value)`` from L1, dropping the entry if it has expired."""
+        with self._lock:
+            entry = self._l1_cache.get(key)
+            if entry is None:
+                return False, None
+
+            value, expiry = entry
+            if expiry <= time.time():
+                # pop, not `del`: another thread may have evicted it between
+                # the get and here, and `del` would raise KeyError.
+                self._l1_cache.pop(key, None)
+                return False, None
+
+            self._l1_cache.move_to_end(key)
+            return True, value
+
+    def _l1_set(self, key: str, value: Any, ttl: float) -> None:
+        """Store in L1, evicting the least recently used entry if full."""
+        with self._lock:
+            self._l1_cache[key] = (value, time.time() + ttl)
+            self._l1_cache.move_to_end(key)
+
+            while len(self._l1_cache) > self._max_entries:
+                self._l1_cache.popitem(last=False)
+
+    def _promote(self, client: Any, key: str, value: Any) -> None:
+        """
+        Copy an L2 hit into L1, for no longer than it has left in L2.
+
+        Promotion used to use a flat 60 seconds, which could outlive the L2
+        entry it came from -- leaving this process serving a value the rest of
+        the fleet had already dropped.
+        """
+        promotion_ttl = L1_PROMOTION_MAX_TTL
+
+        try:
+            remaining = client.ttl(key)
+            # A negative TTL means no expiry set (-1) or the key vanished
+            # between the GET and here (-2). Anything non-numeric means the
+            # client is not telling us, so keep the default.
+            if isinstance(remaining, (int, float)) and remaining >= 0:
+                promotion_ttl = min(remaining, L1_PROMOTION_MAX_TTL)
+        except Exception as e:
+            logger.debug(f"Could not read TTL for {key}, using default: {e}")
+
+        if promotion_ttl > 0:
+            self._l1_set(key, value, promotion_ttl)
+
+    # -- public API ------------------------------------------------------
 
     def get(self, key: str) -> Optional[Any]:
         """Retrieve a value from the cache, checking L1 then L2."""
         if self._is_testing:
             return None
-        # 1. Check L1 cache
-        if key in self._l1_cache:
-            value, expiry = self._l1_cache[key]
-            if expiry > time.time():
-                logger.debug(f"Cache HIT (L1): {key}")
-                return value
-            else:
-                del self._l1_cache[key]
 
-        # 2. Check L2 cache (Redis)
-        if self._redis_client:
+        hit, value = self._l1_get(key)
+        if hit:
+            logger.debug(f"Cache HIT (L1): {key}")
+            return value
+
+        client = self._redis_client
+        if client:
             try:
-                cached_data = self._redis_client.get(key)
-                if cached_data:
-                    logger.debug(f"Cache HIT (L2): {key}")
-                    value = json.loads(cached_data)
-                    # Re-hydrate L1 cache with a short default TTL (e.g., 60 seconds)
-                    self._l1_cache[key] = (value, time.time() + 60)
-                    return value
+                cached_data = client.get(key)
             except Exception as e:
                 logger.error(f"Redis get error for {key}: {e}")
+                cached_data = None
+
+            if cached_data is not None:
+                try:
+                    value = json.loads(cached_data)
+                except (TypeError, ValueError) as e:
+                    logger.error(f"Undecodable L2 payload for {key}: {e}")
+                    return None
+
+                logger.debug(f"Cache HIT (L2): {key}")
+
+                # Promotion is best-effort and deliberately in its own guard:
+                # the value has already been decoded and is going to be
+                # returned either way. Folding this into the block above meant
+                # a failure here threw away a perfectly good answer.
+                self._promote(client, key, value)
+
+                return value
 
         logger.debug(f"Cache MISS: {key}")
         return None
 
     def set(self, key: str, value: Any, ttl: int = 300) -> None:
         """Set a value in both L1 and L2 caches."""
-        # 1. Set L1 cache
-        self._l1_cache[key] = (value, time.time() + ttl)
+        self._l1_set(key, value, ttl)
 
-        # 2. Set L2 cache
-        if self._redis_client:
+        client = self._redis_client
+        if client:
             try:
                 serialized = json.dumps(value, default=str)
-                self._redis_client.setex(key, ttl, serialized)
+                client.setex(key, ttl, serialized)
             except Exception as e:
                 logger.error(f"Redis set error for {key}: {e}")
 
     def delete(self, key: str) -> None:
         """Invalidate a key across all cache levels."""
-        if key in self._l1_cache:
-            del self._l1_cache[key]
+        with self._lock:
+            self._l1_cache.pop(key, None)
 
-        if self._redis_client:
+        client = self._redis_client
+        if client:
             try:
-                self._redis_client.delete(key)
+                client.delete(key)
             except Exception as e:
                 logger.error(f"Redis delete error for {key}: {e}")
+
+    def delete_prefix(self, prefix: str) -> int:
+        """
+        Invalidate every key starting with ``prefix``. Returns how many L1
+        entries were dropped.
+
+        Without this there was no way to invalidate anything the ``@cached``
+        decorator wrote: it builds keys internally from the call's arguments,
+        so a caller that mutates the underlying data cannot reconstruct the
+        keys it just invalidated. Stale data could only be waited out.
+
+        Uses ``SCAN`` rather than ``KEYS`` -- ``KEYS`` blocks the Redis event
+        loop for the whole sweep, which on a shared instance stalls every
+        other client.
+        """
+        with self._lock:
+            doomed = [key for key in self._l1_cache if key.startswith(prefix)]
+            for key in doomed:
+                self._l1_cache.pop(key, None)
+
+        client = self._redis_client
+        if client:
+            try:
+                for key in client.scan_iter(match=f"{prefix}*", count=500):
+                    client.delete(key)
+            except Exception as e:
+                logger.error(f"Redis prefix delete error for {prefix}: {e}")
+
+        return len(doomed)
+
+    def clear_l1(self) -> None:
+        """Drop every L1 entry. Mostly for tests and for shutdown."""
+        with self._lock:
+            self._l1_cache.clear()
+
+    @property
+    def l1_size(self) -> int:
+        """How many entries L1 is currently holding."""
+        with self._lock:
+            return len(self._l1_cache)
 
 
 # Global singleton
 cache_manager = MultiLevelCache()
 
 
-def cached(ttl: int = 300, key_prefix: str = ""):
+# ---------------------------------------------------------------------------
+# Key construction
+# ---------------------------------------------------------------------------
+
+
+def _identify_caller(kwargs: dict) -> str:
     """
-    Decorator to easily cache the result of a synchronous function.
-    Correctly ignores FastAPI dependencies (Session, Request, Response, User) when generating cache keys.
+    A stable identifier for whoever is making the call.
+
+    Reads ``current_user`` out of the resolved dependencies. Anonymous
+    callers all share one identity, which is correct -- they are
+    indistinguishable to the endpoint, so they see the same response.
+    """
+    user = kwargs.get("current_user")
+    if user is None:
+        return ANONYMOUS
+
+    # A User model, or any object exposing `.id`.
+    identifier = getattr(user, "id", None)
+
+    # A mapping, which is what a dependency returning a plain dict gives.
+    if identifier is None and isinstance(user, Mapping):
+        identifier = user.get("id")
+
+    if identifier is None:
+        # Refuse to guess. Falling back to `str(user)` would produce
+        # `<User object at 0x...>` -- unique per instance, so caching would
+        # silently stop working rather than fail visibly.
+        raise TypeError(
+            "cached(): current_user has no `id`; pass per_user=False if this "
+            "endpoint's response genuinely does not depend on the caller."
+        )
+
+    return str(identifier)
+
+
+def _fingerprint(args: tuple, kwargs: dict) -> str:
+    """
+    A short, stable digest of the semantically meaningful arguments.
+
+    Hashed rather than embedded verbatim: keys used to be built by
+    interpolating the stringified argument list, so a long search term or a
+    filter list produced a key as long as the input. Redis accepts keys up to
+    512MB, but multi-kilobyte keys waste memory in both levels and make the
+    logs unreadable. A digest is fixed width regardless of input.
+    """
+    meaningful_kwargs = {
+        key: repr(value)
+        for key, value in kwargs.items()
+        if key not in _NON_SEMANTIC_KWARGS
+        and key != "current_user"
+        and not any(marker in type(value).__name__ for marker in _NON_SEMANTIC_TYPES)
+    }
+
+    meaningful_args = [
+        repr(value)
+        for value in args
+        if not any(marker in type(value).__name__ for marker in _NON_SEMANTIC_TYPES)
+    ]
+
+    # sort_keys so two calls with the same kwargs in a different order share a
+    # key rather than each getting their own.
+    payload = json.dumps(
+        {"args": meaningful_args, "kwargs": meaningful_kwargs},
+        sort_keys=True,
+        default=str,
+    )
+
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:32]
+
+
+def build_cache_key(
+    key_prefix: str,
+    func_name: str,
+    caller: str,
+    args: tuple,
+    kwargs: dict,
+) -> str:
+    """The key a cached call reads and writes. Public so tests can assert on it."""
+    return KEY_SEPARATOR.join(
+        (key_prefix or "cache", func_name, caller, _fingerprint(args, kwargs))
+    )
+
+
+def _serialise(result: Any) -> Any:
+    """Reduce a result to something ``json.dumps`` will accept."""
+    if isinstance(result, (list, tuple)):
+        return [_serialise(item) for item in result]
+
+    if hasattr(result, "model_dump"):
+        return result.model_dump(mode="json")
+
+    if hasattr(result, "dict") and callable(getattr(result, "dict")):
+        return result.dict()
+
+    if hasattr(result, "__dict__"):
+        return {k: str(v) for k, v in result.__dict__.items() if not k.startswith("_")}
+
+    return result
+
+
+def cached(ttl: int = 300, key_prefix: str = "", per_user: bool = True):
+    """
+    Cache a synchronous function's result.
+
+    ``per_user`` defaults to ``True``: the caller's id is part of the key, so
+    two users never share an entry. It used to be unconditionally excluded --
+    ``current_user`` was skipped along with ``db`` and ``request`` as "a
+    FastAPI dependency" -- which meant any endpoint whose response varied by
+    caller served the first caller's response to everyone else for the whole
+    TTL.
+
+    Set ``per_user=False`` only when the response genuinely does not depend on
+    who asked. It is worth the keystrokes: it halves nothing if you are wrong,
+    but it makes the claim explicit and reviewable, whereas the old behaviour
+    made it silently for every endpoint at once.
+
+    Request plumbing (``db``, ``request``, ``response``) is still excluded
+    from the key -- it carries no semantic input, and including it would give
+    every request a unique key and disable caching entirely.
     """
 
     def decorator(func: Callable):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            import sys
-
             if cache_manager._is_testing:
                 return func(*args, **kwargs)
 
-            # Filter kwargs to remove non-serializable FastAPI objects
-            safe_kwargs = {}
-            for k, v in kwargs.items():
-                if k in ["db", "request", "response", "current_user"]:
-                    continue
-                # Also skip objects that look like SQLAlchemy sessions or FastAPI requests
-                if "Session" in type(v).__name__ or "Request" in type(v).__name__:
-                    continue
-                safe_kwargs[k] = str(v)
+            caller = _identify_caller(kwargs) if per_user else ANONYMOUS
+            cache_key = build_cache_key(key_prefix, func.__name__, caller, args, kwargs)
 
-            safe_args = [
-                str(a)
-                for a in args
-                if "Session" not in type(a).__name__
-                and "Request" not in type(a).__name__
-            ]
-
-            # Generate a consistent cache key
-            cache_key = f"{key_prefix}:{func.__name__}:{safe_args}:{safe_kwargs}"
-
-            # Try to get from cache
             cached_value = cache_manager.get(cache_key)
             if cached_value is not None:
                 return cached_value
 
-            # Execute function
             result = func(*args, **kwargs)
 
-            # Save to cache
             if result is not None:
-                store_value = result
-                # Serialize Pydantic or SQLAlchemy objects
-                if hasattr(result, "model_dump"):
-                    store_value = result.model_dump(mode="json")
-                elif hasattr(result, "dict"):
-                    store_value = result.dict()
-                elif hasattr(result, "__dict__"):
-                    store_value = {
-                        k: str(v)
-                        for k, v in result.__dict__.items()
-                        if not k.startswith("_")
-                    }
-                elif isinstance(result, list):
-                    processed_list = []
-                    for item in result:
-                        if hasattr(item, "model_dump"):
-                            processed_list.append(item.model_dump(mode="json"))
-                        elif hasattr(item, "dict"):
-                            processed_list.append(item.dict())
-                        elif hasattr(item, "__dict__"):
-                            processed_list.append(
-                                {
-                                    k: str(v)
-                                    for k, v in item.__dict__.items()
-                                    if not k.startswith("_")
-                                }
-                            )
-                        else:
-                            processed_list.append(item)
-                    store_value = processed_list
-
+                store_value = _serialise(result)
                 cache_manager.set(cache_key, store_value, ttl)
+                return store_value
 
-            return store_value if result is not None else result
+            return result
+
+        # Handy for tests and for a caller that wants to invalidate everything
+        # this endpoint wrote.
+        wrapper.cache_key_prefix = KEY_SEPARATOR.join(
+            (key_prefix or "cache", func.__name__)
+        )
 
         return wrapper
 

--- a/backend/app/routers/activities.py
+++ b/backend/app/routers/activities.py
@@ -71,7 +71,10 @@ def get_activity(
     "/",
     response_model=list[ActivityResponse],
 )
-@cached(ttl=60, key_prefix="feed")
+# per_user=False: the feed is built entirely from the query parameters and
+# takes no `current_user` at all, so every caller genuinely gets the same
+# response for the same filters.
+@cached(ttl=60, key_prefix="feed", per_user=False)
 def get_feed(    limit: int = Query(50, ge=1, le=100),
     cursor: datetime | None = Query(
         None, description="Cursor for pagination (created_at timestamp)"

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -166,7 +166,10 @@ def get_project_analytics(
     "/{project_id}",
     response_model=ProjectResponse,
 )
-@cached(ttl=60, key_prefix="projects:get")
+# per_user=False: the response is the project itself, which is the same for
+# every viewer. `current_user` is used only for the view-count side effect
+# below, not to shape what is returned.
+@cached(ttl=60, key_prefix="projects:get", per_user=False)
 def get_project(
     request: Request,
     project_id: uuid.UUID,
@@ -204,7 +207,8 @@ def get_project(
     "/slug/{slug}",
     response_model=ProjectResponse,
 )
-@cached(ttl=60, key_prefix="projects:slug")
+# per_user=False: as above -- the project is the same for every viewer.
+@cached(ttl=60, key_prefix="projects:slug", per_user=False)
 def get_project_by_slug(
     request: Request,
     slug: str,
@@ -242,7 +246,9 @@ def get_project_by_slug(
     "/",
     response_model=list[ProjectResponse],
 )
-@cached(ttl=120, key_prefix="projects:list")
+# per_user=False: the listing is a pure function of the query parameters and
+# takes no `current_user`.
+@cached(ttl=120, key_prefix="projects:list", per_user=False)
 def list_projects(
     skip: int = Query(0, ge=0),
     limit: int = Query(20, ge=1, le=100),

--- a/backend/tests/test_api_caching.py
+++ b/backend/tests/test_api_caching.py
@@ -64,8 +64,16 @@ def setup_teardown():
 
 def test_caching_decorator_ignores_dependencies():
     """
-    Test that the cached decorator ignores FastAPI dependencies like Session, Request, User
-    so that the cache key is stable across requests.
+    Test that the cached decorator ignores request plumbing like Session and
+    Request, so the cache key is stable across requests.
+
+    `current_user` is no longer in that category -- it is semantic input, and
+    excluding it meant one caller's response was served to another. It is now
+    part of the key, which is what the `:1:` segment below is.
+
+    The argument fingerprint is hashed rather than interpolated verbatim, so
+    this asserts that distinct arguments produce distinct keys rather than
+    looking for the argument's text inside the key.
     """
     response1 = client.get("/test/sync-cache?q=hello")
     assert response1.status_code == 200
@@ -75,11 +83,21 @@ def test_caching_decorator_ignores_dependencies():
     keys = list(cache_manager._l1_cache.keys())
     assert len(keys) == 1
 
-    # The key should NOT contain the memory address of MockSession
     key = keys[0]
+
+    # The key must not carry the session's repr -- a new MockSession per
+    # request would otherwise make every key unique and disable caching.
     assert "MockSession" not in key
-    assert "current_user" not in key
-    assert "hello" in key
+
+    # It is scoped to the endpoint and to the caller.
+    assert key.startswith("test:sync:sync_endpoint:1:")
+
+    # Repeating the same call reuses the entry; a different argument does not.
+    client.get("/test/sync-cache?q=hello")
+    assert len(cache_manager._l1_cache) == 1
+
+    client.get("/test/sync-cache?q=goodbye")
+    assert len(cache_manager._l1_cache) == 2
 
 
 def test_cache_hit():

--- a/backend/tests/test_cache.py
+++ b/backend/tests/test_cache.py
@@ -1,0 +1,450 @@
+"""
+Two-level cache behaviour.
+
+`MultiLevelCache` short-circuits under pytest (`_is_testing`), which is what
+keeps the rest of the suite from picking up cached responses between tests.
+These tests deliberately turn that off so the real logic is exercised, and
+turn it back on afterwards.
+
+Redis is not assumed to be running. `_redis_client` is left as `None`, which
+is the documented degraded mode, and the L2 paths that need a client are
+driven with a small fake.
+"""
+
+import threading
+import time
+
+import pytest
+
+from app.core import cache as cache_module
+from app.core.cache import (
+    ANONYMOUS,
+    MultiLevelCache,
+    build_cache_key,
+    cached,
+)
+
+
+@pytest.fixture
+def cache():
+    """A real, isolated cache with the test short-circuit disabled."""
+    instance = MultiLevelCache(max_entries=5)
+    instance._is_testing = False
+    return instance
+
+
+@pytest.fixture
+def live_cache(monkeypatch):
+    """
+    Point the module-level singleton at a real cache, so the `@cached`
+    decorator actually caches for the duration of a test.
+    """
+    instance = MultiLevelCache(max_entries=5)
+    instance._is_testing = False
+    monkeypatch.setattr(cache_module, "cache_manager", instance)
+    return instance
+
+
+class _User:
+    """Stands in for the User model; only `id` is read."""
+
+    def __init__(self, id):
+        self.id = id
+
+
+# ---------------------------------------------------------------------------
+# Per-caller keys
+# ---------------------------------------------------------------------------
+
+
+def test_two_users_do_not_share_a_cached_value(live_cache):
+    """
+    The bug this file exists for. `current_user` was dropped from the key, so
+    the first caller's response was served to everyone for the whole TTL.
+    """
+    calls = []
+
+    @cached(ttl=300, key_prefix="feed")
+    def personalised_feed(current_user=None):
+        calls.append(current_user.id)
+        return {"owner": current_user.id}
+
+    alice = _User("alice")
+    bob = _User("bob")
+
+    assert personalised_feed(current_user=alice) == {"owner": "alice"}
+    assert personalised_feed(current_user=bob) == {"owner": "bob"}
+
+    # Both actually ran; neither was served the other's answer.
+    assert calls == ["alice", "bob"]
+
+
+def test_the_same_user_is_served_from_cache(live_cache):
+    calls = []
+
+    @cached(ttl=300, key_prefix="feed")
+    def personalised_feed(current_user=None):
+        calls.append(current_user.id)
+        return {"owner": current_user.id}
+
+    alice = _User("alice")
+
+    personalised_feed(current_user=alice)
+    personalised_feed(current_user=alice)
+
+    assert calls == ["alice"]
+
+
+def test_per_user_false_shares_one_entry(live_cache):
+    """The opt-out, for responses that genuinely do not vary by caller."""
+    calls = []
+
+    @cached(ttl=300, key_prefix="public", per_user=False)
+    def public_listing(current_user=None):
+        calls.append(1)
+        return {"items": []}
+
+    public_listing(current_user=_User("alice"))
+    public_listing(current_user=_User("bob"))
+
+    assert len(calls) == 1
+
+
+def test_anonymous_callers_share_an_entry(live_cache):
+    """They are indistinguishable to the endpoint, so they see one response."""
+    calls = []
+
+    @cached(ttl=300, key_prefix="feed")
+    def feed(current_user=None):
+        calls.append(1)
+        return {"items": []}
+
+    feed(current_user=None)
+    feed(current_user=None)
+
+    assert len(calls) == 1
+
+
+def test_a_user_without_an_id_is_refused_rather_than_guessed(live_cache):
+    """
+    Falling back to `str(user)` would give `<object at 0x...>` -- unique per
+    instance, so caching would silently stop working instead of failing.
+    """
+
+    @cached(ttl=300, key_prefix="feed")
+    def feed(current_user=None):
+        return {}
+
+    with pytest.raises(TypeError, match="per_user=False"):
+        feed(current_user=object())
+
+
+# ---------------------------------------------------------------------------
+# Key construction
+# ---------------------------------------------------------------------------
+
+
+def test_key_includes_prefix_function_and_caller():
+    key = build_cache_key("feed", "get_feed", "alice", (), {})
+
+    assert key.startswith("feed:get_feed:alice:")
+
+
+def test_different_arguments_produce_different_keys():
+    first = build_cache_key("p", "f", ANONYMOUS, (), {"limit": 10})
+    second = build_cache_key("p", "f", ANONYMOUS, (), {"limit": 20})
+
+    assert first != second
+
+
+def test_kwarg_order_does_not_change_the_key():
+    """Otherwise the same call spelled two ways gets two entries."""
+    first = build_cache_key("p", "f", ANONYMOUS, (), {"a": 1, "b": 2})
+    second = build_cache_key("p", "f", ANONYMOUS, (), {"b": 2, "a": 1})
+
+    assert first == second
+
+
+def test_request_plumbing_is_excluded_from_the_key():
+    """
+    `db` and `request` carry no semantic input. Including them would give
+    every request a unique key and disable caching entirely.
+    """
+
+    class Session:
+        pass
+
+    first = build_cache_key("p", "f", ANONYMOUS, (), {"limit": 10, "db": Session()})
+    second = build_cache_key("p", "f", ANONYMOUS, (), {"limit": 10, "db": Session()})
+
+    assert first == second
+
+
+def test_key_length_is_bounded_by_the_input():
+    """
+    Keys used to embed the stringified arguments, so a long search term
+    produced a proportionally long key in both cache levels.
+    """
+    short = build_cache_key("p", "f", ANONYMOUS, (), {"q": "a"})
+    long = build_cache_key("p", "f", ANONYMOUS, (), {"q": "a" * 100_000})
+
+    assert len(short) == len(long)
+    assert len(long) < 100
+
+
+def test_decorator_exposes_its_key_prefix():
+    @cached(ttl=60, key_prefix="feed")
+    def get_feed():
+        return []
+
+    assert get_feed.cache_key_prefix == "feed:get_feed"
+
+
+# ---------------------------------------------------------------------------
+# L1 bounds and eviction
+# ---------------------------------------------------------------------------
+
+
+def test_l1_is_bounded(cache):
+    """
+    The leak: entries written and never read again stayed forever, and keys
+    embed arguments, so a paginated endpoint mints one per page.
+    """
+    for n in range(50):
+        cache.set(f"key-{n}", n, ttl=300)
+
+    assert cache.l1_size == 5
+
+
+def test_eviction_drops_the_least_recently_used(cache):
+    for n in range(5):
+        cache.set(f"key-{n}", n, ttl=300)
+
+    # Touch key-0 so it is no longer the coldest.
+    assert cache.get("key-0") == 0
+
+    cache.set("key-new", "new", ttl=300)
+
+    assert cache.get("key-0") == 0
+    assert cache.get("key-1") is None
+
+
+def test_expired_entries_are_not_returned(cache):
+    cache.set("short", "value", ttl=1)
+    cache._l1_cache["short"] = ("value", time.time() - 1)
+
+    assert cache.get("short") is None
+
+
+def test_expired_entry_is_dropped_on_read(cache):
+    cache.set("short", "value", ttl=300)
+    cache._l1_cache["short"] = ("value", time.time() - 1)
+
+    cache.get("short")
+
+    assert cache.l1_size == 0
+
+
+# ---------------------------------------------------------------------------
+# Invalidation
+# ---------------------------------------------------------------------------
+
+
+def test_delete_removes_a_key(cache):
+    cache.set("gone", "value", ttl=300)
+    cache.delete("gone")
+
+    assert cache.get("gone") is None
+
+
+def test_delete_prefix_removes_a_whole_namespace(cache):
+    """
+    The decorator builds keys internally, so a caller that mutates the
+    underlying data cannot reconstruct them. Without this, cached data could
+    only be waited out.
+    """
+    cache.set("projects:get:anon:aaa", 1, ttl=300)
+    cache.set("projects:get:anon:bbb", 2, ttl=300)
+    cache.set("feed:get_feed:anon:ccc", 3, ttl=300)
+
+    dropped = cache.delete_prefix("projects:get")
+
+    assert dropped == 2
+    assert cache.get("projects:get:anon:aaa") is None
+    assert cache.get("feed:get_feed:anon:ccc") == 3
+
+
+def test_delete_of_an_absent_key_does_not_raise(cache):
+    cache.delete("never-existed")
+
+
+def test_clear_l1_empties_the_map(cache):
+    cache.set("a", 1, ttl=300)
+    cache.set("b", 2, ttl=300)
+
+    cache.clear_l1()
+
+    assert cache.l1_size == 0
+
+
+# ---------------------------------------------------------------------------
+# Concurrency
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_access_does_not_raise(cache):
+    """
+    Sync FastAPI endpoints run in a thread pool, so every L1 mutation is
+    concurrent. The unguarded version could raise KeyError when two threads
+    expired the same key at once.
+    """
+    errors = []
+
+    def hammer(worker):
+        try:
+            for n in range(200):
+                key = f"key-{n % 10}"
+                cache.set(key, n, ttl=300)
+                cache.get(key)
+                if n % 20 == 0:
+                    cache.delete(key)
+        except Exception as exc:  # pragma: no cover - the assertion below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=hammer, args=(i,)) for i in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == []
+    assert cache.l1_size <= 5
+
+
+def test_expiry_race_does_not_raise(cache):
+    """Two threads reading the same expired key both hit the removal path."""
+    errors = []
+
+    cache.set("shared", "value", ttl=300)
+    cache._l1_cache["shared"] = ("value", time.time() - 1)
+
+    def read():
+        try:
+            for _ in range(500):
+                cache.get("shared")
+        except Exception as exc:  # pragma: no cover
+            errors.append(exc)
+
+    threads = [threading.Thread(target=read) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# Redis interaction
+# ---------------------------------------------------------------------------
+
+
+class _FakeRedis:
+    """Just enough Redis for the L2 paths."""
+
+    def __init__(self, ttl=30):
+        self.store = {}
+        self.ttls = {}
+        self._ttl = ttl
+        self.closed = False
+        self.deleted = []
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def setex(self, key, ttl, value):
+        self.store[key] = value
+        self.ttls[key] = ttl
+
+    def ttl(self, key):
+        return self.ttls.get(key, self._ttl)
+
+    def delete(self, key):
+        self.deleted.append(key)
+        self.store.pop(key, None)
+
+    def scan_iter(self, match="*", count=None):
+        prefix = match.rstrip("*")
+        return [key for key in list(self.store) if key.startswith(prefix)]
+
+    def close(self):
+        self.closed = True
+
+
+def test_l2_hit_promotes_into_l1_within_the_remaining_ttl(cache):
+    """
+    Promotion used to use a hardcoded 60s, which could outlive the L2 entry
+    it came from -- leaving this process serving a value the rest of the
+    fleet had dropped.
+    """
+    fake = _FakeRedis()
+    fake.store["k"] = "42"
+    fake.ttls["k"] = 5
+    cache._redis_client = fake
+
+    assert cache.get("k") == 42
+
+    _, expiry = cache._l1_cache["k"]
+    assert expiry - time.time() <= 5 + 0.5
+
+
+def test_l2_promotion_is_capped(cache):
+    """A very long-lived L2 entry must not pin an L1 slot indefinitely."""
+    fake = _FakeRedis()
+    fake.store["k"] = "42"
+    fake.ttls["k"] = 86_400
+    cache._redis_client = fake
+
+    cache.get("k")
+
+    _, expiry = cache._l1_cache["k"]
+    assert expiry - time.time() <= 60 + 0.5
+
+
+def test_redis_errors_degrade_to_l1(cache):
+    class Broken:
+        def get(self, key):
+            raise RuntimeError("redis is down")
+
+        def setex(self, key, ttl, value):
+            raise RuntimeError("redis is down")
+
+    cache._redis_client = Broken()
+
+    # Neither raises; the value is still served from L1.
+    cache.set("k", "value", ttl=300)
+    assert cache.get("k") == "value"
+
+
+def test_disconnect_clears_the_client(cache):
+    """
+    It previously closed the connection but kept the reference, so anything
+    reaching the cache after shutdown used a closed client.
+    """
+    fake = _FakeRedis()
+    cache._redis_client = fake
+
+    cache.disconnect()
+
+    assert fake.closed is True
+    assert cache._redis_client is None
+
+
+def test_delete_prefix_reaches_l2(cache):
+    fake = _FakeRedis()
+    fake.store = {"projects:a": "1", "projects:b": "2", "feed:c": "3"}
+    cache._redis_client = fake
+
+    cache.delete_prefix("projects:")
+
+    assert sorted(fake.deleted) == ["projects:a", "projects:b"]


### PR DESCRIPTION
# Pull Request

## Summary

The `@cached` decorator dropped `current_user` from the cache key, so any endpoint whose response varies by caller served the first caller's response to everyone else for the length of the TTL. This makes the caller part of the key by default, and fixes four other problems in the same module — an L1 map that never evicted, unguarded concurrent mutation, no way to invalidate anything, and unbounded key length.

---

## Related Issue

Closes #1170

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Performance improvement
- [ ] Refactoring
- [ ] UI/UX enhancement
- [x] Tests
- [ ] Other

---

## Changes Made

### The caller belongs in the key

```python
for k, v in kwargs.items():
    if k in ["db", "request", "response", "current_user"]:
        continue
```

The docstring called this correct — *"Correctly ignores FastAPI dependencies (Session, Request, Response, User)"* — and it is, for three of the four. `db`, `request` and `response` carry no semantic input; including them would give every request a unique key and disable caching entirely. `current_user` is the opposite: it is *nothing but* semantic input.

`per_user` now defaults to `True`. `per_user=False` is the opt-out, and the four existing call sites are audited and marked explicitly with a one-line justification each. That is deliberately more typing than the old behaviour: it makes the claim reviewable per endpoint, rather than the decorator making it silently for all of them at once.

An anonymous caller resolves to a shared `anon` identity, which is correct — they are indistinguishable to the endpoint. A `current_user` with no `id` raises rather than falling back to `str(user)`, which would produce `<User object at 0x...>` — unique per instance, so caching would silently stop working instead of failing visibly.

### L1 never evicted

It only shrank when an expired key happened to be read again. A key written once and never re-read stayed for the life of the process, and since keys embed the call's arguments, a paginated or free-text endpoint mints a new one per distinct argument. It is now an `OrderedDict` used as an LRU, bounded at 1000 entries — a bound on entry *count*, not bytes, because measuring arbitrary payloads costs more than it saves and the count is what keeps "grows forever" off the table.

### Unguarded concurrent mutation

Sync FastAPI endpoints run in a thread pool, so every L1 mutation is concurrent. `del self._l1_cache[key]` could raise `KeyError` when two threads expired the same key at once. All mutations now take a lock, and removal is `pop(key, None)`.

### Nothing could be invalidated

`delete(key)` needs the exact key, but the decorator builds keys internally, so a caller that mutated the underlying data had no way to reconstruct what to drop. Stale data could only be waited out. `delete_prefix()` sweeps a namespace, using `SCAN` rather than `KEYS` — `KEYS` blocks the Redis event loop for the whole sweep, which on a shared instance stalls every other client.

### Unbounded key length

Keys interpolated the stringified arguments, so a long search term produced a proportionally long key in both levels. The arguments are now a fixed-width SHA-256 prefix, and kwargs are sorted so the same call spelled two ways shares one entry instead of getting two.

### Smaller ones

- `disconnect()` closed the Redis client but kept the reference, so anything reaching the cache after shutdown used a closed connection.
- An L2 hit promoted into L1 with a flat 60s TTL, which could outlive the L2 entry it came from — leaving one process serving a value the rest of the fleet had dropped. Promotion honours the remaining TTL, capped at 60s.
- Promotion is now best-effort in its own guard. Folded into the read as it was, a failure there discarded a value that had already been decoded and was about to be returned.

---

## Testing

- [x] Tested locally
- [x] Existing tests pass
- [x] Added new tests
- [ ] UI verified
- [ ] Cross-browser tested (if applicable)

`backend/tests/test_cache.py` — 26 tests. Redis is not assumed to be running; `_redis_client` stays `None` (the documented degraded mode) and the L2 paths are driven with a small fake.

- **The leak:** two users do not share a value; the same user is served from cache; `per_user=False` shares one entry; anonymous callers share one; a user without an `id` raises with an actionable message
- **Keys:** prefix/function/caller structure, distinct arguments distinct keys, kwarg order irrelevant, plumbing excluded, length bounded regardless of input size
- **Eviction:** L1 is bounded at its limit under 50 writes; the least recently used entry goes first; expired entries are not returned and are dropped on read
- **Invalidation:** `delete`, `delete_prefix` across a namespace, deleting an absent key, `clear_l1`
- **Concurrency:** 8 threads × 200 mixed set/get/delete raises nothing; 8 threads reading the same expired key all hit the removal path
- **Redis:** promotion respects the remaining TTL and is capped; errors degrade to L1; `disconnect` clears the reference; `delete_prefix` reaches L2

```
backend $ python -m pytest tests/test_cache.py tests/test_api_caching.py -q
37 passed
```

Full backend suite before and after this branch: **the same 86 failures, an identical set** — all pre-existing on `main`, none introduced here.

### One existing test changed

`test_api_caching.py::test_caching_decorator_ignores_dependencies` asserted `"hello" in key`, i.e. that the argument's text appears verbatim in the key. Hashing the fingerprint deliberately changes that. Its assertions now cover the same intent against the new format: plumbing still excluded, the key scoped to endpoint and caller, and distinct arguments producing distinct entries.

Two of its sibling tests were also failing on this branch before I fixed two real bugs they caught — `current_user` arriving as a plain `dict` rather than a model, and a `MagicMock` Redis client whose `ttl()` return value is not numeric. Both are handled now (mappings are supported; a non-numeric TTL falls back to the default rather than discarding the value).

---

## Checklist

- [x] My code follows the project's coding standards.
- [x] I have tested my changes locally.
- [x] I have updated the documentation where necessary.
- [x] My changes do not introduce new warnings or errors.
- [x] I have reviewed my own code.
- [x] This pull request focuses on a single feature or fix.
- [x] I have linked the related issue.

---

## Additional Notes

**Cache keys change shape, so existing entries are orphaned by this deploy.** They expire on their own TTL (60–300s for the current call sites) and nothing reads them in the meantime, so the effect is one cold cache period. No migration needed.

**A related problem I did not fix here:** `get_project` and `get_project_by_slug` call `ProjectAnalyticsService.record_view` *inside* a cached function, so the view is only recorded on a cache miss — project view counts are silently under-counting by the cache hit rate. Caching a function with a side effect is the actual bug there, and the fix is to move `record_view` out of the cached call rather than to change the decorator. I left it alone to keep this PR to one subject; happy to open a separate issue for it if reviewers agree it is worth tracking.
