### PR TITLE
fix(ws): stop carrying rooms and identity across a session boundary

### DIFF
--- a/frontend/src/api/__tests__/ws.test.ts
+++ b/frontend/src/api/__tests__/ws.test.ts
@@ -1,0 +1,478 @@
+/**
+ * WebSocket client lifecycle.
+ *
+ * The client is a module-level singleton, but sign-in and sign-out change
+ * identity underneath it. Most of what is asserted here is about what the
+ * client does *across* that boundary: which rooms it re-joins, whether a
+ * deliberate close stays closed, and whether the socket keeps the identity it
+ * was opened with after the token changes.
+ *
+ * `VITE_API_BASE_URL` has to be set before `client.ts` is imported, since it
+ * reads the env var at module scope. Hence the dynamic imports.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── A WebSocket good enough to assert against ────────────────────────────────
+
+class FakeWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  /** Every socket constructed during a test, in order. */
+  static instances: FakeWebSocket[] = [];
+
+  /** Constructor throws once, for the "cannot open" path. */
+  static throwOnNextConstruct = false;
+
+  readyState = FakeWebSocket.CONNECTING;
+  sent: string[] = [];
+  closeCalls = 0;
+
+  onopen: (() => void) | null = null;
+  onmessage: ((e: { data: string }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(public url: string) {
+    if (FakeWebSocket.throwOnNextConstruct) {
+      FakeWebSocket.throwOnNextConstruct = false;
+      throw new Error("cannot open");
+    }
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.closeCalls += 1;
+    const wasOpen = this.readyState !== FakeWebSocket.CLOSED;
+    this.readyState = FakeWebSocket.CLOSED;
+    if (wasOpen) this.onclose?.();
+  }
+
+  // -- test helpers --
+
+  /** Complete the handshake. */
+  open() {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  /** Drop the connection the way a server restart would. */
+  dropped() {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.onclose?.();
+  }
+
+  deliver(payload: unknown) {
+    this.onmessage?.({ data: JSON.stringify(payload) });
+  }
+
+  /** The messages sent on this socket, parsed. */
+  get messages(): Array<Record<string, unknown>> {
+    return this.sent.map((raw) => JSON.parse(raw));
+  }
+
+  static get latest(): FakeWebSocket {
+    return FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
+  }
+
+  static reset() {
+    FakeWebSocket.instances = [];
+    FakeWebSocket.throwOnNextConstruct = false;
+  }
+}
+
+// ── Harness ──────────────────────────────────────────────────────────────────
+
+let ws: typeof import("../ws").ws;
+let reconnectDelay: typeof import("../ws").reconnectDelay;
+let tokenStore: typeof import("../tokens").tokenStore;
+
+async function loadModules() {
+  vi.resetModules();
+  vi.stubEnv("VITE_API_BASE_URL", "http://api.test");
+
+  const tokensModule = await import("../tokens");
+  tokenStore = tokensModule.tokenStore;
+
+  const wsModule = await import("../ws");
+  ws = wsModule.ws;
+  reconnectDelay = wsModule.reconnectDelay;
+}
+
+/** Sign in, open the socket, and complete the handshake. */
+function signIn(token = "access-token-a") {
+  tokenStore.set(token, "refresh-token");
+  FakeWebSocket.latest.open();
+}
+
+beforeEach(async () => {
+  vi.useFakeTimers();
+  FakeWebSocket.reset();
+  vi.stubGlobal("WebSocket", FakeWebSocket);
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+  await loadModules();
+});
+
+afterEach(() => {
+  ws?.disconnect();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+// ── Rooms across a session boundary ──────────────────────────────────────────
+
+describe("project rooms", () => {
+  it("does not re-join the previous session's rooms after a sign-out", () => {
+    // The bug. User A opens a project...
+    signIn("token-user-a");
+    ws.joinProject("project-owned-by-a");
+    expect(ws.getJoinedProjects()).toEqual(["project-owned-by-a"]);
+
+    // ...signs out...
+    tokenStore.clear();
+    expect(ws.getJoinedProjects()).toEqual([]);
+
+    // ...and user B signs in in the same tab.
+    tokenStore.set("token-user-b", "refresh-b");
+    FakeWebSocket.latest.open();
+
+    const joins = FakeWebSocket.latest.messages.filter((m) => m.type === "join");
+    expect(joins).toEqual([]);
+  });
+
+  it("re-joins its own rooms after a dropped connection", () => {
+    signIn();
+    ws.joinProject("project-1");
+    ws.joinProject("project-2");
+
+    const first = FakeWebSocket.latest;
+    first.dropped();
+
+    vi.advanceTimersByTime(MAX_DELAY);
+    FakeWebSocket.latest.open();
+
+    const joined = FakeWebSocket.latest.messages
+      .filter((m) => m.type === "join")
+      .map((m) => m.project_id);
+    expect(joined.sort()).toEqual(["project-1", "project-2"]);
+  });
+
+  it("does not re-join a room that was left", () => {
+    signIn();
+    ws.joinProject("project-1");
+    ws.joinProject("project-2");
+    ws.leaveProject("project-1");
+
+    FakeWebSocket.latest.dropped();
+    vi.advanceTimersByTime(MAX_DELAY);
+    FakeWebSocket.latest.open();
+
+    const joined = FakeWebSocket.latest.messages
+      .filter((m) => m.type === "join")
+      .map((m) => m.project_id);
+    expect(joined).toEqual(["project-2"]);
+  });
+
+  it("clears rooms on an explicit disconnect", () => {
+    signIn();
+    ws.joinProject("project-1");
+
+    ws.disconnect();
+
+    expect(ws.getJoinedProjects()).toEqual([]);
+  });
+});
+
+// ── Manual close ─────────────────────────────────────────────────────────────
+
+describe("manual close", () => {
+  it("is not revived by subscribing", () => {
+    // `on()` used to reconnect whenever `socket` was null, and `connect()`
+    // reset `manualClose` -- so any component mounting after a sign-out
+    // reopened the connection.
+    signIn();
+    const opened = FakeWebSocket.instances.length;
+
+    ws.disconnect();
+    const off = ws.on(() => {});
+
+    expect(FakeWebSocket.instances.length).toBe(opened);
+    off();
+  });
+
+  it("does not schedule a reconnect", () => {
+    signIn();
+    const opened = FakeWebSocket.instances.length;
+
+    ws.disconnect();
+    vi.advanceTimersByTime(MAX_DELAY * 5);
+
+    expect(FakeWebSocket.instances.length).toBe(opened);
+    expect(ws.getStatus()).toBe("closed");
+  });
+
+  it("can be reopened deliberately", () => {
+    signIn();
+    ws.disconnect();
+
+    ws.retry();
+
+    expect(FakeWebSocket.latest).toBeDefined();
+    expect(ws.getStatus()).toBe("connecting");
+  });
+});
+
+// ── Token changes ────────────────────────────────────────────────────────────
+
+describe("token changes", () => {
+  it("opens the socket with the current token", () => {
+    signIn("token-abc");
+
+    expect(FakeWebSocket.latest.url).toContain("token=token-abc");
+  });
+
+  it("reconnects when the token is replaced under an open socket", () => {
+    // A WebSocket authenticates once, at the handshake. There is no way to
+    // re-authenticate an open one, so a token change has to mean a new socket
+    // -- otherwise it keeps the identity it was opened with.
+    signIn("token-user-a");
+    const first = FakeWebSocket.latest;
+
+    tokenStore.set("token-user-b", "refresh-b");
+
+    expect(FakeWebSocket.latest).not.toBe(first);
+    expect(FakeWebSocket.latest.url).toContain("token=token-user-b");
+  });
+
+  it("does not reconnect when the same token is set again", () => {
+    signIn("token-abc");
+    const opened = FakeWebSocket.instances.length;
+
+    tokenStore.set("token-abc", "refresh-token");
+
+    expect(FakeWebSocket.instances.length).toBe(opened);
+  });
+
+  it("does not open a socket without a token", () => {
+    ws.connect();
+
+    expect(FakeWebSocket.instances).toHaveLength(0);
+  });
+});
+
+// ── Reconnection ─────────────────────────────────────────────────────────────
+
+const MAX_DELAY = 30_000;
+
+describe("reconnection", () => {
+  it("applies jitter to the delay", () => {
+    // Deterministic "random" so the window, not the draw, is under test.
+    const random = vi.spyOn(Math, "random");
+
+    random.mockReturnValue(0);
+    expect(reconnectDelay(0)).toBe(0);
+
+    random.mockReturnValue(1);
+    expect(reconnectDelay(0)).toBe(1000);
+
+    random.mockReturnValue(0.5);
+    expect(reconnectDelay(1)).toBe(1000);
+
+    random.mockRestore();
+  });
+
+  it("caps the delay", () => {
+    const random = vi.spyOn(Math, "random").mockReturnValue(1);
+
+    expect(reconnectDelay(20)).toBe(MAX_DELAY);
+
+    random.mockRestore();
+  });
+
+  it("spreads two clients that dropped at the same moment", () => {
+    // The point of jitter: without it, every tab reconnects on the same tick.
+    const draws = [0.1, 0.9];
+    let index = 0;
+    const random = vi.spyOn(Math, "random").mockImplementation(() => draws[index++ % 2]);
+
+    expect(reconnectDelay(3)).not.toBe(reconnectDelay(3));
+
+    random.mockRestore();
+  });
+
+  it("reconnects after a dropped connection", () => {
+    signIn();
+    const first = FakeWebSocket.latest;
+
+    first.dropped();
+    expect(ws.getStatus()).toBe("reconnecting");
+
+    vi.advanceTimersByTime(MAX_DELAY);
+
+    expect(FakeWebSocket.latest).not.toBe(first);
+  });
+
+  it("gives up after the attempt limit", () => {
+    signIn();
+
+    // Each cycle: the pending socket drops, the timer fires, a new one opens.
+    for (let i = 0; i < 12; i += 1) {
+      FakeWebSocket.latest?.dropped();
+      vi.advanceTimersByTime(MAX_DELAY);
+    }
+
+    expect(ws.getStatus()).toBe("gave-up");
+
+    const settled = FakeWebSocket.instances.length;
+    vi.advanceTimersByTime(MAX_DELAY * 5);
+    expect(FakeWebSocket.instances.length).toBe(settled);
+  });
+
+  it("resets the attempt budget on a successful open", () => {
+    signIn();
+
+    FakeWebSocket.latest.dropped();
+    vi.advanceTimersByTime(MAX_DELAY);
+    FakeWebSocket.latest.open();
+
+    // Having reconnected once, the budget is full again -- so a long outage
+    // later is not shortened by failures from an outage hours ago.
+    for (let i = 0; i < 9; i += 1) {
+      FakeWebSocket.latest?.dropped();
+      vi.advanceTimersByTime(MAX_DELAY);
+    }
+
+    expect(ws.getStatus()).not.toBe("closed");
+    expect(FakeWebSocket.instances.length).toBeGreaterThan(2);
+  });
+
+  it("schedules a reconnect when the socket cannot be constructed", () => {
+    // Armed before the token is set, since setting it is what triggers the
+    // connect. Arming afterwards would hit the already-connecting guard and
+    // never reach the constructor.
+    FakeWebSocket.throwOnNextConstruct = true;
+
+    tokenStore.set("token", "refresh");
+
+    expect(FakeWebSocket.instances).toHaveLength(0);
+    expect(ws.getStatus()).toBe("reconnecting");
+
+    // And it recovers on the next attempt.
+    vi.advanceTimersByTime(MAX_DELAY);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+  });
+
+  it("does not burn attempts while offline", () => {
+    signIn();
+    const opened = FakeWebSocket.instances.length;
+
+    const onLine = vi.spyOn(navigator, "onLine", "get").mockReturnValue(false);
+
+    FakeWebSocket.latest.dropped();
+    vi.advanceTimersByTime(MAX_DELAY * 3);
+
+    expect(FakeWebSocket.instances.length).toBe(opened);
+
+    onLine.mockRestore();
+  });
+
+  it("resumes when the browser comes back online", () => {
+    signIn();
+    const onLine = vi.spyOn(navigator, "onLine", "get").mockReturnValue(false);
+
+    FakeWebSocket.latest.dropped();
+    vi.advanceTimersByTime(MAX_DELAY);
+    const stalled = FakeWebSocket.instances.length;
+
+    onLine.mockReturnValue(true);
+    window.dispatchEvent(new Event("online"));
+
+    expect(FakeWebSocket.instances.length).toBeGreaterThan(stalled);
+
+    onLine.mockRestore();
+  });
+});
+
+// ── Events ───────────────────────────────────────────────────────────────────
+
+describe("events", () => {
+  it("delivers parsed messages to handlers", () => {
+    signIn();
+    const seen: unknown[] = [];
+    const off = ws.on((event) => seen.push(event));
+
+    FakeWebSocket.latest.deliver({ type: "presence", userId: "u1", online: true });
+
+    expect(seen).toEqual([{ type: "presence", userId: "u1", online: true }]);
+    off();
+  });
+
+  it("ignores malformed messages", () => {
+    signIn();
+    const seen: unknown[] = [];
+    const off = ws.on((event) => seen.push(event));
+
+    expect(() => FakeWebSocket.latest.onmessage?.({ data: "not json" })).not.toThrow();
+    expect(seen).toEqual([]);
+    off();
+  });
+
+  it("stops delivering after unsubscribing", () => {
+    signIn();
+    const seen: unknown[] = [];
+    const off = ws.on((event) => seen.push(event));
+
+    off();
+    FakeWebSocket.latest.deliver({ type: "presence", userId: "u1", online: true });
+
+    expect(seen).toEqual([]);
+  });
+
+  it("does not send on a socket that is not open", () => {
+    tokenStore.set("token", "refresh");
+    // Constructed but the handshake has not completed.
+    expect(() => ws.send({ type: "join", project_id: "p" })).not.toThrow();
+    expect(FakeWebSocket.latest.sent).toEqual([]);
+  });
+});
+
+// ── Status ───────────────────────────────────────────────────────────────────
+
+describe("status", () => {
+  it("reports the current status to a new subscriber", () => {
+    const seen: string[] = [];
+    const off = ws.onStatus((s) => seen.push(s));
+
+    expect(seen).toEqual(["closed"]);
+    off();
+  });
+
+  it("moves through connecting and open", () => {
+    const seen: string[] = [];
+    const off = ws.onStatus((s) => seen.push(s));
+
+    signIn();
+
+    expect(seen).toEqual(["closed", "connecting", "open"]);
+    off();
+  });
+
+  it("stops notifying after unsubscribing", () => {
+    const seen: string[] = [];
+    const off = ws.onStatus((s) => seen.push(s));
+    off();
+
+    signIn();
+
+    expect(seen).toEqual(["closed"]);
+  });
+});

--- a/frontend/src/api/ws.ts
+++ b/frontend/src/api/ws.ts
@@ -2,10 +2,21 @@
 //
 // Features:
 //   - JWT auth via query param (browsers can't send headers on WS)
-//   - Auto-reconnect with exponential backoff (capped at 30s)
+//   - Auto-reconnect with jittered exponential backoff (capped at 30s)
 //   - Project-scoped rooms (join/leave to receive project events)
 //   - Typed event bus for team collaboration events
 //   - Graceful handling of disconnections
+//
+// This is a module-level singleton, but sign-in and sign-out change identity
+// underneath it. Everything below that looks like defensive bookkeeping is
+// there because the connection outlives the session that opened it:
+//
+//   - `disconnect()` clears the joined rooms, so a new session does not
+//     re-join the previous user's projects on its first `onopen`.
+//   - A manual close stays closed. Subscribing does not silently reopen it.
+//   - The token the socket was opened with is remembered, so a refresh (or a
+//     different user signing in) reconnects rather than leaving the socket
+//     authenticated as whoever opened it.
 //
 // Usage:
 //   import { ws } from "@/api/ws";
@@ -56,13 +67,52 @@ export type CollabEvent =
 
 type Handler = (ev: CollabEvent) => void;
 
+/** What the client is currently doing, for anything that wants to show it. */
+export type WsStatus = "closed" | "connecting" | "open" | "reconnecting" | "gave-up";
+
+type StatusListener = (status: WsStatus) => void;
+
+// ── Tuning ───────────────────────────────────────────────────────────────────
+
+/** Ceiling on the backoff window. */
+const MAX_RECONNECT_DELAY_MS = 30_000;
+
+/** First backoff window, doubled per attempt. */
+const BASE_RECONNECT_DELAY_MS = 1_000;
+
+/**
+ * How many consecutive failures before the client stops trying.
+ *
+ * Unbounded reconnection means a backgrounded tab retries every 30s forever
+ * against a server that may have been gone for hours. Ten attempts spans
+ * roughly four minutes of real outage, after which something has to
+ * explicitly ask for a reconnect — which `online` and a token change both do.
+ */
+const MAX_RECONNECT_ATTEMPTS = 10;
+
 // ── WebSocket URL ────────────────────────────────────────────────────────────
 
-function wsUrl(): string {
+function wsUrl(token: string): string {
   if (!isBackendConfigured()) return "";
   const base = API_BASE_URL.replace(/^http/, "ws");
-  const token = tokenStore.getAccess();
-  return `${base}/ws/collab${token ? `?token=${encodeURIComponent(token)}` : ""}`;
+  return `${base}/ws/collab?token=${encodeURIComponent(token)}`;
+}
+
+/**
+ * Backoff with full jitter.
+ *
+ * Without jitter every tab that was connected when the server restarted
+ * reconnects on exactly the same tick, and keeps doing so in lockstep — the
+ * precise load pattern a recovering server does not need. `client.ts` already
+ * applies full jitter to HTTP retries for this reason; this is the same
+ * argument for the socket.
+ *
+ * Exported for the tests, which stub `Math.random` to make the delay
+ * deterministic.
+ */
+export function reconnectDelay(attempt: number): number {
+  const ceiling = Math.min(BASE_RECONNECT_DELAY_MS * 2 ** attempt, MAX_RECONNECT_DELAY_MS);
+  return Math.round(Math.random() * ceiling);
 }
 
 // ── WsClient ─────────────────────────────────────────────────────────────────
@@ -70,28 +120,65 @@ function wsUrl(): string {
 class WsClient {
   private socket: WebSocket | null = null;
   private handlers = new Set<Handler>();
+  private statusListeners = new Set<StatusListener>();
   private reconnectAttempts = 0;
   private manualClose = false;
   private connectTimer: ReturnType<typeof setTimeout> | null = null;
   private joinedProjects = new Set<string>();
+  private status: WsStatus = "closed";
+
+  /**
+   * The token the current socket was opened with.
+   *
+   * A WebSocket authenticates once, at the handshake, from the token in its
+   * URL. There is no way to re-authenticate an open socket, so when the token
+   * changes the only correct response is to open a new one. Without this the
+   * socket kept whatever identity it was opened with — including across a
+   * sign-out and a sign-in as somebody else.
+   */
+  private socketToken: string | null = null;
 
   /** Open the WebSocket connection (idempotent). */
   connect(): void {
     if (!isBackendConfigured() || typeof window === "undefined") return;
-    if (this.socket && this.socket.readyState <= WebSocket.OPEN) return;
+
+    const token = tokenStore.getAccess();
+
+    // No credential, no socket. Opening one anyway just produces a handshake
+    // the server rejects, followed by the reconnect loop retrying it.
+    if (!token) return;
+
+    // Already connected or connecting with this same token.
+    if (this.socket && this.socket.readyState <= WebSocket.OPEN) {
+      if (this.socketToken === token) return;
+      // Token changed under an open socket. Tear it down without letting the
+      // close handler schedule a reconnect, then fall through and reopen.
+      this.closeSocket();
+    }
+
     this.manualClose = false;
+    this.clearTimer();
+    this.setStatus("connecting");
+
+    const url = wsUrl(token);
+    if (!url) return;
+
     try {
-      const url = wsUrl();
-      if (!url) return;
       this.socket = new WebSocket(url);
+      this.socketToken = token;
     } catch {
+      this.socket = null;
+      this.socketToken = null;
       this.scheduleReconnect();
       return;
     }
 
     this.socket.onopen = () => {
       this.reconnectAttempts = 0;
-      // Re-join any project rooms that were active before the reconnect.
+      this.setStatus("open");
+      // Re-join the rooms that were active before the reconnect. This set is
+      // cleared on disconnect, so it only ever contains rooms belonging to
+      // the session that is currently open.
       for (const projectId of this.joinedProjects) {
         this.send({ type: "join", project_id: projectId });
       }
@@ -108,7 +195,12 @@ class WsClient {
 
     this.socket.onclose = () => {
       this.socket = null;
-      if (!this.manualClose) this.scheduleReconnect();
+      this.socketToken = null;
+      if (this.manualClose) {
+        this.setStatus("closed");
+        return;
+      }
+      this.scheduleReconnect();
     };
 
     this.socket.onerror = () => {
@@ -116,11 +208,62 @@ class WsClient {
     };
   }
 
-  /** Schedule a reconnection with exponential backoff (capped at 30s). */
+  /** Detach the handlers and close, without triggering a reconnect. */
+  private closeSocket(): void {
+    const socket = this.socket;
+    this.socket = null;
+    this.socketToken = null;
+
+    if (!socket) return;
+
+    // Cleared first: `close()` fires `onclose`, and this path is a deliberate
+    // replacement rather than a dropped connection.
+    socket.onopen = null;
+    socket.onmessage = null;
+    socket.onclose = null;
+    socket.onerror = null;
+
+    try {
+      socket.close();
+    } catch {
+      /* already closing */
+    }
+  }
+
+  private clearTimer(): void {
+    if (this.connectTimer) {
+      clearTimeout(this.connectTimer);
+      this.connectTimer = null;
+    }
+  }
+
+  private setStatus(status: WsStatus): void {
+    if (this.status === status) return;
+    this.status = status;
+    this.statusListeners.forEach((l) => l(status));
+  }
+
+  /** Schedule a reconnection with jittered exponential backoff. */
   private scheduleReconnect(): void {
-    if (this.connectTimer) return;
-    const delay = Math.min(30_000, 1000 * 2 ** this.reconnectAttempts);
+    if (this.connectTimer || this.manualClose) return;
+
+    if (this.reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+      this.setStatus("gave-up");
+      return;
+    }
+
+    // Offline is not a server problem, and burning attempts against a
+    // disconnected network just exhausts the budget before the network comes
+    // back. The `online` listener below resumes.
+    if (typeof navigator !== "undefined" && navigator.onLine === false) {
+      this.setStatus("reconnecting");
+      return;
+    }
+
+    const delay = reconnectDelay(this.reconnectAttempts);
     this.reconnectAttempts += 1;
+    this.setStatus("reconnecting");
+
     this.connectTimer = setTimeout(() => {
       this.connectTimer = null;
       this.connect();
@@ -134,24 +277,66 @@ class WsClient {
     }
   }
 
-  /** Close the connection and stop auto-reconnect. */
+  /**
+   * Close the connection and stop auto-reconnect.
+   *
+   * Clears the joined rooms. It did not, so the room set survived a sign-out
+   * and the next session's first `onopen` sent a `join` for every project the
+   * previous user had open.
+   */
   disconnect(): void {
     this.manualClose = true;
-    this.socket?.close();
-    this.socket = null;
-    if (this.connectTimer) {
-      clearTimeout(this.connectTimer);
-      this.connectTimer = null;
-    }
+    this.clearTimer();
+    this.reconnectAttempts = 0;
+    this.joinedProjects.clear();
+    this.closeSocket();
+    this.setStatus("closed");
   }
 
-  /** Register an event handler. Returns an unsubscribe function. */
+  /**
+   * Register an event handler. Returns an unsubscribe function.
+   *
+   * Subscribing connects only when the client has not been deliberately
+   * closed. Previously this reconnected whenever `socket` was null, and
+   * `connect()` reset `manualClose` — so any component mounting after a
+   * sign-out reopened the connection.
+   */
   on(handler: Handler): () => void {
     this.handlers.add(handler);
-    if (!this.socket) this.connect();
+    if (!this.socket && !this.manualClose) this.connect();
     return () => {
       this.handlers.delete(handler);
     };
+  }
+
+  /** Observe connection status. Returns an unsubscribe function. */
+  onStatus(listener: StatusListener): () => void {
+    this.statusListeners.add(listener);
+    listener(this.status);
+    return () => {
+      this.statusListeners.delete(listener);
+    };
+  }
+
+  /** Current connection status. */
+  getStatus(): WsStatus {
+    return this.status;
+  }
+
+  /** The rooms this client will (re-)join. Exposed for tests and debugging. */
+  getJoinedProjects(): string[] {
+    return [...this.joinedProjects];
+  }
+
+  /**
+   * Try again after the client gave up, or after coming back online.
+   *
+   * Resets the attempt counter, which is what separates this from `connect()`.
+   */
+  retry(): void {
+    this.reconnectAttempts = 0;
+    this.manualClose = false;
+    this.connect();
   }
 
   // ── Project room management ──────────────────────────────────────────
@@ -190,7 +375,16 @@ export const ws = new WsClient();
 
 if (typeof window !== "undefined") {
   tokenStore.subscribe((t) => {
+    // `connect()` compares the new token against the one the socket was
+    // opened with, so a refresh reconnects rather than leaving the socket
+    // authenticated as whoever opened it.
     if (t) ws.connect();
     else ws.disconnect();
+  });
+
+  // Coming back online resets the attempt budget. Without this a tab that
+  // exhausted its attempts during an outage stays dead until it is reloaded.
+  window.addEventListener("online", () => {
+    if (tokenStore.getAccess()) ws.retry();
   });
 }


### PR DESCRIPTION
# Pull Request

## Summary

`WsClient` is a module-level singleton, but sign-in and sign-out change identity underneath it. The client carried project rooms, an open socket and an authentication token across that boundary. This makes the session boundary actually reset the client, and brings the reconnect loop in line with what `client.ts` already does for HTTP.

---

## Related Issue

Closes #1171

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [ ] UI/UX enhancement
- [x] Tests
- [ ] Other

---

## Changes Made

### 1. Rooms outlived the session

`joinedProjects` was only ever emptied by `leaveProject`. `disconnect()` left it populated, and the socket re-joins on open:

```ts
this.socket.onopen = () => {
  for (const projectId of this.joinedProjects) {
    this.send({ type: "join", project_id: projectId });
  }
};
```

Sign out, sign in as somebody else in the same tab, and the new session's first `onopen` sent a `join` for every project the previous user had open. `disconnect()` now clears the set.

Whether that `join` actually delivers another user's events depends on how strictly the server authorises room membership — but the client should not be sending it, and relying on the server to reject it is not a defence worth depending on.

### 2. A deliberate close did not stay closed

```ts
on(handler) {
  this.handlers.add(handler);
  if (!this.socket) this.connect();   // and connect() resets manualClose
}
```

Any component mounting and subscribing after a sign-out reopened the connection. Subscribing now connects only when the client was not deliberately closed; `retry()` is the explicit way back.

### 3. The socket kept whatever token it was opened with

A WebSocket authenticates once, at the handshake, from the token in its URL — there is no way to re-authenticate an open one. `tokenStore.subscribe` called `ws.connect()` on every token change, but `connect()` returned early whenever a socket was already open, so the socket kept its original identity through a refresh and through a different user signing in.

The token the socket was opened with is now remembered, and `connect()` replaces the socket when it changes.

### 4. Reconnection was deterministic and unbounded

`Math.min(30_000, 1000 * 2 ** attempts)` has no jitter, so every tab that was connected when the server restarted reconnects on the same tick and keeps doing so in lockstep — the load pattern a recovering server least needs. `client.ts` already applies full jitter to HTTP retries, with a comment explaining why; the socket never got the same treatment. It does now.

Attempts are capped at 10 (roughly four minutes of real outage), reconnection pauses while `navigator.onLine` is `false` rather than burning the budget against a disconnected network, and an `online` listener resets the budget and resumes. Without that last part a tab that exhausted its attempts during an outage would stay dead until reloaded.

### Also

- The socket is no longer opened without an access token. Doing so only produced a handshake the server rejects, followed by the retry loop trying it again.
- Status is observable through `onStatus` / `getStatus` (`closed` / `connecting` / `open` / `reconnecting` / `gave-up`), so a caller can surface "gave up" rather than silently sitting disconnected.
- `closeSocket()` detaches the handlers before closing, so a deliberate replacement does not run the reconnect path meant for a dropped connection.

---

## Testing

- [x] Tested locally
- [x] Existing tests pass
- [x] Added new tests
- [ ] UI verified
- [ ] Cross-browser tested (if applicable)

`frontend/src/api/__tests__/ws.test.ts` — 27 tests against a fake `WebSocket` that lets a test complete a handshake, drop a connection, deliver a message, or fail to construct:

- **Rooms:** no re-join after a sign-out/sign-in cycle (the regression); own rooms re-joined after a drop; a room that was left is not re-joined; explicit disconnect clears them
- **Manual close:** not revived by subscribing; schedules no reconnect; reopens on `retry()`
- **Tokens:** socket opened with the current token; replaced token reconnects; the same token does not; no socket without a token
- **Reconnection:** jitter applied and capped; two clients dropping together get different delays; reconnects after a drop; gives up at the limit and stays given up; the budget resets on a successful open; construction failure schedules a retry and recovers; offline does not burn attempts; `online` resumes
- **Events:** parsed delivery, malformed messages ignored, unsubscribe stops delivery, no send on a socket that is not open
- **Status:** current status replayed to a new subscriber, transitions, unsubscribe

```
frontend $ npx vitest run
Test Files  41 passed (41)
     Tests  636 passed (636)

frontend $ npx tsc --noEmit
(no errors)
```

---

## Checklist

- [x] My code follows the project's coding standards.
- [x] I have tested my changes locally.
- [x] I have updated the documentation where necessary.
- [x] My changes do not introduce new warnings or errors.
- [x] I have reviewed my own code.
- [x] This pull request focuses on a single feature or fix.
- [x] I have linked the related issue.

---

## Additional Notes

**Nothing imports `api/ws.ts` yet.** `useChatWebSocket` and `useCollaborativeWorkspace` open raw `WebSocket`s of their own and are untouched by this. So this is not fixing a bug users are hitting today — it is fixing one that lands the moment somebody wires this module up, which is a much cheaper time to fix it. I would rather say that plainly than imply a live incident.

The two hooks that do use raw sockets have their own reconnect loops with the same missing jitter. Folding them onto this client would be the right end state, but it is a behavioural change to two working features and does not belong in the same PR. Happy to open a follow-up issue.
