### PR TITLE
fix(auth): propagate sign-out and session changes across tabs

### DIFF
--- a/frontend/src/api/__tests__/tokens.test.ts
+++ b/frontend/src/api/__tests__/tokens.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Token storage and cross-tab session sync.
+ *
+ * `storage` events do not fire in the tab that made the change, so a real
+ * two-tab scenario cannot be reproduced in one jsdom window. These tests
+ * dispatch the event the browser would have delivered, which is the same
+ * thing from the listener's point of view — and they assert that the local
+ * writes this tab makes itself do *not* go through that path, since a
+ * listener that reacted to its own writes would loop.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const REFRESH_KEY = "devlink.refresh";
+const ACCESS_KEY = "devlink.access";
+
+let tokenStore: typeof import("../tokens").tokenStore;
+let stopSessionSync: typeof import("../tokens").stopSessionSync;
+
+/**
+ * Fire the `storage` event another tab's write would have produced.
+ *
+ * jsdom does not propagate storage writes into events, so the value is
+ * written first and the event dispatched second — which is the order and the
+ * state a real second tab would leave behind.
+ */
+function storageEventFromAnotherTab(
+  key: string | null,
+  newValue: string | null,
+  oldValue: string | null,
+) {
+  if (key === null) {
+    window.localStorage.clear();
+  } else if (newValue === null) {
+    window.localStorage.removeItem(key);
+  } else {
+    window.localStorage.setItem(key, newValue);
+  }
+
+  window.dispatchEvent(
+    new StorageEvent("storage", {
+      key,
+      newValue,
+      oldValue,
+      storageArea: window.localStorage,
+    }),
+  );
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+
+  const module = await import("../tokens");
+  tokenStore = module.tokenStore;
+  stopSessionSync = module.stopSessionSync;
+});
+
+afterEach(() => {
+  stopSessionSync?.();
+});
+
+// ── Basic storage ────────────────────────────────────────────────────────────
+
+describe("storage", () => {
+  it("keeps the access token out of localStorage", () => {
+    tokenStore.set("access", "refresh");
+
+    expect(window.sessionStorage.getItem(ACCESS_KEY)).toBe("access");
+    expect(window.localStorage.getItem(ACCESS_KEY)).toBeNull();
+    expect(window.localStorage.getItem(REFRESH_KEY)).toBe("refresh");
+  });
+
+  it("reads the access token back from sessionStorage after a reload", async () => {
+    window.sessionStorage.setItem(ACCESS_KEY, "survived");
+    vi.resetModules();
+
+    const { tokenStore: reloaded } = await import("../tokens");
+
+    expect(reloaded.getAccess()).toBe("survived");
+  });
+
+  it("leaves the refresh token alone when it is not passed", () => {
+    tokenStore.set("access-1", "refresh-1");
+    tokenStore.set("access-2");
+
+    expect(tokenStore.getRefresh()).toBe("refresh-1");
+    expect(tokenStore.getAccess()).toBe("access-2");
+  });
+
+  it("clear removes both", () => {
+    tokenStore.set("access", "refresh");
+    tokenStore.clear();
+
+    expect(tokenStore.getAccess()).toBeNull();
+    expect(tokenStore.getRefresh()).toBeNull();
+  });
+
+  it("notifies subscribers on set and clear", () => {
+    const seen: (string | null)[] = [];
+    const off = tokenStore.subscribe((t) => seen.push(t));
+
+    tokenStore.set("access", "refresh");
+    tokenStore.clear();
+
+    expect(seen).toEqual(["access", null]);
+    off();
+  });
+
+  it("unsubscribe returns nothing usable as a value", () => {
+    // `Set.delete` returns a boolean; an unsubscribe that returns one is easy
+    // to misread, and misbehaves as a React effect cleanup.
+    const off = tokenStore.subscribe(() => {});
+
+    expect(off()).toBeUndefined();
+  });
+
+  it("stops notifying after unsubscribing", () => {
+    const seen: (string | null)[] = [];
+    const off = tokenStore.subscribe((t) => seen.push(t));
+    off();
+
+    tokenStore.set("access", "refresh");
+
+    expect(seen).toEqual([]);
+  });
+});
+
+// ── Sign-out in another tab ──────────────────────────────────────────────────
+
+describe("sign-out in another tab", () => {
+  it("clears this tab's access token", () => {
+    // The bug: this tab stayed fully authenticated, and kept making
+    // authorised requests, until its own access token happened to expire.
+    tokenStore.set("access", "refresh");
+
+    storageEventFromAnotherTab(REFRESH_KEY, null, "refresh");
+
+    expect(tokenStore.getAccess()).toBeNull();
+    expect(window.sessionStorage.getItem(ACCESS_KEY)).toBeNull();
+  });
+
+  it("notifies subscribers", () => {
+    tokenStore.set("access", "refresh");
+
+    const seen: (string | null)[] = [];
+    const off = tokenStore.subscribe((t) => seen.push(t));
+
+    storageEventFromAnotherTab(REFRESH_KEY, null, "refresh");
+
+    expect(seen).toEqual([null]);
+    off();
+  });
+
+  it("treats localStorage.clear() as a sign-out", () => {
+    tokenStore.set("access", "refresh");
+
+    storageEventFromAnotherTab(null, null, null);
+
+    expect(tokenStore.getAccess()).toBeNull();
+  });
+
+  it("does nothing when this tab was already signed out", () => {
+    const seen: (string | null)[] = [];
+    const off = tokenStore.subscribe((t) => seen.push(t));
+
+    storageEventFromAnotherTab(REFRESH_KEY, null, "refresh");
+
+    expect(seen).toEqual([]);
+    off();
+  });
+});
+
+// ── Sign-in as somebody else in another tab ──────────────────────────────────
+
+describe("a different session in another tab", () => {
+  it("drops this tab's stale access token", () => {
+    // Otherwise this tab renders user A while holding A's access token, then
+    // on expiry refreshes against B's refresh token and silently becomes B --
+    // with a page still full of A's data.
+    tokenStore.set("access-user-a", "refresh-user-a");
+
+    storageEventFromAnotherTab(REFRESH_KEY, "refresh-user-b", "refresh-user-a");
+
+    expect(tokenStore.getAccess()).toBeNull();
+  });
+
+  it("leaves the new refresh token in place", () => {
+    // It belongs to the new session and is perfectly valid; only this tab's
+    // access token is stale.
+    tokenStore.set("access-user-a", "refresh-user-a");
+
+    storageEventFromAnotherTab(REFRESH_KEY, "refresh-user-b", "refresh-user-a");
+
+    expect(tokenStore.getRefresh()).toBe("refresh-user-b");
+  });
+
+  it("notifies subscribers that this tab is unauthenticated", () => {
+    tokenStore.set("access-user-a", "refresh-user-a");
+
+    const seen: (string | null)[] = [];
+    const off = tokenStore.subscribe((t) => seen.push(t));
+
+    storageEventFromAnotherTab(REFRESH_KEY, "refresh-user-b", "refresh-user-a");
+
+    expect(seen).toEqual([null]);
+    off();
+  });
+});
+
+// ── Events that must not disturb the session ─────────────────────────────────
+
+describe("unrelated storage activity", () => {
+  it("ignores a different key", () => {
+    tokenStore.set("access", "refresh");
+
+    storageEventFromAnotherTab("some.other.key", "value", null);
+
+    expect(tokenStore.getAccess()).toBe("access");
+  });
+
+  it("ignores a write that did not change the value", () => {
+    tokenStore.set("access", "refresh");
+
+    storageEventFromAnotherTab(REFRESH_KEY, "refresh", "refresh");
+
+    expect(tokenStore.getAccess()).toBe("access");
+  });
+
+  it("does not react to this tab's own writes", () => {
+    // `storage` does not fire in the originating tab, so a local `set` must
+    // notify exactly once -- via `set` itself, not via the listener as well.
+    tokenStore.set("access-1", "refresh-1");
+
+    const seen: (string | null)[] = [];
+    const off = tokenStore.subscribe((t) => seen.push(t));
+
+    tokenStore.set("access-2", "refresh-2");
+
+    expect(seen).toEqual(["access-2"]);
+    expect(tokenStore.getAccess()).toBe("access-2");
+    off();
+  });
+
+  it("does not loop when a subscriber writes back", () => {
+    tokenStore.set("access", "refresh");
+
+    let calls = 0;
+    const off = tokenStore.subscribe((t) => {
+      calls += 1;
+      if (calls > 5) throw new Error("runaway notification loop");
+      if (t === null) tokenStore.getAccess();
+    });
+
+    storageEventFromAnotherTab(REFRESH_KEY, null, "refresh");
+
+    expect(calls).toBe(1);
+    off();
+  });
+});
+
+// ── Teardown ─────────────────────────────────────────────────────────────────
+
+describe("listener lifecycle", () => {
+  it("stops reacting after teardown", () => {
+    tokenStore.set("access", "refresh");
+
+    stopSessionSync();
+    storageEventFromAnotherTab(REFRESH_KEY, null, "refresh");
+
+    expect(tokenStore.getAccess()).toBe("access");
+  });
+
+  it("registering twice does not double-handle an event", async () => {
+    const { startSessionSync } = await import("../tokens");
+    startSessionSync();
+    startSessionSync();
+
+    tokenStore.set("access", "refresh");
+
+    const seen: (string | null)[] = [];
+    const off = tokenStore.subscribe((t) => seen.push(t));
+
+    storageEventFromAnotherTab(REFRESH_KEY, null, "refresh");
+
+    expect(seen).toEqual([null]);
+    off();
+  });
+});

--- a/frontend/src/api/tokens.ts
+++ b/frontend/src/api/tokens.ts
@@ -1,6 +1,21 @@
 // JWT access + refresh token storage.
+//
 // Access token kept in-memory (safer against XSS); refresh in localStorage
 // so sessions survive reloads. Swap to httpOnly cookies when backend supports.
+//
+// The three places a session lives have different scopes, and that difference
+// is the whole reason the `storage` listener at the bottom of this file
+// exists:
+//
+//   accessToken (module variable)  per JS context, so per tab
+//   sessionStorage                 per tab
+//   localStorage (refresh)         shared across every tab on the origin
+//
+// localStorage was chosen for the refresh token because it is shared, so a
+// reload keeps the session. But being shared also means another tab can
+// change it underneath this one, and the browser tells us when that happens.
+// Not listening meant signing out in one tab left every other tab fully
+// authenticated until its access token happened to expire.
 
 const ACCESS_KEY = "devlink.access";
 const REFRESH_KEY = "devlink.refresh";
@@ -9,6 +24,18 @@ let accessToken: string | null = null;
 
 type Listener = (token: string | null) => void;
 const listeners = new Set<Listener>();
+
+function notify(token: string | null): void {
+  listeners.forEach((l) => l(token));
+}
+
+/** Drop this tab's access token without touching the shared refresh token. */
+function clearLocalAccess(): void {
+  accessToken = null;
+  if (typeof window !== "undefined") {
+    window.sessionStorage.removeItem(ACCESS_KEY);
+  }
+}
 
 export const tokenStore = {
   getAccess(): string | null {
@@ -31,13 +58,95 @@ export const tokenStore = {
         else window.localStorage.removeItem(REFRESH_KEY);
       }
     }
-    listeners.forEach((l) => l(access));
+    notify(access);
   },
   clear() {
     this.set(null, null);
   },
-  subscribe(l: Listener) {
+  subscribe(l: Listener): () => void {
     listeners.add(l);
-    return () => listeners.delete(l);
+    // Wrapped rather than returned bare: `Set.delete` returns a boolean, and
+    // an unsubscribe function that returns a value is easy to misread as
+    // meaningful, and misbehaves if used where a cleanup returning void is
+    // expected (a React effect, for one).
+    return () => {
+      listeners.delete(l);
+    };
   },
 };
+
+// ── Cross-tab session sync ───────────────────────────────────────────────────
+
+/**
+ * React to another tab changing the shared refresh token.
+ *
+ * `storage` events do not fire in the tab that made the change, so anything
+ * reaching here originated elsewhere. Exported for the tests, which dispatch
+ * synthetic events rather than driving two real tabs.
+ */
+export function handleStorageEvent(event: StorageEvent): void {
+  // `key === null` means `localStorage.clear()`. That takes the refresh token
+  // with it, so it is a sign-out like any other.
+  if (event.key === null) {
+    if (tokenStore.getAccess() === null) return;
+    clearLocalAccess();
+    notify(null);
+    return;
+  }
+
+  if (event.key !== REFRESH_KEY) return;
+
+  // Same value written again, or a write that changed nothing. Bailing out
+  // keeps an unrelated re-save from signing the tab out.
+  if (event.newValue === event.oldValue) return;
+
+  if (event.newValue === null) {
+    // Signed out elsewhere. Drop this tab's access token too -- it is still
+    // valid server-side until it expires, and leaving it in place is what let
+    // a "signed out" tab keep making authorised requests.
+    if (tokenStore.getAccess() === null) return;
+    clearLocalAccess();
+    notify(null);
+    return;
+  }
+
+  // The refresh token was replaced with a different one, which means a
+  // different session -- often a different user -- signed in elsewhere.
+  //
+  // This tab's access token belongs to the previous session. Keeping it is
+  // the worse of the two failure modes: the tab would go on rendering the old
+  // user's data, and on expiry would silently refresh against the *new*
+  // user's refresh token and become them, with a page still full of somebody
+  // else's content. Dropping it makes this tab unauthenticated, so the app
+  // re-establishes identity from the new refresh token instead of inheriting
+  // a stale one.
+  if (tokenStore.getAccess() === null) return;
+  clearLocalAccess();
+  notify(null);
+}
+
+let listening = false;
+
+/**
+ * Start syncing this tab with the others. Idempotent and SSR-safe.
+ *
+ * Returns a teardown function. Called once at module load below; exported so
+ * a test can register and unregister a clean listener.
+ */
+export function startSessionSync(): () => void {
+  if (typeof window === "undefined") return () => {};
+  if (listening) return stopSessionSync;
+
+  window.addEventListener("storage", handleStorageEvent);
+  listening = true;
+
+  return stopSessionSync;
+}
+
+export function stopSessionSync(): void {
+  if (typeof window === "undefined") return;
+  window.removeEventListener("storage", handleStorageEvent);
+  listening = false;
+}
+
+startSessionSync();

--- a/frontend/src/contexts/auth-context.tsx
+++ b/frontend/src/contexts/auth-context.tsx
@@ -14,6 +14,17 @@ export interface AuthUser {
 export function useAuth() {
   const [user, setUser] = useState<AuthUser | null>(null);
 
+  // Bumped whenever the token changes, to re-run the lookup below.
+  //
+  // This used to read the token once on mount and never look again, so a
+  // token change -- including a sign-out in another tab, which `tokenStore`
+  // now propagates -- left this hook showing the previous user indefinitely.
+  const [tokenVersion, setTokenVersion] = useState(0);
+
+  useEffect(() => {
+    return tokenStore.subscribe(() => setTokenVersion((v) => v + 1));
+  }, []);
+
   useEffect(() => {
     if (!tokenStore.getAccess()) {
       setUser(null);
@@ -31,7 +42,7 @@ export function useAuth() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [tokenVersion]);
 
   const logout = useCallback(() => {
     tokenStore.clear();


### PR DESCRIPTION
# Pull Request

## Summary

The refresh token lives in `localStorage`, which is shared across every tab on the origin and fires a `storage` event to the others when it changes. Nothing listened for it, so a session change in one tab was invisible to the rest — signing out in one tab left the others fully authenticated.

---

## Related Issue

Closes #1172

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [ ] UI/UX enhancement
- [x] Tests
- [ ] Other

---

## Changes Made

### The gap

The session lives in three places with three different scopes:

| Where | What | Scope |
|---|---|---|
| module variable `accessToken` | access token | per tab |
| `sessionStorage` | access token | per tab |
| `localStorage` | refresh token | **shared across all tabs** |

The comment at the top of `tokens.ts` explains the design — access in memory to limit XSS exposure, refresh in `localStorage` so the session survives a reload — and that reasoning is sound. The gap is that `localStorage` was chosen for its cross-tab *persistence* without wiring up the cross-tab *notification* that comes with it. `grep -rn '"storage"' frontend/src` returned nothing.

**Sign-out did not propagate.** Tab A calls `tokenStore.clear()`, which removes the refresh token from shared storage. Tab B still holds its own access token in memory and in its own `sessionStorage`, so it stays signed in and keeps making authorised requests until that token expires — at which point it drops out at a moment unrelated to the logout, with whatever request was in flight failing. On a shared machine, "log out" did not mean what the user assumed.

**Identity could diverge.** Sign out in tab A and sign in as a different user. Tab B still renders user A and still holds A's access token. When it expires, `refreshAccessToken()` reads `localStorage`, finds **B's** refresh token, and tab B silently becomes user B — with a page still full of A's data.

### The fix

`tokens.ts` listens for `storage` on the refresh key:

- **Removed elsewhere** (or `localStorage.clear()`, which arrives as `key === null`) → clear this tab's access token and notify subscribers.
- **Replaced with a different value** → clear the stale access token but leave the new refresh token alone. It belongs to the new session and is valid; only this tab's access token is stale. This tab becomes unauthenticated and re-establishes identity from the new refresh token rather than inheriting one from the previous session. Dropping it is the better of the two failure modes — the alternative is the silent identity swap above.
- **A different key, or a write that changed nothing** → ignored, so an unrelated `localStorage` write does not sign the tab out.

`storage` does not fire in the tab that made the change, so a local `set()` notifies exactly once and the listener cannot loop. There is a test for that specifically.

Registration is idempotent, SSR-safe, and returns a teardown function.

### `useAuth` had to be wired up too

```ts
useEffect(() => {
  if (!tokenStore.getAccess()) { setUser(null); return; }
  api.get<AuthUser>("/api/users/me")...
}, []);   // ← empty deps
```

It read the token once on mount and never subscribed, so none of the above would have reached the UI. It now re-runs the lookup when the token changes. That also fixes the same-tab case, which was already broken independently: a token refresh or a sign-in went unnoticed by this hook too.

### Also

`subscribe()` returned `listeners.delete(l)` directly, i.e. a boolean. An unsubscribe function that returns a value is easy to misread as meaningful and misbehaves where a cleanup returning `void` is expected — a React effect, for one. It returns `void` now.

---

## Testing

- [x] Tested locally
- [x] Existing tests pass
- [x] Added new tests
- [ ] UI verified
- [ ] Cross-browser tested (if applicable)

`frontend/src/api/__tests__/tokens.test.ts` — 20 tests. A real two-tab scenario cannot be reproduced in one jsdom window, so the tests write the value and then dispatch the `storage` event the browser would have delivered — the same order and the same resulting state a second tab leaves behind.

- **Storage:** the access token stays out of `localStorage`; it survives a reload via `sessionStorage`; an omitted refresh argument leaves the refresh token alone; `clear` removes both; subscribers notified on set and clear; unsubscribe returns nothing and stops delivery
- **Sign-out elsewhere:** this tab's access token is cleared (the regression); subscribers notified; `localStorage.clear()` counts; already-signed-out is a no-op
- **A different session elsewhere:** the stale access token is dropped, the new refresh token is left in place, subscribers told this tab is unauthenticated
- **Must not disturb the session:** a different key, a no-change write, this tab's own writes (notified exactly once, not twice), and a subscriber that reads back during notification does not loop
- **Lifecycle:** teardown stops reacting; registering twice does not double-handle an event

```
frontend $ npx vitest run
Test Files  41 passed (41)
     Tests  629 passed (629)

frontend $ npx tsc --noEmit
(no errors)

frontend $ npx eslint src/api/tokens.ts src/api/__tests__/tokens.test.ts src/contexts/auth-context.tsx
(clean)
```

---

## Checklist

- [x] My code follows the project's coding standards.
- [x] I have tested my changes locally.
- [x] I have updated the documentation where necessary.
- [x] My changes do not introduce new warnings or errors.
- [x] I have reviewed my own code.
- [x] This pull request focuses on a single feature or fix.
- [x] I have linked the related issue.

---

## Additional Notes

**On the "replaced" case being a sign-out locally.** The alternative is to keep the tab signed in and let it silently adopt the new identity. I went with signing it out because the tab's rendered content belongs to the previous user, and adopting an identity the user did not choose *in that tab* is the more surprising outcome — it is the exact failure described in the issue. The tab re-authenticates from the new refresh token on its next request, so a user who genuinely wants both tabs on the new account gets there with one reload rather than seeing a mismatched page.

**Still not fixed, and out of scope here:** logout is local-only — it drops the tokens but does not tell the server, so a refresh token that leaked before the logout stays valid until it expires. That needs a server-side revocation list keyed on the refresh token's `jti` (which `create_refresh_token` already mints). Worth its own issue.
