### PR TITLE
test: strengthen profile analytics trend coverage

### DIFF
--- a/backend/tests/test_profile_analytics.py
+++ b/backend/tests/test_profile_analytics.py
@@ -154,3 +154,13 @@ def test_profile_analytics_endpoints():
     # Clean up overrides
     app.dependency_overrides.pop(get_current_user, None)
     app.dependency_overrides.pop(get_optional_current_user, None)
+
+def test_profile_analytics_trends_have_expected_days():
+    db = TestingSessionLocal()
+    user_id = uuid.uuid4()
+
+    result = AnalyticsService.get_profile_analytics(db=db, user_id=user_id)
+    db.close()
+
+    assert len(result.trends) == 7
+    assert all(trend.date is not None for trend in result.trends)


### PR DESCRIPTION
## Summary

Adds an additional test case to strengthen coverage for the profile analytics trends response.

The existing profile analytics tests already cover empty analytics, populated analytics, profile views, connection requests, repository/project clicks, and the profile analytics endpoints. This change adds an explicit assertion that the generated trend data contains the expected number of entries and that each trend entry has a valid date.

Fixes  #983

## Changes Made

- Added `test_profile_analytics_trends_have_expected_days`
- Verifies profile analytics returns exactly 7 trend entries
- Verifies every trend entry contains a non-null date
- Uses the existing `AnalyticsService.get_profile_analytics()` test setup
- No production/application logic was changed

## Issue Criteria / Acceptance Criteria

### Profile Analytics Coverage
- [x] Profile analytics functionality has dedicated automated test coverage
- [x] Empty analytics response is covered
- [x] Analytics with existing profile activity is covered
- [x] Profile views are covered
- [x] Connection requests are covered
- [x] Repository clicks are covered
- [x] Project clicks are covered
- [x] Profile analytics GET endpoint is covered
- [x] Profile analytics click endpoint is covered
- [x] Analytics trend data is explicitly validated
- [x] Trend response contains the expected 7 entries
- [x] Each trend entry is validated to contain a date

## Testing

### Test Added

```text
test_profile_analytics_trends_have_expected_days