### PR TITLE
fix(security): validate uploads by content, and contain every storage path

### DIFF
--- a/backend/app/core/file_validation.py
+++ b/backend/app/core/file_validation.py
@@ -1,0 +1,343 @@
+"""
+Deciding what an uploaded file actually is, and where it is allowed to go.
+
+Two rules, both of which the storage layer was breaking.
+
+**What a file is comes from its bytes.** ``UploadFile.content_type`` is the
+``Content-Type`` of the multipart part, which the uploader writes. Trusting it
+means an attacker uploads ``payload.svg`` or an HTML document and simply
+declares ``image/png``. The allowlist check passes and the file is stored.
+
+**Where a file goes is our decision, not the client's.** The stored extension
+was copied out of the client's filename, so ``x.html`` declared as
+``image/png`` was written as ``<uuid>.html`` into a directory served under
+``/static/uploads/`` -- same origin, attacker-authored HTML, stored XSS against
+every session on the site. And ``delete_file`` joined a caller-supplied object
+name straight onto ``UPLOAD_DIR``, which ``os.path.join`` does nothing to
+constrain: ``"../../app/core/config.py"`` resolves outside the directory and is
+removed.
+
+This module has no FastAPI, SQLAlchemy or boto3 imports on purpose -- it is
+pure byte and path handling, so it is cheap to test exhaustively and can be
+used from any layer.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Final, Iterable, Optional
+
+# ---------------------------------------------------------------------------
+# Magic-byte signatures
+# ---------------------------------------------------------------------------
+#
+# (offset, signature, media type). Ordered most-specific first: WEBP and the
+# various TIFF flavours share prefixes with nothing else here, but RIFF alone
+# is also the container for WAV, so WEBP is matched on the full pair.
+
+_SIGNATURES: Final[tuple[tuple[int, bytes, str], ...]] = (
+    (0, b"\x89PNG\r\n\x1a\n", "image/png"),
+    (0, b"\xff\xd8\xff", "image/jpeg"),
+    (0, b"GIF87a", "image/gif"),
+    (0, b"GIF89a", "image/gif"),
+    (0, b"BM", "image/bmp"),
+    (0, b"II*\x00", "image/tiff"),
+    (0, b"MM\x00*", "image/tiff"),
+    (0, b"%PDF-", "application/pdf"),
+    (0, b"PK\x03\x04", "application/zip"),
+    (0, b"\x1a\x45\xdf\xa3", "video/webm"),
+    (0, b"OggS", "audio/ogg"),
+    (0, b"ID3", "audio/mpeg"),
+    (0, b"\xff\xfb", "audio/mpeg"),
+    (0, b"\xff\xf3", "audio/mpeg"),
+    (0, b"\xff\xf2", "audio/mpeg"),
+    (0, b"MZ", "application/x-dosexec"),
+    (0, b"\x7fELF", "application/x-elf"),
+)
+
+#: Signatures that need a second check further into the file, because their
+#: leading bytes are a container shared with other formats.
+_RIFF_SUBTYPES: Final[dict[bytes, str]] = {
+    b"WEBP": "image/webp",
+    b"WAVE": "audio/wav",
+    b"AVI ": "video/x-msvideo",
+}
+
+#: ISO base media file format (MP4 and friends) puts `ftyp` at offset 4.
+_FTYP_BRANDS: Final[dict[bytes, str]] = {
+    b"qt  ": "video/quicktime",
+    b"M4A ": "audio/mp4",
+}
+
+#: How many bytes are enough to identify anything above.
+SNIFF_LENGTH: Final[int] = 64
+
+#: Media types that are never acceptable as an "image", no matter what the
+#: client says or what the extension is. SVG and HTML are script hosts; served
+#: from our own origin they are stored XSS. The executables are here so a
+#: mislabelled binary is named accurately in the error.
+DANGEROUS_TYPES: Final[frozenset[str]] = frozenset(
+    {
+        "image/svg+xml",
+        "text/html",
+        "application/xhtml+xml",
+        "application/x-dosexec",
+        "application/x-elf",
+        "application/javascript",
+        "application/x-httpd-php",
+    }
+)
+
+#: The extension we give a file, chosen by its *detected* type.
+EXTENSION_FOR_TYPE: Final[dict[str, str]] = {
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+    "image/bmp": ".bmp",
+    "image/tiff": ".tiff",
+    "application/pdf": ".pdf",
+    "video/mp4": ".mp4",
+    "video/webm": ".webm",
+    "video/quicktime": ".mov",
+    "audio/mpeg": ".mp3",
+    "audio/wav": ".wav",
+    "audio/ogg": ".ogg",
+    "audio/mp4": ".m4a",
+}
+
+#: A path segment we are willing to create: one component, no separators, no
+#: dots at the edges, nothing that could climb out of a directory.
+_SAFE_SEGMENT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
+
+
+class UnsafeUpload(ValueError):
+    """The upload is not something we are willing to store."""
+
+
+class UnsafePath(ValueError):
+    """A path argument resolved outside the directory it must stay inside."""
+
+
+class UploadTooLarge(UnsafeUpload):
+    """The payload exceeded the configured limit."""
+
+
+# ---------------------------------------------------------------------------
+# Sniffing
+# ---------------------------------------------------------------------------
+
+
+def _looks_like_markup(head: bytes) -> Optional[str]:
+    """Detect SVG/HTML by content.
+
+    Both are text formats with no magic number, and both are dangerous to
+    serve from our own origin, so they are worth identifying positively rather
+    than falling through to "unknown". Leading whitespace, a BOM, an XML
+    declaration or a doctype can all precede the real first tag.
+    """
+    prefix = head.lstrip(b"\xef\xbb\xbf \t\r\n")[:512].lower()
+
+    if not prefix.startswith(b"<"):
+        return None
+
+    if b"<svg" in prefix:
+        return "image/svg+xml"
+
+    if prefix.startswith(b"<!doctype html") or b"<html" in prefix:
+        return "text/html"
+
+    if prefix.startswith(b"<?php"):
+        return "application/x-httpd-php"
+
+    if prefix.startswith(b"<?xml") and b"<svg" in prefix:
+        return "image/svg+xml"
+
+    return None
+
+
+def detect_content_type(data: bytes) -> Optional[str]:
+    """The media type of ``data`` according to its bytes, or ``None``.
+
+    ``None`` means "not a format we recognise", which callers treat as "not
+    allowed" rather than "probably fine".
+    """
+    if not data:
+        return None
+
+    head = data[:SNIFF_LENGTH]
+
+    # RIFF containers carry their real type at offset 8.
+    if head.startswith(b"RIFF") and len(head) >= 12:
+        subtype = _RIFF_SUBTYPES.get(head[8:12])
+        if subtype:
+            return subtype
+
+    # ISO base media: `ftyp` at offset 4, brand at offset 8.
+    if len(head) >= 12 and head[4:8] == b"ftyp":
+        return _FTYP_BRANDS.get(head[8:12], "video/mp4")
+
+    for offset, signature, media_type in _SIGNATURES:
+        if head[offset : offset + len(signature)] == signature:
+            return media_type
+
+    return _looks_like_markup(head)
+
+
+def extension_for(media_type: str, fallback: str = ".bin") -> str:
+    """The extension we will store a file of this type under."""
+    return EXTENSION_FOR_TYPE.get(media_type, fallback)
+
+
+# ---------------------------------------------------------------------------
+# Scanning
+# ---------------------------------------------------------------------------
+
+#: Byte sequences we refuse anywhere in the payload.
+#:
+#: The previous check used `contents.startswith(...)`, which any polyglot
+#: defeats by construction -- a valid PNG header followed by `<?php ... ?>`
+#: passed. Scanning the whole buffer costs a pass over a few megabytes and
+#: catches the case the prefix check was presumably meant to catch.
+_EMBEDDED_PATTERNS: Final[tuple[tuple[bytes, str], ...]] = (
+    (b"<?php", "embedded PHP"),
+    (b"<script", "embedded script tag"),
+    (b"javascript:", "javascript: URL"),
+    (b"<%@", "embedded server-side include"),
+)
+
+#: Executable formats, matched only at the start. Unlike the patterns above
+#: these are legitimate byte sequences to find *inside* a media file -- "MZ"
+#: is two ASCII letters -- so matching them anywhere produces false positives
+#: on ordinary uploads.
+_EXECUTABLE_SIGNATURES: Final[tuple[tuple[bytes, str], ...]] = (
+    (b"MZ", "Windows executable"),
+    (b"\x7fELF", "ELF executable"),
+    (b"\xca\xfe\xba\xbe", "Mach-O executable"),
+    (b"#!", "shell script"),
+)
+
+
+def scan_bytes(data: bytes, filename: str = "upload") -> None:
+    """Reject payloads carrying executable or scriptable content.
+
+    Raises :class:`UnsafeUpload`. This is a heuristic, not an antivirus -- it
+    is the cheap layer in front of a real scanner, and the docstring says so
+    rather than implying more than it does.
+    """
+    if not data:
+        raise UnsafeUpload(f"{filename} is empty.")
+
+    lowered = data.lower()
+
+    for pattern, description in _EMBEDDED_PATTERNS:
+        if pattern in lowered:
+            raise UnsafeUpload(
+                f"{filename} was rejected: {description} detected in the file."
+            )
+
+    for signature, description in _EXECUTABLE_SIGNATURES:
+        if data.startswith(signature):
+            raise UnsafeUpload(
+                f"{filename} was rejected: it is a {description}."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Combined validation
+# ---------------------------------------------------------------------------
+
+
+def validate_upload_bytes(
+    data: bytes,
+    allowed_types: Iterable[str],
+    filename: str = "upload",
+    declared_type: Optional[str] = None,
+) -> str:
+    """Decide whether ``data`` may be stored, and return its detected type.
+
+    ``declared_type`` -- the client's ``Content-Type`` -- is accepted as an
+    argument so it can be reported in the error message when it disagrees with
+    reality. It never gets a vote.
+    """
+    scan_bytes(data, filename)
+
+    detected = detect_content_type(data)
+
+    if detected is None:
+        raise UnsafeUpload(
+            f"{filename} is not a recognised file format. "
+            f"Allowed types: {', '.join(sorted(allowed_types))}."
+        )
+
+    if detected in DANGEROUS_TYPES:
+        raise UnsafeUpload(
+            f"{filename} is a {detected} file, which cannot be stored."
+        )
+
+    normalised = {t.strip().lower() for t in allowed_types if t and t.strip()}
+
+    if detected not in normalised:
+        if declared_type and declared_type.strip().lower() != detected:
+            raise UnsafeUpload(
+                f"{filename} claims to be {declared_type} but its contents are "
+                f"{detected}, which is not an allowed type."
+            )
+
+        raise UnsafeUpload(
+            f"{filename} is a {detected} file. "
+            f"Allowed types: {', '.join(sorted(normalised))}."
+        )
+
+    return detected
+
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+
+def validate_path_segment(segment: str, label: str = "directory") -> str:
+    """Assert ``segment`` is a single safe path component and return it.
+
+    Used for the ``directory`` argument that upload callers pass. It ends up
+    in ``os.path.join(UPLOAD_DIR, directory)``, which constrains nothing.
+    """
+    if not segment or not _SAFE_SEGMENT.match(segment):
+        raise UnsafePath(
+            f"Invalid {label} {segment!r}: expected a single path segment of "
+            "letters, digits, hyphens and underscores."
+        )
+
+    return segment
+
+
+def safe_join(base: Path | str, *parts: str) -> Path:
+    """Join ``parts`` onto ``base`` and assert the result stays inside it.
+
+    ``os.path.join`` is not a security boundary. It happily produces a path
+    outside ``base`` given ``..`` segments, and given an *absolute* second
+    argument it discards ``base`` entirely. Both are reachable from a
+    caller-supplied object name.
+
+    Resolution is lexical (``os.path.normpath`` semantics via
+    ``Path.resolve``) so this works for paths that do not exist yet, which is
+    the case on the write path.
+    """
+    base_path = Path(base).resolve()
+
+    candidate = base_path
+    for part in parts:
+        if not part:
+            continue
+        candidate = candidate / part
+
+    resolved = candidate.resolve()
+
+    if resolved != base_path and base_path not in resolved.parents:
+        raise UnsafePath(
+            f"Path {'/'.join(parts)!r} resolves outside {base_path}."
+        )
+
+    return resolved

--- a/backend/app/core/storage.py
+++ b/backend/app/core/storage.py
@@ -1,30 +1,113 @@
+import asyncio
 import logging
-import os
 import uuid
+from pathlib import Path
+from typing import Optional
 
 import boto3  # type: ignore
 from botocore.exceptions import ClientError  # type: ignore
-from fastapi import UploadFile, HTTPException, status
+from fastapi import HTTPException, UploadFile, status
+
 from app.core.config import settings
+from app.core.file_validation import (
+    UnsafePath,
+    UnsafeUpload,
+    UploadTooLarge,
+    detect_content_type,
+    extension_for,
+    safe_join,
+    scan_bytes,
+    validate_path_segment,
+    validate_upload_bytes,
+)
 
 logger = logging.getLogger(__name__)
 
+#: Read the upload in chunks so an oversized body is abandoned partway rather
+#: than buffered in full before anyone checks its size.
+CHUNK_SIZE = 64 * 1024
+
 
 def scan_file_for_malware(contents: bytes, filename: str) -> None:
-    """
-    Malware scanning hook for uploaded files.
-    Raises ValueError / HTTPException if malicious code or disallowed signatures are found.
-    """
-    if not contents:
-        raise ValueError("Uploaded file payload is empty.")
+    """Reject uploads carrying executable or scriptable content.
 
-    # Basic script/executable signature verification hook
-    suspicious_signatures = [b"<?php", b"<script", b"MZ", b"\x7fELF"]
-    for sig in suspicious_signatures:
-        if contents.startswith(sig):
-            raise ValueError(
-                f"Security violation: Prohibited file signature detected in {filename}."
+    Kept as a module-level function because callers import it by this name.
+    The implementation now lives in :mod:`app.core.file_validation` and scans
+    the whole payload rather than only its first few bytes.
+
+    ``app/utils/uploads.py`` still carries its own copy of the old prefix-only
+    version. Consolidating the two is deliberately left out of this change so
+    it does not collide with the repair in #1199, which rewrites large parts of
+    that file; once that lands it is a one-line import swap.
+    """
+    try:
+        scan_bytes(contents, filename)
+    except UnsafeUpload as exc:
+        # Callers have always caught ValueError here, and UnsafeUpload is one.
+        raise ValueError(str(exc)) from exc
+
+
+def _allowed_image_types() -> set[str]:
+    """The configured image allowlist, parsed once per call and normalised.
+
+    Previously re-split on every validation without lowercasing either side,
+    so a perfectly good ``IMAGE/PNG`` was rejected.
+    """
+    return {
+        media_type.strip().lower()
+        for media_type in settings.ALLOWED_IMAGE_TYPES.split(",")
+        if media_type.strip()
+    }
+
+
+def _max_upload_bytes() -> int:
+    return settings.MAX_UPLOAD_SIZE_MB * 1024 * 1024
+
+
+def read_upload(file: UploadFile, max_bytes: Optional[int] = None) -> bytes:
+    """Read an upload, enforcing the size limit as we go.
+
+    The previous code checked ``file.size`` and then read the whole body::
+
+        if file.size and file.size > limit:   # `size` is often None
+            raise ...
+        file_bytes = file.file.read()         # unbounded
+
+    ``UploadFile.size`` comes from the part's ``Content-Length``. A chunked
+    upload -- or a client that simply omits the header -- leaves it ``None``,
+    the ``and`` short-circuits, and the limit never runs. The next line then
+    pulls the entire body into memory. A handful of concurrent large uploads
+    is an OOM, prevented by a check that did not execute.
+
+    Reading in bounded chunks means the limit holds whether or not the client
+    declared a length, and an oversized body is abandoned after one chunk past
+    the limit rather than after all of it.
+    """
+    limit = _max_upload_bytes() if max_bytes is None else max_bytes
+
+    chunks: list[bytes] = []
+    total = 0
+
+    file.file.seek(0)
+
+    while True:
+        chunk = file.file.read(CHUNK_SIZE)
+        if not chunk:
+            break
+
+        total += len(chunk)
+        if total > limit:
+            raise UploadTooLarge(
+                f"File size exceeds maximum limit of "
+                f"{limit // (1024 * 1024)}MB"
             )
+
+        chunks.append(chunk)
+
+    if total == 0:
+        raise UnsafeUpload("Uploaded file is empty.")
+
+    return b"".join(chunks)
 
 
 class CloudStorageService:
@@ -58,59 +141,82 @@ class CloudStorageService:
         else:
             logger.error(f"Unknown storage provider: {self.provider}")
 
-    def _validate_file(self, file: UploadFile) -> None:
-        """Validate file size and type."""
-        # Validate content type
-        allowed_types = [t.strip() for t in settings.ALLOWED_IMAGE_TYPES.split(",")]
-        if file.content_type not in allowed_types:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"File type {file.content_type} is not allowed. Allowed types: {settings.ALLOWED_IMAGE_TYPES}",
-            )
+    # ------------------------------------------------------------------
+    # Paths
+    # ------------------------------------------------------------------
 
-        # File size strict boundary validation
-        if file.size and file.size > settings.MAX_UPLOAD_SIZE_MB * 1024 * 1024:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"File size exceeds maximum limit of {settings.MAX_UPLOAD_SIZE_MB}MB",
-            )
+    @property
+    def upload_root(self) -> Path:
+        """The directory local uploads may never escape."""
+        return Path(settings.UPLOAD_DIR).resolve()
+
+    # ------------------------------------------------------------------
+    # Upload
+    # ------------------------------------------------------------------
 
     def upload_file(self, file: UploadFile, directory: str = "general") -> str:
-        """
-        Upload a file to the configured storage provider.
-        Returns the generated path/key of the file.
-        """
-        self._validate_file(file)
+        """Validate and store an upload. Returns the object key.
 
-        # Read file contents securely for validation and malware scanning
+        The file's type is determined by sniffing its bytes. The client's
+        ``Content-Type`` header is reported in the error when the two
+        disagree, but it does not decide anything -- an attacker writes that
+        header, so an allowlist checked against it is an allowlist checked
+        against the attacker.
+        """
+        # `directory` is joined onto the upload root, and `os.path.join`
+        # constrains nothing.
         try:
-            file_bytes = file.file.read()
-        except Exception as e:
-            logger.error(f"Failed to read upload stream: {e}")
+            safe_directory = validate_path_segment(directory, "directory")
+        except UnsafePath as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=str(exc),
+            ) from exc
+
+        try:
+            file_bytes = read_upload(file)
+        except UploadTooLarge as exc:
+            raise HTTPException(
+                status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+                detail=str(exc),
+            ) from exc
+        except UnsafeUpload as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=str(exc),
+            ) from exc
+        except Exception as exc:
+            logger.error(f"Failed to read upload stream: {exc}")
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Failed to read uploaded file contents.",
-            )
+            ) from exc
 
-        # Execute malware scan hook prior to storage commit
         try:
-            scan_file_for_malware(file_bytes, file.filename or "unknown")
-        except ValueError as ve:
+            detected_type = validate_upload_bytes(
+                file_bytes,
+                allowed_types=_allowed_image_types(),
+                filename=file.filename or "upload",
+                declared_type=file.content_type,
+            )
+        except UnsafeUpload as exc:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=str(ve),
-            )
+                detail=str(exc),
+            ) from exc
+
+        # The extension follows what the file *is*, not what it was called.
+        # Copying the client's extension is how `x.html` declared as
+        # `image/png` became `<uuid>.html` under a directory we serve.
+        filename = f"{uuid.uuid4().hex}{extension_for(detected_type)}"
+        object_name = f"{safe_directory}/{filename}"
 
         if self.provider == "local":
-            os.makedirs(os.path.join(settings.UPLOAD_DIR, directory), exist_ok=True)
-            ext = os.path.splitext(file.filename)[1] if file.filename else ""
-            filename = f"{uuid.uuid4().hex}{ext}"
-            file_path = os.path.join(settings.UPLOAD_DIR, directory, filename)
+            destination = safe_join(self.upload_root, safe_directory, filename)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_bytes(file_bytes)
 
-            with open(file_path, "wb") as buffer:
-                buffer.write(file_bytes)
-
-            return f"{directory}/{filename}"
+            return object_name
 
         if not self.client:
             raise HTTPException(
@@ -118,29 +224,47 @@ class CloudStorageService:
                 detail="Cloud storage client is not properly initialized.",
             )
 
-        # Generate unique secure filename to prevent traversal/collisions
-        ext = os.path.splitext(file.filename)[1] if file.filename else ""
-        filename = f"{uuid.uuid4().hex}{ext}"
-        object_name = f"{directory}/{filename}"
-
         try:
             self.client.put_object(
                 Bucket=self.bucket_name,
                 Key=object_name,
                 Body=file_bytes,
-                ContentType=file.content_type,
+                # The detected type, so the CDN serves it as what it is.
+                ContentType=detected_type,
+                # Belt and braces: even if something slips through, the object
+                # downloads instead of rendering in the origin's context.
+                ContentDisposition="attachment",
             )
             return object_name
-        except ClientError as e:
-            logger.error(f"Error uploading file to {self.provider}: {e}")
+        except ClientError as exc:
+            logger.error(f"Error uploading file to {self.provider}: {exc}")
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Failed to upload file to cloud storage.",
-            )
+            ) from exc
+
+    async def upload_file_async(
+        self, file: UploadFile, directory: str = "general"
+    ) -> str:
+        """:meth:`upload_file` off the event loop.
+
+        Reading the body, hashing it, writing it to disk and `put_object` are
+        all synchronous and were being called directly from `async def`
+        endpoints, blocking every other request on the worker for the duration
+        of the upload.
+        """
+        return await asyncio.to_thread(self.upload_file, file, directory)
+
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
 
     def generate_presigned_url(self, object_name: str, expiration: int = 3600) -> str:
-        """
-        Generate a presigned URL to share an S3 object.
+        """A URL the client can fetch the object from.
+
+        Raises on failure rather than returning ``""``. An empty string
+        rendered as ``<img src="">`` on the page and logged nothing at the
+        call site, so a misconfigured bucket looked like a missing image.
         """
         if self.provider == "local":
             if settings.CDN_BASE_URL:
@@ -148,27 +272,56 @@ class CloudStorageService:
             return f"/static/uploads/{object_name}"
 
         if not self.client:
-            return ""
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Cloud storage client is not properly initialized.",
+            )
 
         try:
-            response = self.client.generate_presigned_url(
+            return self.client.generate_presigned_url(
                 "get_object",
                 Params={"Bucket": self.bucket_name, "Key": object_name},
                 ExpiresIn=expiration,
             )
-            return response
-        except ClientError as e:
-            logger.error(f"Error generating presigned URL: {e}")
-            return ""
+        except ClientError as exc:
+            logger.error(f"Error generating presigned URL: {exc}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to generate a download URL.",
+            ) from exc
+
+    # ------------------------------------------------------------------
+    # Delete
+    # ------------------------------------------------------------------
 
     def delete_file(self, object_name: str) -> bool:
-        """
-        Delete a file from the configured storage provider.
-        """
-        if self.provider == "local":
+        """Delete a stored object.
+
+        ``object_name`` reaches this from request data in several places, and
+        the local branch used to do::
+
             file_path = os.path.join(settings.UPLOAD_DIR, object_name)
             if os.path.exists(file_path):
                 os.remove(file_path)
+
+        ``os.path.join`` does not constrain anything: ``"../../app/main.py"``
+        resolves outside ``UPLOAD_DIR`` and is deleted, and an *absolute*
+        object name discards ``UPLOAD_DIR`` altogether. Any endpoint
+        forwarding a caller-supplied key here was an arbitrary-file-delete
+        primitive.
+        """
+        if self.provider == "local":
+            try:
+                file_path = safe_join(self.upload_root, *Path(object_name).parts)
+            except UnsafePath as exc:
+                logger.warning("Refusing to delete outside upload dir: %s", exc)
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Invalid object name.",
+                ) from exc
+
+            if file_path.is_file():
+                file_path.unlink()
                 return True
             return False
 
@@ -178,9 +331,26 @@ class CloudStorageService:
         try:
             self.client.delete_object(Bucket=self.bucket_name, Key=object_name)
             return True
-        except ClientError as e:
-            logger.error(f"Error deleting file from {self.provider}: {e}")
+        except ClientError as exc:
+            logger.error(f"Error deleting file from {self.provider}: {exc}")
             return False
+
+    async def delete_file_async(self, object_name: str) -> bool:
+        """:meth:`delete_file` off the event loop."""
+        return await asyncio.to_thread(self.delete_file, object_name)
 
 
 storage_service = CloudStorageService()
+
+# Re-exported so callers can catch them without importing the validation
+# module directly.
+__all__ = [
+    "CloudStorageService",
+    "UnsafePath",
+    "UnsafeUpload",
+    "UploadTooLarge",
+    "detect_content_type",
+    "read_upload",
+    "scan_file_for_malware",
+    "storage_service",
+]

--- a/backend/app/tests/core/test_storage.py
+++ b/backend/app/tests/core/test_storage.py
@@ -18,13 +18,20 @@ def mock_settings(monkeypatch):
     monkeypatch.setattr(settings, "MAX_UPLOAD_SIZE_MB", 5)
 
 
+# A real PNG header. `b"fake image content"` used to be enough here, because
+# validation only read the client's `Content-Type`. It is not enough now: what
+# a file is gets decided by its bytes, so the fixture has to supply bytes that
+# actually are the thing they claim to be.
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
+
+
 @pytest.fixture
 def mock_upload_file():
     file = MagicMock(spec=UploadFile)
     file.filename = "test.png"
     file.content_type = "image/png"
-    file.file = BytesIO(b"fake image content")
-    file.size = 1000
+    file.file = BytesIO(PNG_BYTES)
+    file.size = len(PNG_BYTES)
     return file
 
 
@@ -55,8 +62,12 @@ def test_storage_service_upload_success(mock_boto3, mock_settings, mock_upload_f
     mock_client.put_object.assert_called_once_with(
         Bucket="test-bucket",
         Key=result,
-        Body=b"fake image content",
+        Body=PNG_BYTES,
+        # The detected type rather than the declared one, and stored as an
+        # attachment so anything that slips through downloads instead of
+        # rendering in our origin's context.
         ContentType="image/png",
+        ContentDisposition="attachment",
     )
 
 
@@ -64,6 +75,14 @@ def test_storage_service_upload_success(mock_boto3, mock_settings, mock_upload_f
 def test_storage_service_upload_invalid_type(
     mock_boto3, mock_settings, mock_upload_file
 ):
+    """A PDF is not in the image allowlist, whatever the client declares.
+
+    This used to pass a PDF `Content-Type` over an image body; the check read
+    the header. It now works the other way round -- a real PDF body declared as
+    an image is what gets rejected, and the declared type is only used to make
+    the error message useful.
+    """
+    mock_upload_file.file = BytesIO(b"%PDF-1.7\n" + b"\x00" * 64)
     mock_upload_file.content_type = "application/pdf"
     service = CloudStorageService()
 
@@ -71,21 +90,62 @@ def test_storage_service_upload_invalid_type(
         service.upload_file(mock_upload_file)
 
     assert exc.value.status_code == 400
-    assert "not allowed" in exc.value.detail
+    assert "application/pdf" in exc.value.detail
 
 
 @patch("boto3.client")
-def test_storage_service_upload_invalid_size(
+def test_storage_service_upload_mislabelled_type_is_rejected(
     mock_boto3, mock_settings, mock_upload_file
 ):
-    mock_upload_file.size = 10 * 1024 * 1024  # 10MB, limit is 5MB
+    """The case the header-based check could not see at all."""
+    mock_upload_file.file = BytesIO(b"<!DOCTYPE html><html>hi</html>")
+    mock_upload_file.content_type = "image/png"
     service = CloudStorageService()
 
     with pytest.raises(HTTPException) as exc:
         service.upload_file(mock_upload_file)
 
     assert exc.value.status_code == 400
+
+
+@patch("boto3.client")
+def test_storage_service_upload_invalid_size(
+    mock_boto3, mock_settings, mock_upload_file
+):
+    """The body has to actually be oversized.
+
+    Setting `file.size` alone no longer rejects anything, and that is the
+    point: `size` comes from the client's `Content-Length` and is absent on a
+    chunked upload, so it cannot be the thing the limit depends on. The limit
+    is enforced against the bytes as they are read.
+    """
+    oversized = b"\x89PNG\r\n\x1a\n" + b"\x00" * (10 * 1024 * 1024)
+    mock_upload_file.file = BytesIO(oversized)
+    mock_upload_file.size = len(oversized)  # 10MB, limit is 5MB
+    service = CloudStorageService()
+
+    with pytest.raises(HTTPException) as exc:
+        service.upload_file(mock_upload_file)
+
+    assert exc.value.status_code == 413
     assert "exceeds maximum limit" in exc.value.detail
+
+
+@patch("boto3.client")
+def test_storage_service_size_limit_holds_without_content_length(
+    mock_boto3, mock_settings, mock_upload_file
+):
+    """`if file.size and file.size > limit` skipped the check when `size` was
+    `None`, and the next line read the whole body into memory anyway."""
+    oversized = b"\x89PNG\r\n\x1a\n" + b"\x00" * (10 * 1024 * 1024)
+    mock_upload_file.file = BytesIO(oversized)
+    mock_upload_file.size = None
+    service = CloudStorageService()
+
+    with pytest.raises(HTTPException) as exc:
+        service.upload_file(mock_upload_file)
+
+    assert exc.value.status_code == 413
 
 
 @patch("boto3.client")

--- a/backend/tests/test_file_validation.py
+++ b/backend/tests/test_file_validation.py
@@ -1,0 +1,352 @@
+"""
+Tests for ``app.core.file_validation``.
+
+Pure byte and path handling, so these run with no fixtures, no database and no
+FastAPI app. The two behaviours worth being exhaustive about are the ones that
+were exploitable: a file that lies about what it is, and a path that climbs out
+of the directory it was supposed to stay in.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.core.file_validation import (
+    DANGEROUS_TYPES,
+    SNIFF_LENGTH,
+    UnsafePath,
+    UnsafeUpload,
+    detect_content_type,
+    extension_for,
+    safe_join,
+    scan_bytes,
+    validate_path_segment,
+    validate_upload_bytes,
+)
+
+# ---------------------------------------------------------------------------
+# Sample payloads
+# ---------------------------------------------------------------------------
+
+PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+JPEG = b"\xff\xd8\xff\xe0" + b"\x00" * 32
+GIF = b"GIF89a" + b"\x00" * 32
+BMP = b"BM" + b"\x00" * 32
+TIFF_LE = b"II*\x00" + b"\x00" * 32
+TIFF_BE = b"MM\x00*" + b"\x00" * 32
+WEBP = b"RIFF\x24\x00\x00\x00WEBPVP8 " + b"\x00" * 16
+WAV = b"RIFF\x24\x08\x00\x00WAVEfmt " + b"\x00" * 16
+MP4 = b"\x00\x00\x00\x18ftypisom" + b"\x00" * 16
+MOV = b"\x00\x00\x00\x14ftypqt  " + b"\x00" * 16
+WEBM = b"\x1a\x45\xdf\xa3" + b"\x00" * 32
+MP3 = b"ID3\x03\x00\x00\x00" + b"\x00" * 32
+OGG = b"OggS\x00\x02" + b"\x00" * 32
+PDF = b"%PDF-1.7\n" + b"\x00" * 32
+SVG = b'<svg xmlns="http://www.w3.org/2000/svg"><circle r="1"/></svg>'
+HTML = b"<!DOCTYPE html><html><body>hi</body></html>"
+ELF = b"\x7fELF\x02\x01\x01" + b"\x00" * 32
+EXE = b"MZ\x90\x00\x03" + b"\x00" * 32
+
+IMAGE_TYPES = {"image/png", "image/jpeg", "image/webp"}
+
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        (PNG, "image/png"),
+        (JPEG, "image/jpeg"),
+        (GIF, "image/gif"),
+        (BMP, "image/bmp"),
+        (TIFF_LE, "image/tiff"),
+        (TIFF_BE, "image/tiff"),
+        (WEBP, "image/webp"),
+        (WAV, "audio/wav"),
+        (MP4, "video/mp4"),
+        (MOV, "video/quicktime"),
+        (WEBM, "video/webm"),
+        (MP3, "audio/mpeg"),
+        (OGG, "audio/ogg"),
+        (PDF, "application/pdf"),
+        (SVG, "image/svg+xml"),
+        (HTML, "text/html"),
+        (ELF, "application/x-elf"),
+        (EXE, "application/x-dosexec"),
+    ],
+)
+def test_detection_reads_the_bytes(payload: bytes, expected: str) -> None:
+    assert detect_content_type(payload) == expected
+
+
+def test_riff_is_not_assumed_to_be_webp() -> None:
+    """RIFF is a container. WAV and WEBP share the first four bytes."""
+    assert detect_content_type(WEBP) == "image/webp"
+    assert detect_content_type(WAV) == "audio/wav"
+
+
+def test_detection_returns_none_for_unknown_bytes() -> None:
+    assert detect_content_type(b"just some plain text, no signature") is None
+
+
+def test_detection_returns_none_for_empty_input() -> None:
+    assert detect_content_type(b"") is None
+
+
+def test_detection_needs_only_the_head_of_the_file() -> None:
+    assert detect_content_type(PNG[:SNIFF_LENGTH]) == "image/png"
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [b"", b"  \n\t", b"\xef\xbb\xbf", b'<?xml version="1.0"?>'],
+)
+def test_svg_is_detected_behind_leading_noise(prefix: bytes) -> None:
+    """Whitespace, a BOM or an XML declaration can all precede the real tag."""
+    assert detect_content_type(prefix + SVG) == "image/svg+xml"
+
+
+def test_extension_follows_the_detected_type() -> None:
+    assert extension_for("image/png") == ".png"
+    assert extension_for("image/jpeg") == ".jpg"
+    assert extension_for("video/quicktime") == ".mov"
+
+
+def test_extension_falls_back_for_an_unmapped_type() -> None:
+    assert extension_for("application/x-whatever") == ".bin"
+
+
+# ---------------------------------------------------------------------------
+# Scanning
+# ---------------------------------------------------------------------------
+
+
+def test_scan_rejects_empty_payloads() -> None:
+    with pytest.raises(UnsafeUpload, match="empty"):
+        scan_bytes(b"", "empty.png")
+
+
+def test_scan_catches_a_payload_embedded_after_a_valid_header() -> None:
+    """The whole point of scanning the buffer instead of its prefix.
+
+    ``startswith`` was trivially defeated by exactly this construction: a
+    real PNG header followed by whatever you wanted.
+    """
+    polyglot = PNG + b"<?php system($_GET['c']); ?>"
+
+    with pytest.raises(UnsafeUpload, match="embedded PHP"):
+        scan_bytes(polyglot, "avatar.png")
+
+
+def test_scan_catches_a_script_tag_anywhere_in_the_file() -> None:
+    with pytest.raises(UnsafeUpload, match="script tag"):
+        scan_bytes(GIF + b"\n<script>alert(1)</script>", "x.gif")
+
+
+def test_scan_is_case_insensitive() -> None:
+    with pytest.raises(UnsafeUpload, match="script tag"):
+        scan_bytes(GIF + b"<SCRIPT>alert(1)</SCRIPT>", "x.gif")
+
+
+@pytest.mark.parametrize(
+    ("payload", "match"),
+    [
+        (EXE, "Windows executable"),
+        (ELF, "ELF executable"),
+        (b"#!/bin/sh\necho hi", "shell script"),
+    ],
+)
+def test_scan_rejects_executables(payload: bytes, match: str) -> None:
+    with pytest.raises(UnsafeUpload, match=match):
+        scan_bytes(payload, "thing")
+
+
+def test_scan_allows_ordinary_media() -> None:
+    for payload in (PNG, JPEG, GIF, WEBP, MP4, MP3, PDF):
+        scan_bytes(payload, "file")
+
+
+def test_executable_signatures_are_only_matched_at_the_start() -> None:
+    """"MZ" is two ASCII letters and appears in ordinary binary data.
+
+    Matching it anywhere would reject legitimate uploads.
+    """
+    scan_bytes(PNG + b"some MZ bytes in the middle", "avatar.png")
+
+
+# ---------------------------------------------------------------------------
+# Combined validation
+# ---------------------------------------------------------------------------
+
+
+def test_a_real_png_is_accepted() -> None:
+    assert validate_upload_bytes(PNG, IMAGE_TYPES, "a.png", "image/png") == "image/png"
+
+
+def test_the_declared_content_type_does_not_decide() -> None:
+    """The attack the old allowlist could not see.
+
+    Upload HTML, declare `image/png`, and the header-based check passed.
+    """
+    with pytest.raises(UnsafeUpload) as exc:
+        validate_upload_bytes(HTML, IMAGE_TYPES, "avatar.png", "image/png")
+
+    assert "text/html" in str(exc.value)
+
+
+def test_an_svg_declared_as_png_is_rejected() -> None:
+    with pytest.raises(UnsafeUpload):
+        validate_upload_bytes(SVG, IMAGE_TYPES, "avatar.png", "image/png")
+
+
+def test_svg_is_rejected_even_when_explicitly_allowed() -> None:
+    """SVG is a script host. Allowing it by configuration is still stored XSS."""
+    assert "image/svg+xml" in DANGEROUS_TYPES
+
+    with pytest.raises(UnsafeUpload, match="cannot be stored"):
+        validate_upload_bytes(
+            SVG, IMAGE_TYPES | {"image/svg+xml"}, "logo.svg", "image/svg+xml"
+        )
+
+
+def test_html_is_rejected_even_when_explicitly_allowed() -> None:
+    with pytest.raises(UnsafeUpload, match="cannot be stored"):
+        validate_upload_bytes(
+            HTML, IMAGE_TYPES | {"text/html"}, "page.html", "text/html"
+        )
+
+
+def test_a_disallowed_but_harmless_type_is_rejected_clearly() -> None:
+    with pytest.raises(UnsafeUpload) as exc:
+        validate_upload_bytes(PDF, IMAGE_TYPES, "doc.pdf", "application/pdf")
+
+    assert "application/pdf" in str(exc.value)
+
+
+def test_unrecognised_bytes_are_rejected_rather_than_assumed_fine() -> None:
+    with pytest.raises(UnsafeUpload, match="not a recognised file format"):
+        validate_upload_bytes(b"hello there", IMAGE_TYPES, "x.png", "image/png")
+
+
+def test_the_allowlist_comparison_is_case_insensitive() -> None:
+    """`IMAGE/PNG` in configuration was rejecting perfectly good PNGs."""
+    assert validate_upload_bytes(PNG, {"IMAGE/PNG"}, "a.png", "image/png") == (
+        "image/png"
+    )
+
+
+def test_a_polyglot_is_caught_before_type_detection() -> None:
+    """It sniffs as a PNG; the scan is what stops it."""
+    polyglot = PNG + b"<?php echo 1; ?>"
+    assert detect_content_type(polyglot) == "image/png"
+
+    with pytest.raises(UnsafeUpload, match="embedded PHP"):
+        validate_upload_bytes(polyglot, IMAGE_TYPES, "avatar.png", "image/png")
+
+
+# ---------------------------------------------------------------------------
+# Path segments
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("segment", ["general", "avatars", "user_123", "a-b-c", "x"])
+def test_ordinary_segments_are_accepted(segment: str) -> None:
+    assert validate_path_segment(segment) == segment
+
+
+@pytest.mark.parametrize(
+    "segment",
+    [
+        "",
+        "..",
+        "../etc",
+        "a/b",
+        "a\\b",
+        "/absolute",
+        ".hidden",
+        "-leading-hyphen",
+        "with space",
+        "x" * 100,
+        "nul\x00byte",
+    ],
+)
+def test_dangerous_segments_are_rejected(segment: str) -> None:
+    with pytest.raises(UnsafePath):
+        validate_path_segment(segment)
+
+
+# ---------------------------------------------------------------------------
+# safe_join
+# ---------------------------------------------------------------------------
+
+
+def test_safe_join_builds_a_path_inside_the_base(tmp_path: Path) -> None:
+    result = safe_join(tmp_path, "avatars", "abc.png")
+
+    assert result == (tmp_path / "avatars" / "abc.png").resolve()
+
+
+def test_safe_join_works_for_paths_that_do_not_exist_yet(tmp_path: Path) -> None:
+    """Resolution has to be lexical -- this runs on the write path."""
+    result = safe_join(tmp_path, "brand", "new", "file.png")
+    assert not result.exists()
+    assert str(result).startswith(str(tmp_path.resolve()))
+
+
+@pytest.mark.parametrize(
+    "parts",
+    [
+        ("..", "escaped.txt"),
+        ("..", "..", "etc", "passwd"),
+        ("avatars", "..", "..", "secret.py"),
+        ("a", "..", "..", "..", "b"),
+    ],
+)
+def test_safe_join_refuses_to_climb_out(tmp_path: Path, parts) -> None:
+    base = tmp_path / "uploads"
+    base.mkdir()
+
+    with pytest.raises(UnsafePath):
+        safe_join(base, *parts)
+
+
+def test_safe_join_is_not_fooled_by_the_dot_stripping_bypass(tmp_path: Path) -> None:
+    """``....//`` defeats sanitisers that *remove* occurrences of ``../``.
+
+    It does nothing here, because containment is decided by resolving the path
+    and comparing, not by rewriting the string. ``....`` is simply an
+    oddly-named directory inside the base, so this is allowed -- and staying
+    inside is the property that matters.
+    """
+    base = tmp_path / "uploads"
+    base.mkdir()
+
+    result = safe_join(base, "....//", "file.txt")
+
+    assert base.resolve() in result.parents
+
+
+def test_safe_join_refuses_an_absolute_component(tmp_path: Path) -> None:
+    """`Path("/a") / "/etc/passwd"` discards the base entirely.
+
+    So does `os.path.join`. This is reachable from a caller-supplied object
+    name.
+    """
+    base = tmp_path / "uploads"
+    base.mkdir()
+
+    with pytest.raises(UnsafePath):
+        safe_join(base, "/etc/passwd")
+
+
+def test_safe_join_allows_the_base_itself(tmp_path: Path) -> None:
+    assert safe_join(tmp_path) == tmp_path.resolve()
+
+
+def test_safe_join_ignores_empty_components(tmp_path: Path) -> None:
+    assert safe_join(tmp_path, "", "a.png") == (tmp_path / "a.png").resolve()

--- a/backend/tests/test_storage_service.py
+++ b/backend/tests/test_storage_service.py
@@ -1,0 +1,349 @@
+"""
+Tests for ``app.core.storage``.
+
+The existing ``app/tests/core/test_storage.py`` covers the happy paths against
+a mocked boto3. This module covers what that one could not: the cases where the
+client lies about the file, and the cases where a caller-supplied string is
+used as a filesystem path.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException, UploadFile
+
+from app.core import storage as storage_module
+from app.core.storage import CloudStorageService, read_upload, scan_file_for_malware
+
+PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
+JPEG = b"\xff\xd8\xff\xe0" + b"\x00" * 64
+HTML = b"<!DOCTYPE html><html><script>alert(document.cookie)</script></html>"
+SVG = b'<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)"/>'
+
+
+def make_upload(
+    content: bytes,
+    filename: str = "avatar.png",
+    content_type: str = "image/png",
+) -> UploadFile:
+    """An UploadFile backed by an in-memory buffer."""
+    upload = UploadFile(
+        file=io.BytesIO(content),
+        filename=filename,
+        headers={"content-type": content_type},
+    )
+    return upload
+
+
+@pytest.fixture()
+def local_service(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A storage service writing into a temp directory."""
+    monkeypatch.setattr(storage_module.settings, "STORAGE_PROVIDER", "local")
+    monkeypatch.setattr(storage_module.settings, "UPLOAD_DIR", str(tmp_path))
+    monkeypatch.setattr(
+        storage_module.settings, "ALLOWED_IMAGE_TYPES", "image/png,image/jpeg"
+    )
+    monkeypatch.setattr(storage_module.settings, "MAX_UPLOAD_SIZE_MB", 5)
+
+    return CloudStorageService()
+
+
+# ---------------------------------------------------------------------------
+# Content validation
+# ---------------------------------------------------------------------------
+
+
+def test_a_real_png_uploads(local_service, tmp_path: Path) -> None:
+    key = local_service.upload_file(make_upload(PNG), directory="avatars")
+
+    assert key.startswith("avatars/")
+    assert key.endswith(".png")
+    assert (tmp_path / key).read_bytes() == PNG
+
+
+def test_html_declared_as_png_is_rejected(local_service, tmp_path: Path) -> None:
+    """The central defect: validation was reading the client's header.
+
+    Serving attacker-authored HTML from our own origin under
+    ``/static/uploads/`` is stored XSS against every session on the site.
+    """
+    with pytest.raises(HTTPException) as exc:
+        local_service.upload_file(make_upload(HTML, "avatar.png", "image/png"))
+
+    assert exc.value.status_code == 400
+    assert not list(tmp_path.rglob("*.html"))
+    assert not list(tmp_path.rglob("*.png"))
+
+
+def test_svg_declared_as_png_is_rejected(local_service) -> None:
+    with pytest.raises(HTTPException) as exc:
+        local_service.upload_file(make_upload(SVG, "logo.png", "image/png"))
+
+    assert exc.value.status_code == 400
+
+
+def test_the_stored_extension_comes_from_the_content(local_service) -> None:
+    """A JPEG named ``.png`` is stored as ``.jpg``.
+
+    The extension used to be copied out of the client's filename, which is how
+    ``x.html`` declared as ``image/png`` became ``<uuid>.html``.
+    """
+    key = local_service.upload_file(make_upload(JPEG, "mislabelled.png", "image/png"))
+
+    assert key.endswith(".jpg")
+
+
+def test_an_executable_named_png_is_rejected(local_service) -> None:
+    with pytest.raises(HTTPException) as exc:
+        local_service.upload_file(
+            make_upload(b"MZ\x90\x00" + b"\x00" * 64, "avatar.png", "image/png")
+        )
+
+    assert exc.value.status_code == 400
+
+
+def test_a_polyglot_is_rejected(local_service) -> None:
+    """Sniffs as a PNG; the whole-buffer scan is what catches it."""
+    with pytest.raises(HTTPException):
+        local_service.upload_file(
+            make_upload(PNG + b"<?php system($_GET['c']); ?>", "avatar.png")
+        )
+
+
+def test_the_allowlist_is_case_insensitive(
+    local_service, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(storage_module.settings, "ALLOWED_IMAGE_TYPES", "IMAGE/PNG")
+
+    key = local_service.upload_file(make_upload(PNG))
+
+    assert key.endswith(".png")
+
+
+# ---------------------------------------------------------------------------
+# Size
+# ---------------------------------------------------------------------------
+
+
+def test_an_oversized_upload_is_rejected(
+    local_service, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(storage_module.settings, "MAX_UPLOAD_SIZE_MB", 1)
+
+    with pytest.raises(HTTPException) as exc:
+        local_service.upload_file(make_upload(PNG + b"\x00" * (2 * 1024 * 1024)))
+
+    assert exc.value.status_code == 413
+
+
+def test_the_size_limit_holds_without_a_declared_length(
+    local_service, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``UploadFile.size`` is ``None`` for a chunked upload.
+
+    The old check was ``if file.size and file.size > limit``, so an undeclared
+    length short-circuited past it and the next line read the whole body into
+    memory.
+    """
+    monkeypatch.setattr(storage_module.settings, "MAX_UPLOAD_SIZE_MB", 1)
+
+    upload = make_upload(PNG + b"\x00" * (2 * 1024 * 1024))
+    assert upload.size is None  # no content-length was set
+
+    with pytest.raises(HTTPException) as exc:
+        local_service.upload_file(upload)
+
+    assert exc.value.status_code == 413
+
+
+def test_read_upload_stops_reading_past_the_limit() -> None:
+    """The body is abandoned, not buffered in full and then measured."""
+    upload = make_upload(b"\x00" * (1024 * 1024))
+
+    with pytest.raises(storage_module.UploadTooLarge):
+        read_upload(upload, max_bytes=1024)
+
+
+def test_an_empty_upload_is_rejected(local_service) -> None:
+    with pytest.raises(HTTPException) as exc:
+        local_service.upload_file(make_upload(b""))
+
+    assert exc.value.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "directory",
+    ["../escape", "..", "a/b", "/etc", ".hidden", ""],
+)
+def test_a_dangerous_directory_is_rejected(local_service, directory: str) -> None:
+    with pytest.raises(HTTPException) as exc:
+        local_service.upload_file(make_upload(PNG), directory=directory)
+
+    assert exc.value.status_code == 400
+
+
+def test_delete_refuses_to_escape_the_upload_directory(
+    local_service, tmp_path: Path
+) -> None:
+    """This was an arbitrary-file-delete primitive.
+
+    ``os.path.join(UPLOAD_DIR, object_name)`` constrains nothing, and several
+    endpoints forward a stored key from request data straight into it.
+    """
+    victim = tmp_path.parent / "important.txt"
+    victim.write_text("do not delete me")
+
+    with pytest.raises(HTTPException) as exc:
+        local_service.delete_file("../important.txt")
+
+    assert exc.value.status_code == 400
+    assert victim.exists()
+    assert victim.read_text() == "do not delete me"
+
+
+def test_delete_refuses_an_absolute_object_name(
+    local_service, tmp_path: Path
+) -> None:
+    """An absolute second argument makes ``join`` discard the base entirely."""
+    victim = tmp_path.parent / "absolute-target.txt"
+    victim.write_text("still here")
+
+    with pytest.raises(HTTPException):
+        local_service.delete_file(str(victim))
+
+    assert victim.exists()
+
+
+def test_delete_removes_a_file_inside_the_upload_directory(
+    local_service, tmp_path: Path
+) -> None:
+    key = local_service.upload_file(make_upload(PNG), directory="avatars")
+    assert (tmp_path / key).exists()
+
+    assert local_service.delete_file(key) is True
+    assert not (tmp_path / key).exists()
+
+
+def test_delete_returns_false_for_a_missing_file(local_service) -> None:
+    assert local_service.delete_file("avatars/does-not-exist.png") is False
+
+
+def test_uploads_do_not_collide(local_service, tmp_path: Path) -> None:
+    first = local_service.upload_file(make_upload(PNG), directory="avatars")
+    second = local_service.upload_file(make_upload(PNG), directory="avatars")
+
+    assert first != second
+    assert len(list((tmp_path / "avatars").iterdir())) == 2
+
+
+# ---------------------------------------------------------------------------
+# Cloud provider
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def s3_service(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(storage_module.settings, "STORAGE_PROVIDER", "s3")
+    monkeypatch.setattr(storage_module.settings, "AWS_BUCKET_NAME", "bucket")
+    monkeypatch.setattr(
+        storage_module.settings, "ALLOWED_IMAGE_TYPES", "image/png,image/jpeg"
+    )
+    monkeypatch.setattr(storage_module.settings, "MAX_UPLOAD_SIZE_MB", 5)
+
+    with patch("app.core.storage.boto3") as boto3_mock:
+        client = MagicMock()
+        boto3_mock.client.return_value = client
+        service = CloudStorageService()
+        yield service, client
+
+
+def test_s3_objects_are_tagged_with_the_detected_type(s3_service) -> None:
+    """Not the client's header -- the CDN would serve it as whatever was
+    claimed."""
+    service, client = s3_service
+
+    service.upload_file(make_upload(JPEG, "avatar.png", "image/png"))
+
+    kwargs = client.put_object.call_args.kwargs
+    assert kwargs["ContentType"] == "image/jpeg"
+
+
+def test_s3_objects_are_stored_as_attachments(s3_service) -> None:
+    """Defence in depth: anything that slips through downloads rather than
+    rendering in the origin's context."""
+    service, client = s3_service
+
+    service.upload_file(make_upload(PNG))
+
+    assert client.put_object.call_args.kwargs["ContentDisposition"] == "attachment"
+
+
+def test_a_presigned_url_failure_raises_instead_of_returning_empty(
+    s3_service,
+) -> None:
+    """Returning ``""`` rendered as ``<img src="">`` and logged nothing at the
+    call site, so a misconfigured bucket looked like a missing image."""
+    from botocore.exceptions import ClientError
+
+    service, client = s3_service
+    client.generate_presigned_url.side_effect = ClientError(
+        {"Error": {"Code": "AccessDenied", "Message": "nope"}}, "GetObject"
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        service.generate_presigned_url("avatars/x.png")
+
+    assert exc.value.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# The scanner shim
+# ---------------------------------------------------------------------------
+
+
+def test_scan_file_for_malware_still_raises_value_error() -> None:
+    """Existing callers catch ``ValueError``; that contract is unchanged."""
+    with pytest.raises(ValueError):
+        scan_file_for_malware(b"MZ\x90\x00", "x.png")
+
+    with pytest.raises(ValueError):
+        scan_file_for_malware(b"", "x.png")
+
+
+def test_scan_file_for_malware_now_scans_the_whole_buffer() -> None:
+    """The old version only checked ``startswith``."""
+    with pytest.raises(ValueError):
+        scan_file_for_malware(PNG + b"<?php echo 1; ?>", "x.png")
+
+
+# ---------------------------------------------------------------------------
+# Async wrappers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upload_file_async_runs_off_the_event_loop(
+    local_service, tmp_path: Path
+) -> None:
+    key = await local_service.upload_file_async(make_upload(PNG), directory="avatars")
+
+    assert (tmp_path / key).exists()
+
+
+@pytest.mark.asyncio
+async def test_delete_file_async_runs_off_the_event_loop(
+    local_service, tmp_path: Path
+) -> None:
+    key = await local_service.upload_file_async(make_upload(PNG), directory="avatars")
+
+    assert await local_service.delete_file_async(key) is True
+    assert not (tmp_path / key).exists()


### PR DESCRIPTION
Fixes #1196

Two rules were being broken in `app/core/storage.py`: **what a file is** was decided by the client, and **where a file goes** was decided by the client.

## What a file is

`_validate_file` compared `file.content_type` — the `Content-Type` of the multipart part, which the *uploader* writes — against the allowlist. Nothing ever looked at the bytes. Upload an HTML document, declare `image/png`, and it passed.

The stored extension came from the client too:

```python
# Generate unique secure filename to prevent traversal/collisions
ext = os.path.splitext(file.filename)[1] if file.filename else ""
filename = f"{uuid.uuid4().hex}{ext}"
```

The UUID does handle collisions, but the extension is copied verbatim out of the user's filename. So `x.html` declared as `image/png` was written as `<uuid>.html` into `UPLOAD_DIR`, which is served back under `/static/uploads/`. Same origin, attacker-authored HTML: **stored XSS against every session on the site**. `.svg` gets there the same way, and an SVG is a script host.

**Now:** a new `app/core/file_validation.py` sniffs magic bytes and returns the real media type. The client's header is passed in only so the error can say *"claims to be image/png but its contents are text/html"* — it never gets a vote. The stored extension is derived from the **detected** type. SVG and HTML are refused outright even if configuration allows them.

## Where a file goes

```python
def delete_file(self, object_name: str) -> bool:
    if self.provider == "local":
        file_path = os.path.join(settings.UPLOAD_DIR, object_name)
        if os.path.exists(file_path):
            os.remove(file_path)
```

`os.path.join` is not a security boundary. `object_name = "../../app/main.py"` resolves outside `UPLOAD_DIR` and is deleted; an *absolute* `object_name` makes `join` discard `UPLOAD_DIR` entirely. `object_name` reaches this from request data in several places, which makes it an arbitrary-file-delete primitive. The `directory` argument to `upload_file` was joined the same way.

**Now:** both go through `safe_join`, which resolves the path and asserts it is inside the base — and does so lexically, so it works for paths that do not exist yet (the write path). `directory` must additionally be a single safe path segment.

Note that containment is checked by *resolving and comparing*, not by rewriting the string, so the `....//` trick that defeats strip-based sanitisers does nothing here — there is a test asserting exactly that.

## The size limit only ran when the client declared a length

```python
if file.size and file.size > settings.MAX_UPLOAD_SIZE_MB * 1024 * 1024:
    raise ...
file_bytes = file.file.read()
```

`UploadFile.size` is populated from the part's `Content-Length`. On a chunked upload — or from a client that simply omits the header — it is `None`, the `and` short-circuits, and the check never runs. The very next line then pulls the entire body into memory. A handful of concurrent large uploads is an OOM, prevented by a check that did not execute.

**Now:** the body is read in 64 KB chunks with the limit enforced as it goes, so it holds whether or not a length was declared, and an oversized body is abandoned one chunk past the limit rather than buffered in full. The response is `413` rather than `400`.

## The malware hook only looked at the first few bytes

```python
if contents.startswith(sig):
```

Defeated by construction — a valid PNG header followed by `<?php ... ?>` passed, which is what every real polyglot is. It scans the whole buffer now.

Executable signatures are still matched only at the *start*, deliberately: `MZ` is two ASCII letters and occurs in ordinary binary data, so matching it anywhere produces false positives on legitimate uploads. The old code had that failure too, in the other direction — a text file beginning with `MZ` was rejected.

## Smaller things in the same module

- `generate_presigned_url` returned `""` on failure, which rendered as `<img src="">` and logged nothing at the call site, so a misconfigured bucket looked like a missing image. It raises now.
- The allowlist was re-split on every call and compared without lowercasing either side, so `IMAGE/PNG` in configuration rejected perfectly good PNGs.
- S3 objects are stored with the **detected** content type (the CDN was being told whatever the client claimed) and `Content-Disposition: attachment`, so anything that slips through downloads rather than rendering in our origin's context.
- `upload_file_async` / `delete_file_async` run the blocking read/write/`put_object` in a worker thread. These were being called straight from `async def` endpoints, blocking every other request on the worker for the duration of an upload. The sync methods are unchanged so existing callers keep working; migrating them is a follow-up.

## Tests

- `tests/test_file_validation.py` — 71 tests. Pure byte and path handling, no fixtures or database. Covers detection across 18 formats, the RIFF container ambiguity (WEBP vs WAV share a prefix), SVG behind a BOM/whitespace/XML declaration, polyglots, and every traversal shape I could think of.
- `tests/test_storage_service.py` — 38 tests against a temp directory and a mocked boto3, exercising the actual attack paths: HTML-as-PNG, SVG-as-PNG, an executable named `.png`, a polyglot, `../` in a delete, an absolute object name, and an oversized body with no declared length.

Three tests in `app/tests/core/test_storage.py` encoded the *old* contract — a body of `b"fake image content"` declared as `image/png`, and a size check driven by `file.size` alone. I updated them to the new contract and added two more rather than deleting them; the fixture now supplies bytes that actually are a PNG.

## Deliberately not in this PR

`app/utils/uploads.py` carries a **verbatim copy** of the old `scan_file_for_malware`, so the two upload paths have two independently-drifting copies of the same weak check. #1196 asks for them to be consolidated, and they should be — but #1199 rewrites large parts of that file to fix the syntax errors currently keeping `main` from importing, and touching it here would guarantee a conflict. Once that lands this is a one-line import swap. The shim in `storage.py` keeps the old name and the old `ValueError` contract so no caller has to change.

## Note on CI

`main` does not compile right now (#1194), so every backend test fails at collection. I verified this branch locally with #1199 applied: 109/109 pass across the three storage test files, and the rest of the suite is unchanged apart from two pre-existing failures — `test_invite_user` (needs a live Redis for Celery) and `test_analytics_api_endpoint` (only fails when `tests/` and `app/tests/` run in one process; both fail identically on `main`).

## Review notes

- The signature table is hand-rolled rather than pulling in `python-magic`/`filetype`, to avoid a new dependency and a libmagic system requirement for something this small. If we would rather have the library, the module is a drop-in place to swap it.
- `Content-Disposition: attachment` on every S3 object is safe but blunt — if we ever serve avatars inline from S3 rather than through a CDN transform, that will need revisiting.
- I did not migrate existing callers to the `_async` variants; that touches a lot of routers and belongs in its own change.
