### PR TITLE
fix(api): bind idempotency to the request, not just to the key

### DIFF
--- a/backend/app/middleware/idempotency.py
+++ b/backend/app/middleware/idempotency.py
@@ -1,45 +1,328 @@
+"""
+Idempotency for unsafe requests.
+
+The contract
+------------
+
+A client that is about to make a request it cannot safely repeat sends an
+``Idempotency-Key`` header. If it never hears back -- a timeout, a dropped
+connection, a crashed tab -- it retries with the same key, and gets the
+*original* response rather than a second execution.
+
+What makes that safe is that the key is bound to the request. A stored
+response is only replayed for a request that is byte-for-byte the same one
+that produced it:
+
+    key + method + path + body  ->  response
+
+Previously only the key was in the cache key::
+
+    cache_key = f"idempotent:{user_id}:{idempotency_key}"
+
+so a client that reused a key across two genuinely different requests -- a
+mobile app deriving the key from a screen-level UUID, or anything retrying a
+batch under one key -- got the first response replayed for the second, and the
+second request never ran. Silent data loss, and the shape of client that hits
+it is exactly the shape of client that needs idempotency in the first place.
+
+Requests whose fingerprint disagrees with the stored one now get ``422``. That
+is what Stripe and the IETF ``Idempotency-Key`` draft both do, and a loud
+rejection is much easier to debug than a wrong response body.
+
+Failure posture
+---------------
+
+This layer is an optimisation on top of a correct API, so it fails *open*
+everywhere it can:
+
+* Redis unreachable at startup or mid-request -> the request runs normally.
+* A cache *write* fails after the handler committed -> logged, swallowed. The
+  work already happened; turning that into a 500 would make the client retry
+  an operation that succeeded.
+
+The one place it fails closed is the concurrency lock: if another request is
+already in flight under this key, the duplicate gets ``409`` with a
+``Retry-After`` rather than being allowed to run alongside it.
+"""
+
+from __future__ import annotations
+
+import hashlib
 import json
 import logging
-from typing import Callable
+import uuid
+from typing import Any, Callable, Optional
 
-import redis
+import redis.asyncio as aioredis
 from fastapi import Request, Response
 from fastapi.routing import APIRoute
-from jose import JWTError, jwt
 
 from app.core.config import settings
+from app.core.security import InvalidTokenType, TokenType, decode_token
 
 logger = logging.getLogger(__name__)
 
-# Initialize a global redis connection pool for idempotency caching
-try:
-    redis_client = redis.from_url(settings.REDIS_URL, decode_responses=True)
-except Exception as e:
-    logger.error(f"Failed to connect to Redis for idempotency: {e}")
-    redis_client = None
+#: Methods that can carry an idempotency key. GET/HEAD/OPTIONS are already
+#: safe and DELETE is already idempotent by definition.
+IDEMPOTENT_METHODS = frozenset({"POST", "PUT", "PATCH"})
+
+#: How long a stored response is replayable.
+RESPONSE_TTL_SECONDS = 24 * 60 * 60
+
+#: How long the in-flight lock lives. Sized above the request timeout: if the
+#: lock expires while the handler is still running, a retry proceeds
+#: concurrently and produces the duplicate this middleware exists to prevent.
+LOCK_TTL_SECONDS = 120
+
+#: What a duplicate-in-flight response tells the client to wait.
+RETRY_AFTER_SECONDS = 2
+
+#: Response headers worth replaying. Everything else -- `Date`, `Server`,
+#: `Content-Length`, and in particular any `Set-Cookie` -- describes the
+#: original exchange, not the payload, and replaying a day-old `Set-Cookie` is
+#: not something a cache should do. `Content-Length` is recomputed by Starlette
+#: from the body we hand it.
+REPLAYABLE_HEADERS = frozenset(
+    {
+        "content-type",
+        "content-language",
+        "location",
+        "etag",
+        "cache-control",
+    }
+)
+
+#: Marks a replayed response, so a client (or a test) can tell the difference.
+CACHE_STATUS_HEADER = "X-Idempotent-Replay"
+
+#: Set when a handler's response could not be stored, so the caller knows a
+#: retry with the same key will re-execute rather than replay.
+NOT_STORED_HEADER = "X-Idempotent-Stored"
 
 
-def _extract_user_id(request: Request) -> str:
-    auth_header = request.headers.get("Authorization", "")
-    if auth_header.startswith("Bearer "):
+# ---------------------------------------------------------------------------
+# Redis
+# ---------------------------------------------------------------------------
+#
+# The client is created lazily rather than at import. Building it at import
+# time means a Redis that is merely slow to start takes the whole application
+# down with it, and it makes the module impossible to import in a test that
+# does not care about idempotency at all.
+
+_redis_client: Optional[aioredis.Redis] = None
+_redis_unavailable = False
+
+
+async def get_redis() -> Optional[aioredis.Redis]:
+    """The shared async Redis client, or ``None`` if Redis is not reachable.
+
+    ``None`` is a normal answer, not an error: every caller treats it as
+    "skip idempotency and run the request".
+    """
+    global _redis_client, _redis_unavailable
+
+    if _redis_unavailable:
+        return None
+
+    if _redis_client is None:
         try:
-            payload = jwt.decode(
-                auth_header[7:],
-                settings.SECRET_KEY,
-                algorithms=[settings.JWT_ALGORITHM],
+            _redis_client = aioredis.from_url(
+                settings.REDIS_URL,
+                decode_responses=True,
             )
-            sub = payload.get("sub")
-            if sub:
-                return str(sub)
-        except JWTError:
-            pass
-    return "anonymous"
+        except Exception as exc:  # pragma: no cover - configuration error
+            logger.error("Idempotency: could not create Redis client: %s", exc)
+            _redis_unavailable = True
+            return None
+
+    return _redis_client
+
+
+async def reset_redis_client() -> None:
+    """Drop the cached client. For tests, and for a clean shutdown."""
+    global _redis_client, _redis_unavailable
+
+    if _redis_client is not None:
+        try:
+            await _redis_client.aclose()
+        except Exception:  # pragma: no cover - best effort
+            logger.debug("Idempotency: error closing Redis client", exc_info=True)
+
+    _redis_client = None
+    _redis_unavailable = False
+
+
+# ---------------------------------------------------------------------------
+# Identity
+# ---------------------------------------------------------------------------
+
+
+def extract_user_id(request: Request) -> Optional[str]:
+    """The authenticated subject, or ``None``.
+
+    Two things this does that the previous version did not.
+
+    It **verifies the token type**. `jwt.decode` on its own checks the
+    signature and the expiry but nothing else, so a refresh, verification or
+    password-reset token was accepted as identity here. ``decode_token`` with
+    an expected type folds all three checks into one pass.
+
+    It returns ``None`` rather than the string ``"anonymous"``. Every
+    unauthenticated caller previously shared the ``idempotent:anonymous:<key>``
+    namespace, so one anonymous client could read another's cached response
+    body by reusing a guessable key. There is no safe way to scope a cache
+    entry to an unidentified caller, so unauthenticated requests skip
+    idempotency entirely.
+    """
+    auth_header = request.headers.get("Authorization", "")
+
+    if not auth_header.startswith("Bearer "):
+        return None
+
+    try:
+        payload = decode_token(
+            auth_header[7:],
+            expected_type=TokenType.ACCESS,
+        )
+    except (InvalidTokenType, ValueError):
+        return None
+
+    subject = payload.get("sub")
+
+    return str(subject) if subject else None
+
+
+# ---------------------------------------------------------------------------
+# Keys and fingerprints
+# ---------------------------------------------------------------------------
+
+
+def build_cache_key(user_id: str, method: str, path: str, key: str) -> str:
+    """The Redis key for one (caller, endpoint, idempotency key) triple.
+
+    The method and path are in the key rather than only in the fingerprint so
+    that the same key used against two different endpoints does not even
+    collide -- both requests run, which is what the client meant, instead of
+    one being rejected with a fingerprint mismatch.
+
+    Hashed because an idempotency key is client-supplied and a path can be
+    long; this keeps every Redis key the same bounded size.
+    """
+    digest = hashlib.sha256(
+        "\x00".join((method.upper(), path, key)).encode("utf-8")
+    ).hexdigest()
+
+    return f"idempotent:v2:{user_id}:{digest}"
+
+
+def build_fingerprint(method: str, path: str, body: bytes) -> str:
+    """A digest of everything about the request that must not change.
+
+    Compared against the stored fingerprint on a cache hit. A mismatch means
+    the client reused a key for a different request, which is a client error
+    rather than something to paper over.
+
+    Headers are deliberately out of scope: a retry legitimately carries a
+    different `User-Agent`, trace id or `Authorization` (a refreshed token),
+    and rejecting on those would make idempotency unusable.
+    """
+    hasher = hashlib.sha256()
+    hasher.update(method.upper().encode("utf-8"))
+    hasher.update(b"\x00")
+    hasher.update(path.encode("utf-8"))
+    hasher.update(b"\x00")
+    hasher.update(body)
+
+    return hasher.hexdigest()
+
+
+def filter_headers(headers: Any) -> dict[str, str]:
+    """Keep only the response headers that describe the payload."""
+    return {
+        name: value
+        for name, value in headers.items()
+        if name.lower() in REPLAYABLE_HEADERS
+    }
+
+
+# ---------------------------------------------------------------------------
+# Stored payloads
+# ---------------------------------------------------------------------------
+
+
+def serialise_response(
+    response: Response,
+    body: bytes,
+    fingerprint: str,
+) -> str:
+    """Encode a response for storage."""
+    return json.dumps(
+        {
+            "fingerprint": fingerprint,
+            "status_code": response.status_code,
+            "headers": filter_headers(response.headers),
+            "body": body.decode("utf-8", errors="replace"),
+            "media_type": getattr(response, "media_type", None)
+            or response.headers.get("content-type")
+            or "application/json",
+        }
+    )
+
+
+def build_replay(stored: dict) -> Response:
+    """Rebuild a stored response for replay."""
+    headers = dict(stored.get("headers") or {})
+    headers[CACHE_STATUS_HEADER] = "true"
+
+    return Response(
+        content=stored.get("body", ""),
+        status_code=stored.get("status_code", 200),
+        headers=headers,
+        media_type=stored.get("media_type") or "application/json",
+    )
+
+
+def build_conflict_response(message: str, status_code: int) -> Response:
+    """A JSON error response that does not depend on the app's handlers."""
+    return Response(
+        content=json.dumps({"success": False, "message": message}),
+        status_code=status_code,
+        media_type="application/json",
+    )
+
+
+def build_mismatch_response(path: str) -> Response:
+    """422 for a key reused against a different request body."""
+    return build_conflict_response(
+        "This Idempotency-Key was already used for a different request to "
+        f"{path}. Use a new key for a new request, or resend the original "
+        "request unchanged to replay its response.",
+        422,
+    )
+
+
+def build_in_progress_response() -> Response:
+    """409 for a duplicate that arrived while the original is still running."""
+    response = build_conflict_response(
+        "A request with this Idempotency-Key is already in progress.",
+        409,
+    )
+    # Without this the client has nothing to back off against and will hammer.
+    response.headers["Retry-After"] = str(RETRY_AFTER_SECONDS)
+
+    return response
+
+
+# ---------------------------------------------------------------------------
+# The route class
+# ---------------------------------------------------------------------------
 
 
 class IdempotentRoute(APIRoute):
-    """
-    Custom APIRoute that implements Idempotency for POST/PUT/PATCH requests.
-    Requires an 'Idempotency-Key' header. Caches the response in Redis for 24 hours.
+    """An ``APIRoute`` that honours ``Idempotency-Key`` on unsafe methods.
+
+    Attach with ``APIRouter(route_class=IdempotentRoute)``. Requests without
+    the header are unaffected, so this is safe to put on a whole router.
     """
 
     def get_route_handler(self) -> Callable:
@@ -48,87 +331,146 @@ class IdempotentRoute(APIRoute):
         async def custom_route_handler(request: Request) -> Response:
             idempotency_key = request.headers.get("Idempotency-Key")
 
-            if not idempotency_key or request.method not in ["POST", "PUT", "PATCH"]:
-                # If no key is provided, bypass idempotency check
+            if not idempotency_key or request.method not in IDEMPOTENT_METHODS:
                 return await original_route_handler(request)
 
-            if redis_client is None:
-                # Fallback if Redis is down
-                logger.warning(
-                    "Redis client is not available. Bypassing idempotency check."
-                )
+            user_id = extract_user_id(request)
+            if user_id is None:
+                # No identity to scope the entry to. See `extract_user_id`.
                 return await original_route_handler(request)
 
-            user_id = _extract_user_id(request)
+            client = await get_redis()
+            if client is None:
+                logger.warning("Idempotency: Redis unavailable, bypassing.")
+                return await original_route_handler(request)
 
-            cache_key = f"idempotent:{user_id}:{idempotency_key}"
+            path = request.url.path
 
-            # Check cache
+            # Reading the body here is safe: Starlette caches it on the
+            # request, so the handler downstream still receives it.
+            body = await request.body()
+
+            cache_key = build_cache_key(
+                user_id, request.method, path, idempotency_key
+            )
+            fingerprint = build_fingerprint(request.method, path, body)
+
+            # ---- Replay, if we have one ------------------------------------
+
             try:
-                cached_data_str = redis_client.get(cache_key)
-                if cached_data_str:
-                    data = json.loads(cached_data_str)
-
-                    headers = data.get("headers", {})
-                    headers["X-Idempotent-Cache"] = "hit"
-
-                    return Response(
-                        content=data["body"],
-                        status_code=data["status_code"],
-                        headers=headers,
-                        media_type=data.get("media_type", "application/json"),
-                    )
-            except Exception as e:
-                logger.error(f"Error reading idempotency key from Redis: {e}")
+                cached = await client.get(cache_key)
+            except Exception as exc:
+                logger.error("Idempotency: read failed for %s: %s", cache_key, exc)
                 return await original_route_handler(request)
 
-            # Lock to prevent race conditions on the same key
+            if cached:
+                try:
+                    stored = json.loads(cached)
+                except (TypeError, ValueError):
+                    # A corrupt entry should not wedge the endpoint forever.
+                    logger.error("Idempotency: corrupt entry at %s", cache_key)
+                    stored = None
+
+                if stored is not None:
+                    if stored.get("fingerprint") != fingerprint:
+                        return build_mismatch_response(path)
+
+                    return build_replay(stored)
+
+            # ---- Claim the key ---------------------------------------------
+            #
+            # One command, so there is no window in which the key exists
+            # without a TTL. `SETNX` followed by `EXPIRE` is two round trips,
+            # and a process killed between them left a lock that never expired
+            # -- that idempotency key then answered 409 forever, recoverable
+            # only by deleting it in Redis by hand.
+            #
+            # The value is a token unique to this attempt so that the release
+            # below can check it still owns the lock. Without that, a handler
+            # that overran the TTL would delete a lock a *different* request
+            # had since acquired.
+
             lock_key = f"{cache_key}:lock"
-            is_new = redis_client.setnx(lock_key, "locked")
-            if not is_new:
-                # Another request is currently processing this key
-                return Response(
-                    content=json.dumps(
-                        {"success": False, "message": "Request already in progress"}
-                    ),
-                    status_code=409,
-                    media_type="application/json",
-                )
-
-            redis_client.expire(lock_key, 60)  # 60 second lock
+            lock_token = uuid.uuid4().hex
 
             try:
-                # Process the request
-                response: Response = await original_route_handler(request)
+                acquired = await client.set(
+                    lock_key,
+                    lock_token,
+                    nx=True,
+                    ex=LOCK_TTL_SECONDS,
+                )
+            except Exception as exc:
+                logger.error("Idempotency: lock failed for %s: %s", lock_key, exc)
+                return await original_route_handler(request)
 
-                # Only cache successful or client-error responses, not 500s
-                if hasattr(response, "body") and response.status_code < 500:
-                    body_bytes = getattr(response, "body", b"")
-                    body_str = (
-                        body_bytes.decode("utf-8")
-                        if isinstance(body_bytes, bytes)
-                        else str(body_bytes)
+            if not acquired:
+                return build_in_progress_response()
+
+            # ---- Run, then store -------------------------------------------
+
+            try:
+                response = await original_route_handler(request)
+
+                body_bytes = getattr(response, "body", None)
+
+                if not isinstance(body_bytes, (bytes, bytearray)):
+                    # A StreamingResponse or FileResponse has no materialised
+                    # body. Consuming its iterator to cache it would break
+                    # streaming, so these are passed through unstored and the
+                    # response says so rather than leaving the client to
+                    # assume a retry will replay.
+                    response.headers[NOT_STORED_HEADER] = "false"
+                    return response
+
+                if response.status_code >= 500:
+                    # A server error is not an outcome worth making permanent
+                    # for 24 hours; the retry should get a real attempt.
+                    response.headers[NOT_STORED_HEADER] = "false"
+                    return response
+
+                try:
+                    await client.setex(
+                        cache_key,
+                        RESPONSE_TTL_SECONDS,
+                        serialise_response(response, bytes(body_bytes), fingerprint),
                     )
-                    cache_payload = {
-                        "status_code": response.status_code,
-                        "headers": dict(response.headers),
-                        "body": body_str,
-                        "media_type": getattr(
-                            response, "media_type", "application/json"
-                        ),
-                    }
-                    redis_client.setex(
-                        cache_key, 86400, json.dumps(cache_payload)
-                    )  # cache for 24 hours
-                    return Response(
-                        content=body_bytes,
-                        status_code=response.status_code,
-                        headers=dict(response.headers),
-                        media_type=getattr(response, "media_type", "application/json"),
+                    response.headers[NOT_STORED_HEADER] = "true"
+                except Exception as exc:
+                    # The handler already committed its work. Surfacing this
+                    # as a 500 would tell the client an operation failed when
+                    # it succeeded, and invite a retry of it.
+                    logger.error(
+                        "Idempotency: could not store response for %s: %s",
+                        cache_key,
+                        exc,
                     )
+                    response.headers[NOT_STORED_HEADER] = "false"
+
+                return response
+
             finally:
-                redis_client.delete(lock_key)
-
-            return response
+                await release_lock(client, lock_key, lock_token)
 
         return custom_route_handler
+
+
+#: Release the lock only if we still hold it. Compare-and-delete has to be
+#: atomic, or the check and the delete can straddle another request's
+#: acquisition.
+_RELEASE_LOCK_SCRIPT = """
+if redis.call('get', KEYS[1]) == ARGV[1] then
+    return redis.call('del', KEYS[1])
+end
+return 0
+"""
+
+
+async def release_lock(client: aioredis.Redis, lock_key: str, token: str) -> None:
+    """Drop our in-flight lock, tolerating any Redis failure."""
+    try:
+        await client.eval(_RELEASE_LOCK_SCRIPT, 1, lock_key, token)
+    except Exception as exc:
+        # The lock has a TTL, so the worst case is that this key rejects
+        # duplicates for a couple of minutes longer than necessary.
+        logger.warning("Idempotency: could not release %s: %s", lock_key, exc)

--- a/backend/tests/test_idempotency_middleware.py
+++ b/backend/tests/test_idempotency_middleware.py
@@ -1,0 +1,727 @@
+"""
+Tests for ``app.middleware.idempotency``.
+
+Everything here runs against an in-process fake Redis rather than a real
+server, so the suite has no external dependency and can exercise the awkward
+cases directly -- a lock that is already held, a read that raises, a write that
+raises, a corrupt stored entry.
+
+The fake implements only what the middleware uses (``get``, ``set`` with
+``nx``/``ex``, ``setex``, ``eval`` of the release script, ``delete``) and
+implements it with the same semantics, including ``SET NX`` returning ``None``
+when the key exists.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Optional
+
+import pytest
+from fastapi import APIRouter, FastAPI, Request
+from fastapi.responses import StreamingResponse
+from fastapi.testclient import TestClient
+
+from app.core.security import (
+    TokenType,
+    create_access_token,
+    create_refresh_token,
+    _create_token,
+)
+from app.middleware import idempotency
+from app.middleware.idempotency import (
+    CACHE_STATUS_HEADER,
+    LOCK_TTL_SECONDS,
+    NOT_STORED_HEADER,
+    RESPONSE_TTL_SECONDS,
+    IdempotentRoute,
+    build_cache_key,
+    build_fingerprint,
+    extract_user_id,
+    filter_headers,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake Redis
+# ---------------------------------------------------------------------------
+
+
+class FakeRedis:
+    """Enough of the async Redis surface for this middleware."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, tuple[str, Optional[float]]] = {}
+        self.fail_on_get = False
+        self.fail_on_set = False
+        self.fail_on_setex = False
+        self.set_calls: list[dict[str, Any]] = []
+
+    # -- internals ----------------------------------------------------------
+
+    def _live(self, key: str) -> Optional[str]:
+        entry = self.store.get(key)
+        if entry is None:
+            return None
+
+        value, expires_at = entry
+        if expires_at is not None and expires_at <= time.monotonic():
+            del self.store[key]
+            return None
+
+        return value
+
+    def ttl_of(self, key: str) -> Optional[float]:
+        entry = self.store.get(key)
+        if entry is None or entry[1] is None:
+            return None
+        return entry[1] - time.monotonic()
+
+    def seed(self, key: str, value: str) -> None:
+        self.store[key] = (value, None)
+
+    # -- the surface the middleware uses ------------------------------------
+
+    async def get(self, key: str) -> Optional[str]:
+        if self.fail_on_get:
+            raise ConnectionError("boom")
+        return self._live(key)
+
+    async def set(
+        self,
+        key: str,
+        value: str,
+        nx: bool = False,
+        ex: Optional[int] = None,
+    ) -> Optional[bool]:
+        if self.fail_on_set:
+            raise ConnectionError("boom")
+
+        self.set_calls.append({"key": key, "nx": nx, "ex": ex})
+
+        if nx and self._live(key) is not None:
+            # Real Redis returns None, not False, when NX declines.
+            return None
+
+        self.store[key] = (value, time.monotonic() + ex if ex else None)
+        return True
+
+    async def setex(self, key: str, seconds: int, value: str) -> bool:
+        if self.fail_on_setex:
+            raise ConnectionError("boom")
+        self.store[key] = (value, time.monotonic() + seconds)
+        return True
+
+    async def delete(self, key: str) -> int:
+        return 1 if self.store.pop(key, None) is not None else 0
+
+    async def eval(self, script: str, numkeys: int, *args: str) -> int:
+        """Only the compare-and-delete release script is ever evaluated."""
+        key, token = args[0], args[1]
+        if self._live(key) == token:
+            del self.store[key]
+            return 1
+        return 0
+
+    async def aclose(self) -> None:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def fake_redis(monkeypatch: pytest.MonkeyPatch) -> FakeRedis:
+    client = FakeRedis()
+
+    async def _get_redis():
+        return client
+
+    monkeypatch.setattr(idempotency, "get_redis", _get_redis)
+    return client
+
+
+@pytest.fixture()
+def token() -> str:
+    return create_access_token("11111111-1111-1111-1111-111111111111")
+
+
+@pytest.fixture()
+def other_token() -> str:
+    return create_access_token("22222222-2222-2222-2222-222222222222")
+
+
+@pytest.fixture()
+def app_and_counter():
+    """An app whose POST handler counts how many times it actually ran."""
+    calls = {"count": 0, "bodies": []}
+
+    router = APIRouter(route_class=IdempotentRoute)
+
+    @router.post("/things")
+    async def create_thing(request: Request):
+        calls["count"] += 1
+        body = await request.body()
+        calls["bodies"].append(body)
+        return {"id": calls["count"], "echo": body.decode() or None}
+
+    @router.post("/others")
+    async def create_other():
+        calls["count"] += 1
+        return {"where": "others"}
+
+    @router.post("/boom")
+    async def boom():
+        calls["count"] += 1
+        from fastapi.responses import JSONResponse
+
+        return JSONResponse({"detail": "nope"}, status_code=500)
+
+    @router.post("/rejected")
+    async def rejected():
+        calls["count"] += 1
+        from fastapi.responses import JSONResponse
+
+        return JSONResponse({"detail": "bad input"}, status_code=422)
+
+    @router.post("/stream")
+    async def stream():
+        calls["count"] += 1
+
+        def chunks():
+            yield b"a"
+            yield b"b"
+
+        return StreamingResponse(chunks(), media_type="text/plain")
+
+    @router.get("/things")
+    async def list_things():
+        calls["count"] += 1
+        return {"ok": True}
+
+    app = FastAPI()
+    app.include_router(router)
+
+    return app, calls
+
+
+@pytest.fixture()
+def client(app_and_counter):
+    app, _ = app_and_counter
+    return TestClient(app)
+
+
+@pytest.fixture()
+def calls(app_and_counter):
+    _, calls = app_and_counter
+    return calls
+
+
+def auth(token: str, key: Optional[str] = None) -> dict[str, str]:
+    headers = {"Authorization": f"Bearer {token}"}
+    if key:
+        headers["Idempotency-Key"] = key
+    return headers
+
+
+# ---------------------------------------------------------------------------
+# Identity
+# ---------------------------------------------------------------------------
+
+
+def _request_with_auth(header_value: Optional[str]) -> Request:
+    headers = []
+    if header_value is not None:
+        headers.append((b"authorization", header_value.encode()))
+
+    return Request({"type": "http", "headers": headers, "method": "POST", "path": "/"})
+
+
+def test_extract_user_id_reads_an_access_token(token: str) -> None:
+    assert extract_user_id(_request_with_auth(f"Bearer {token}")) == (
+        "11111111-1111-1111-1111-111111111111"
+    )
+
+
+def test_extract_user_id_rejects_a_refresh_token() -> None:
+    """A refresh token is a valid signature but the wrong kind of token.
+
+    The previous implementation called `jwt.decode` directly, which checks the
+    signature and the expiry and nothing else, so any token this service ever
+    minted authenticated here.
+    """
+    refresh = create_refresh_token("11111111-1111-1111-1111-111111111111")
+    assert extract_user_id(_request_with_auth(f"Bearer {refresh}")) is None
+
+
+def test_extract_user_id_rejects_a_password_reset_token() -> None:
+    from datetime import timedelta
+
+    reset = _create_token(
+        subject="11111111-1111-1111-1111-111111111111",
+        expires_delta=timedelta(minutes=10),
+        token_type=TokenType.RESET_PASSWORD,
+    )
+    assert extract_user_id(_request_with_auth(f"Bearer {reset}")) is None
+
+
+@pytest.mark.parametrize(
+    "header",
+    [None, "", "Basic abc", "Bearer ", "Bearer not-a-jwt", "bearer lowercase"],
+)
+def test_extract_user_id_returns_none_without_a_usable_token(header) -> None:
+    assert extract_user_id(_request_with_auth(header)) is None
+
+
+# ---------------------------------------------------------------------------
+# Keys and fingerprints
+# ---------------------------------------------------------------------------
+
+
+def test_cache_key_separates_endpoints() -> None:
+    """The same key against two paths must not collide."""
+    a = build_cache_key("u1", "POST", "/api/projects", "k")
+    b = build_cache_key("u1", "POST", "/api/applications", "k")
+    assert a != b
+
+
+def test_cache_key_separates_methods() -> None:
+    a = build_cache_key("u1", "POST", "/api/projects", "k")
+    b = build_cache_key("u1", "PUT", "/api/projects", "k")
+    assert a != b
+
+
+def test_cache_key_separates_callers() -> None:
+    a = build_cache_key("u1", "POST", "/api/projects", "k")
+    b = build_cache_key("u2", "POST", "/api/projects", "k")
+    assert a != b
+
+
+def test_cache_key_is_bounded_and_stable() -> None:
+    """Long client-supplied keys must not produce unbounded Redis keys."""
+    key = build_cache_key("u1", "POST", "/api/projects", "x" * 5000)
+    assert len(key) < 128
+    assert key == build_cache_key("u1", "POST", "/api/projects", "x" * 5000)
+
+
+def test_fingerprint_changes_with_the_body() -> None:
+    a = build_fingerprint("POST", "/p", b'{"n": 1}')
+    b = build_fingerprint("POST", "/p", b'{"n": 2}')
+    assert a != b
+
+
+def test_fingerprint_is_stable_for_an_identical_request() -> None:
+    a = build_fingerprint("POST", "/p", b'{"n": 1}')
+    b = build_fingerprint("POST", "/p", b'{"n": 1}')
+    assert a == b
+
+
+def test_filter_headers_drops_set_cookie_and_transport_headers() -> None:
+    from starlette.datastructures import Headers
+
+    kept = filter_headers(
+        Headers(
+            {
+                "content-type": "application/json",
+                "etag": '"abc"',
+                "set-cookie": "session=secret",
+                "date": "Sat, 16 Aug 2026 00:00:00 GMT",
+                "content-length": "42",
+                "server": "uvicorn",
+            }
+        )
+    )
+
+    assert kept == {"content-type": "application/json", "etag": '"abc"'}
+
+
+# ---------------------------------------------------------------------------
+# Replay
+# ---------------------------------------------------------------------------
+
+
+def test_a_repeated_request_runs_once(client, calls, fake_redis, token) -> None:
+    first = client.post("/things", json={"n": 1}, headers=auth(token, "k1"))
+    second = client.post("/things", json={"n": 1}, headers=auth(token, "k1"))
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json() == second.json()
+    assert calls["count"] == 1
+
+
+def test_a_replay_is_labelled(client, fake_redis, token) -> None:
+    client.post("/things", json={"n": 1}, headers=auth(token, "k1"))
+    replayed = client.post("/things", json={"n": 1}, headers=auth(token, "k1"))
+
+    assert replayed.headers[CACHE_STATUS_HEADER] == "true"
+
+
+def test_the_first_response_is_not_labelled_as_a_replay(
+    client, fake_redis, token
+) -> None:
+    first = client.post("/things", json={"n": 1}, headers=auth(token, "k1"))
+    assert CACHE_STATUS_HEADER not in first.headers
+    assert first.headers[NOT_STORED_HEADER] == "true"
+
+
+def test_requests_without_a_key_are_never_deduplicated(
+    client, calls, fake_redis, token
+) -> None:
+    client.post("/things", json={"n": 1}, headers=auth(token))
+    client.post("/things", json={"n": 1}, headers=auth(token))
+
+    assert calls["count"] == 2
+    assert fake_redis.store == {}
+
+
+def test_get_requests_are_untouched(client, calls, fake_redis, token) -> None:
+    client.get("/things", headers=auth(token, "k1"))
+    client.get("/things", headers=auth(token, "k1"))
+
+    assert calls["count"] == 2
+
+
+def test_the_handler_still_receives_the_body(client, calls, fake_redis, token) -> None:
+    """The middleware reads the body to fingerprint it; the handler must
+    still get it. Starlette caches it on the request, but that is exactly the
+    kind of thing that quietly stops being true."""
+    client.post("/things", json={"n": 7}, headers=auth(token, "k1"))
+
+    assert len(calls["bodies"]) == 1
+    assert json.loads(calls["bodies"][0]) == {"n": 7}
+
+
+# ---------------------------------------------------------------------------
+# Request binding -- the bug this rewrite is about
+# ---------------------------------------------------------------------------
+
+
+def test_reusing_a_key_with_a_different_body_is_rejected(
+    client, calls, fake_redis, token
+) -> None:
+    """The original defect: this used to replay the first response."""
+    first = client.post("/things", json={"n": 1}, headers=auth(token, "k1"))
+    second = client.post("/things", json={"n": 2}, headers=auth(token, "k1"))
+
+    assert first.status_code == 200
+    assert second.status_code == 422
+    assert "different request" in second.json()["message"]
+
+    # The second request was rejected, not silently answered with the first
+    # request's response, and it did not execute.
+    assert calls["count"] == 1
+
+
+def test_a_key_reused_against_a_different_endpoint_runs(
+    client, calls, fake_redis, token
+) -> None:
+    """Different endpoints do not collide, so both requests execute.
+
+    Previously the second call got the first endpoint's response body.
+    """
+    first = client.post("/things", json={"n": 1}, headers=auth(token, "k1"))
+    second = client.post("/others", headers=auth(token, "k1"))
+
+    assert json.loads(first.json()["echo"]) == {"n": 1}
+    assert second.json() == {"where": "others"}
+    assert calls["count"] == 2
+
+
+def test_two_users_with_the_same_key_do_not_share_a_response(
+    client, calls, fake_redis, token, other_token
+) -> None:
+    first = client.post("/things", json={"n": 1}, headers=auth(token, "shared"))
+    second = client.post("/things", json={"n": 1}, headers=auth(other_token, "shared"))
+
+    assert calls["count"] == 2
+    assert first.json()["id"] != second.json()["id"]
+
+
+def test_unauthenticated_requests_bypass_idempotency(
+    client, calls, fake_redis
+) -> None:
+    """No identity means no safe way to scope the entry, so no caching.
+
+    The old code bucketed every anonymous caller under the literal string
+    "anonymous", so one could read another's cached response.
+    """
+    client.post("/things", json={"n": 1}, headers={"Idempotency-Key": "k1"})
+    client.post("/things", json={"n": 1}, headers={"Idempotency-Key": "k1"})
+
+    assert calls["count"] == 2
+    assert fake_redis.store == {}
+
+
+def test_a_refresh_token_does_not_authenticate_the_cache_entry(
+    client, calls, fake_redis
+) -> None:
+    refresh = create_refresh_token("11111111-1111-1111-1111-111111111111")
+
+    client.post("/things", json={"n": 1}, headers=auth(refresh, "k1"))
+    client.post("/things", json={"n": 1}, headers=auth(refresh, "k1"))
+
+    assert calls["count"] == 2
+    assert fake_redis.store == {}
+
+
+# ---------------------------------------------------------------------------
+# The lock
+# ---------------------------------------------------------------------------
+
+
+def test_the_lock_is_acquired_atomically_with_its_ttl(
+    client, fake_redis, token
+) -> None:
+    """`SET NX EX` in one command.
+
+    `SETNX` followed by a separate `EXPIRE` left the key without a TTL if the
+    process died in between, and that key then answered 409 forever.
+    """
+    client.post("/things", json={"n": 1}, headers=auth(token, "k1"))
+
+    lock_sets = [c for c in fake_redis.set_calls if c["key"].endswith(":lock")]
+    assert len(lock_sets) == 1
+    assert lock_sets[0]["nx"] is True
+    assert lock_sets[0]["ex"] == LOCK_TTL_SECONDS
+
+
+def test_a_duplicate_in_flight_gets_409_with_retry_after(
+    client, calls, fake_redis, token
+) -> None:
+    cache_key = build_cache_key(
+        "11111111-1111-1111-1111-111111111111", "POST", "/things", "k1"
+    )
+    fake_redis.store[f"{cache_key}:lock"] = ("someone-else", None)
+
+    response = client.post("/things", json={"n": 1}, headers=auth(token, "k1"))
+
+    assert response.status_code == 409
+    assert response.headers["Retry-After"] == "2"
+    assert calls["count"] == 0
+
+
+def test_the_lock_is_released_after_a_successful_request(
+    client, fake_redis, token
+) -> None:
+    client.post("/things", json={"n": 1}, headers=auth(token, "k1"))
+
+    assert not [k for k in fake_redis.store if k.endswith(":lock")]
+
+
+def test_the_lock_is_released_when_the_handler_raises(fake_redis, token) -> None:
+    router = APIRouter(route_class=IdempotentRoute)
+
+    @router.post("/explode")
+    async def explode():
+        raise RuntimeError("handler blew up")
+
+    app = FastAPI()
+    app.include_router(router)
+
+    with pytest.raises(RuntimeError):
+        TestClient(app, raise_server_exceptions=True).post(
+            "/explode", headers=auth(token, "k1")
+        )
+
+    assert not [k for k in fake_redis.store if k.endswith(":lock")]
+
+
+def test_releasing_only_removes_our_own_lock(fake_redis) -> None:
+    """A handler that overran the TTL must not delete a successor's lock."""
+    import asyncio
+
+    from app.middleware.idempotency import release_lock
+
+    fake_redis.store["k:lock"] = ("someone-elses-token", None)
+
+    asyncio.run(release_lock(fake_redis, "k:lock", "our-token"))
+
+    assert fake_redis.store["k:lock"] == ("someone-elses-token", None)
+
+
+def test_releasing_removes_a_lock_we_hold(fake_redis) -> None:
+    import asyncio
+
+    from app.middleware.idempotency import release_lock
+
+    fake_redis.store["k:lock"] = ("our-token", None)
+
+    asyncio.run(release_lock(fake_redis, "k:lock", "our-token"))
+
+    assert "k:lock" not in fake_redis.store
+
+
+def test_a_second_request_succeeds_after_the_first_completes(
+    client, calls, fake_redis, token
+) -> None:
+    """The lock must not outlive the request that took it."""
+    client.post("/things", json={"n": 1}, headers=auth(token, "k1"))
+    second = client.post("/things", json={"n": 1}, headers=auth(token, "k1"))
+
+    assert second.status_code == 200
+    assert calls["count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# What gets stored
+# ---------------------------------------------------------------------------
+
+
+def test_a_stored_entry_carries_the_fingerprint_and_a_ttl(
+    client, calls, fake_redis, token
+) -> None:
+    client.post("/things", json={"n": 1}, headers=auth(token, "k1"))
+
+    cache_key = build_cache_key(
+        "11111111-1111-1111-1111-111111111111", "POST", "/things", "k1"
+    )
+    stored = json.loads(fake_redis.store[cache_key][0])
+
+    # Fingerprinted over the bytes the handler actually saw, rather than a
+    # re-serialisation of the same object -- the client's encoding is not
+    # ours to guess.
+    assert stored["fingerprint"] == build_fingerprint(
+        "POST", "/things", calls["bodies"][0]
+    )
+    assert stored["status_code"] == 200
+
+    ttl = fake_redis.ttl_of(cache_key)
+    assert ttl is not None and 0 < ttl <= RESPONSE_TTL_SECONDS
+
+
+def test_a_client_error_is_stored_and_replayed(
+    client, calls, fake_redis, token
+) -> None:
+    """A rejection is a real outcome; replaying it keeps the retry consistent."""
+    first = client.post("/rejected", headers=auth(token, "k1"))
+    second = client.post("/rejected", headers=auth(token, "k1"))
+
+    assert first.status_code == 422
+    assert second.status_code == 422
+    assert second.headers[CACHE_STATUS_HEADER] == "true"
+    assert calls["count"] == 1
+
+
+def test_a_server_error_is_not_stored(client, calls, fake_redis, token) -> None:
+    """A 500 should not be made permanent for 24 hours."""
+    first = client.post("/boom", headers=auth(token, "k1"))
+    second = client.post("/boom", headers=auth(token, "k1"))
+
+    assert first.status_code == 500
+    assert first.headers[NOT_STORED_HEADER] == "false"
+    assert second.status_code == 500
+    assert calls["count"] == 2
+
+
+def test_a_streaming_response_is_passed_through_unstored(
+    client, calls, fake_redis, token
+) -> None:
+    """Consuming the iterator to cache it would break streaming."""
+    first = client.post("/stream", headers=auth(token, "k1"))
+
+    assert first.status_code == 200
+    assert first.text == "ab"
+    assert first.headers[NOT_STORED_HEADER] == "false"
+
+    second = client.post("/stream", headers=auth(token, "k1"))
+    assert second.text == "ab"
+    assert calls["count"] == 2
+
+
+def test_set_cookie_is_not_replayed(fake_redis, token) -> None:
+    router = APIRouter(route_class=IdempotentRoute)
+
+    @router.post("/login-ish")
+    async def login_ish():
+        from fastapi.responses import JSONResponse
+
+        response = JSONResponse({"ok": True})
+        response.set_cookie("session", "supersecret")
+        return response
+
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    first = client.post("/login-ish", headers=auth(token, "k1"))
+    assert "set-cookie" in {k.lower() for k in first.headers}
+
+    second = client.post("/login-ish", headers=auth(token, "k1"))
+    assert second.headers[CACHE_STATUS_HEADER] == "true"
+    assert "set-cookie" not in {k.lower() for k in second.headers}
+
+
+# ---------------------------------------------------------------------------
+# Failure posture
+# ---------------------------------------------------------------------------
+
+
+def test_redis_unavailable_bypasses_cleanly(
+    client, calls, monkeypatch, token
+) -> None:
+    async def _no_redis():
+        return None
+
+    monkeypatch.setattr(idempotency, "get_redis", _no_redis)
+
+    first = client.post("/things", json={"n": 1}, headers=auth(token, "k1"))
+    second = client.post("/things", json={"n": 1}, headers=auth(token, "k1"))
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert calls["count"] == 2
+
+
+def test_a_failing_read_bypasses_rather_than_500s(
+    client, calls, fake_redis, token
+) -> None:
+    fake_redis.fail_on_get = True
+
+    response = client.post("/things", json={"n": 1}, headers=auth(token, "k1"))
+
+    assert response.status_code == 200
+    assert calls["count"] == 1
+
+
+def test_a_failing_lock_bypasses_rather_than_500s(
+    client, calls, fake_redis, token
+) -> None:
+    fake_redis.fail_on_set = True
+
+    response = client.post("/things", json={"n": 1}, headers=auth(token, "k1"))
+
+    assert response.status_code == 200
+    assert calls["count"] == 1
+
+
+def test_a_failing_write_does_not_turn_a_success_into_a_500(
+    client, calls, fake_redis, token
+) -> None:
+    """The handler already committed. A cache failure must not tell the
+    client the operation failed and invite them to retry it."""
+    fake_redis.fail_on_setex = True
+
+    response = client.post("/things", json={"n": 1}, headers=auth(token, "k1"))
+
+    assert response.status_code == 200
+    assert response.json()["id"] == 1
+    assert response.headers[NOT_STORED_HEADER] == "false"
+    assert calls["count"] == 1
+
+
+def test_a_corrupt_stored_entry_does_not_wedge_the_endpoint(
+    client, calls, fake_redis, token
+) -> None:
+    cache_key = build_cache_key(
+        "11111111-1111-1111-1111-111111111111", "POST", "/things", "k1"
+    )
+    fake_redis.seed(cache_key, "{not json")
+
+    response = client.post("/things", json={"n": 1}, headers=auth(token, "k1"))
+
+    assert response.status_code == 200
+    assert calls["count"] == 1


### PR DESCRIPTION
Fixes #1195

`IdempotentRoute` is the route class for `projects`, `applications` and `issues` — the three routers where a duplicate write costs the most. It was not delivering idempotency.

## The core defect

The cache key was the client's key and nothing else:

```python
cache_key = f"idempotent:{user_id}:{idempotency_key}"
```

Nothing about *which request* this was — not the method, not the path, not the body — was stored or compared. So a client that reused a key across two genuinely different requests got the first response replayed for the second, and the second was never executed:

```
POST /api/v1/projects        Idempotency-Key: abc   -> 201 {"id": "proj_1", ...}
POST /api/v1/applications    Idempotency-Key: abc   -> 201 {"id": "proj_1", ...}   # never ran
```

Silent data loss, and the shape of client that hits it — a mobile app deriving the key from a screen-level UUID, anything retrying a batch under one key — is exactly the shape of client that needs idempotency in the first place.

**Now:** the Redis key covers `(caller, method, path, key)`, and the stored entry carries a SHA-256 fingerprint of the body. Method and path are in the *key* rather than only the fingerprint, so the same key against two different endpoints does not collide at all — both requests run, which is what the client meant. A replay to the *same* endpoint whose body fingerprint disagrees gets **422** rather than someone else's response. That is what Stripe and the IETF `Idempotency-Key` draft both do, and a loud rejection is far easier to debug than a wrong body.

Headers are deliberately not fingerprinted: a legitimate retry carries a different `User-Agent`, trace id, or `Authorization` (a refreshed token), and rejecting on those would make the feature unusable.

## The lock could strand a key permanently

```python
is_new = redis_client.setnx(lock_key, "locked")
if not is_new:
    return Response(..., status_code=409)
redis_client.expire(lock_key, 60)
```

Two round trips. A process killed, a dropped connection, or a Redis failover between them left the lock key **with no TTL** — and that idempotency key then answered 409 forever, recoverable only by deleting it in Redis by hand.

Now a single `SET key token NX EX 120`, which cannot land in that state. The value is a token unique to this attempt and release is a compare-and-delete Lua script, so a handler that overruns the TTL cannot delete a lock a *different* request has since acquired. The TTL went from 60s to 120s so it sits above the request timeout rather than below it — a lock that expires mid-handler lets a retry run concurrently, which is the exact duplicate this exists to prevent.

## Blocking the event loop

The route handler is `async`, but every Redis call was the synchronous client — `get`, `setnx`, `expire`, `setex`, `delete` were all blocking socket reads on the event loop thread, stalling every other in-flight request on the worker. Now `redis.asyncio`.

The client is also built lazily instead of at import, so a Redis that is merely slow to start no longer takes the application down with it, and the module can be imported by a test that does not care about idempotency.

## Identity

`jwt.decode` was called directly, which verifies the signature and the expiry and *nothing else* — so a refresh, verification, or password-reset token authenticated here. `app/core/security.py` already exposes `decode_token(..., expected_type=TokenType.ACCESS)` for exactly this; it is used now.

Unauthenticated callers were all bucketed under the literal string `"anonymous"`, so one anonymous client could read another's cached response body by reusing a guessable key. There is no safe way to scope a cache entry to an unidentified caller, so unauthenticated requests now bypass idempotency entirely.

## Failure posture

This layer is an optimisation on top of a correct API, so it fails **open** everywhere it can. The one thing it fails closed on is the concurrency lock.

The cache write was previously unguarded: a Redis failure at that moment propagated *after* the handler had committed its work, so the client saw a 500 for an operation that had succeeded — and retried it. It is now logged and swallowed. Responses carry `X-Idempotent-Stored` so a caller knows whether a retry will replay or re-execute.

A corrupt stored entry no longer wedges the endpoint; it is logged and the request runs.

## Replayed headers

`dict(response.headers)` was stored and re-sent verbatim, including `Date`, `Content-Length` and any `Set-Cookie`. Replaying a day-old `Set-Cookie` is not something a cache should do. Only payload headers survive now (`Content-Type`, `Content-Language`, `Location`, `ETag`, `Cache-Control`); `Content-Length` is recomputed by Starlette.

## Other behaviour

- A duplicate in flight gets `Retry-After: 2` alongside its 409, so the client has something to back off against.
- 5xx responses are not stored — a server error should not be made permanent for 24 hours.
- 4xx responses *are* stored and replayed. A rejection is a real outcome, and a retry should get the same answer.
- Streaming and file responses are passed through unstored rather than having their iterator consumed (which would break streaming), and are labelled so the caller knows.

## Tests

`tests/test_idempotency_middleware.py`, 44 tests, running against an in-process fake Redis — no server needed, and it can exercise the awkward paths directly: a lock already held, a read that raises, a write that raises, a corrupt entry.

The ones that matter most:

- `test_reusing_a_key_with_a_different_body_is_rejected` — the original defect
- `test_a_key_reused_against_a_different_endpoint_runs`
- `test_two_users_with_the_same_key_do_not_share_a_response`
- `test_unauthenticated_requests_bypass_idempotency`
- `test_a_refresh_token_does_not_authenticate_the_cache_entry`
- `test_the_lock_is_acquired_atomically_with_its_ttl`
- `test_releasing_only_removes_our_own_lock`
- `test_a_failing_write_does_not_turn_a_success_into_a_500`
- `test_set_cookie_is_not_replayed`

The fake reproduces real Redis semantics where they matter, including `SET NX` returning `None` rather than `False` when it declines.

## Note on CI

`main` currently does not compile (#1194), so **every** backend test fails at collection right now, including these. #1199 fixes that. I verified this branch locally with that fix applied: 44/44 pass, and `test_projects.py` / `test_applications.py` / `test_issues.py` — the three routers using this route class — are unchanged apart from the pre-existing `test_invite_user` failure, which needs a live Redis for Celery and fails on `main` too.

## Review notes

- `LOCK_TTL_SECONDS = 120` is a guess at "comfortably above the request timeout". If there is a real number for that in this deployment, it should be that instead.
- The cache key is versioned (`idempotent:v2:`) so existing v1 entries are simply ignored rather than misread. They expire on their own within 24 hours.
- Fingerprinting the raw body means a client that re-serialises its JSON with different key ordering or whitespace between attempts will get a 422. That is the strict reading and matches Stripe. Happy to relax it to a canonicalised form if we think clients will trip on it.
