### PR TITLE
fix(rbac): one permission table, and grants that respect their scope

### DIFF
--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -37,6 +37,7 @@ from app.routers import (
     project_dashboards,
     project_releases,
     projects,
+    permissions,
     recommendations,
     repositories,
     repository_quality,
@@ -73,6 +74,9 @@ api_v1_router.include_router(auth.router, prefix="/auth", tags=["Authentication"
 api_v1_router.include_router(mfa.router)
 api_v1_router.include_router(oauth_linking.router)
 api_v1_router.include_router(users.router, prefix="/users", tags=["Users"])
+api_v1_router.include_router(
+    permissions.router, prefix="/users", tags=["Permissions"]
+)
 api_v1_router.include_router(blocks.router, prefix="/blocks", tags=["User Blocks"])
 api_v1_router.include_router(export.router, prefix="/users", tags=["Export"])
 api_v1_router.include_router(pinned_projects.router)

--- a/backend/app/core/rbac.py
+++ b/backend/app/core/rbac.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import uuid
 from enum import Enum
+from typing import Dict, List, Optional, TypedDict
 
 from sqlalchemy import and_, select
 from sqlalchemy.orm import Session
@@ -43,6 +44,21 @@ from app.models.organization_member import OrganizationMember, OrgMemberRole
 from app.models.project import Project
 from app.models.project_member import MemberRole, ProjectMember
 from app.models.user import User
+
+
+class ScopedPermissions(TypedDict):
+    """Permissions grouped by the scope they apply in.
+
+    ``organizations`` and ``projects`` are keyed by stringified UUID. A
+    permission listed under a given id applies to *that* organization or
+    project and to nothing else -- which is the whole point, and the thing the
+    previous flat ``set[str]`` could not express.
+    """
+
+    system: List[str]
+    organizations: Dict[str, List[str]]
+    projects: Dict[str, List[str]]
+
 
 # ─── System-Level Roles ─────────────────────────────────────────────────────
 
@@ -186,6 +202,18 @@ PROJECT_REMOVE_MEMBERS = "project:remove_members"
 PROJECT_EDIT_CONTENT = "project:edit_content"
 PROJECT_REVIEW = "project:review"
 
+#: Project-level grants, defined **once**.
+#:
+#: This table was previously written out twice, back to back: an annotated
+#: ``dict[MemberRole, frozenset[str]]`` immediately followed by a plain ``dict``
+#: literal that rebound the same name. The second won, so the first twenty-four
+#: lines were dead -- never read, never executed, and never able to disagree
+#: loudly enough for anyone to notice. They had already drifted: the dead table
+#: gave MAINTAINER three permissions, the live one gave it seven, and the live
+#: one added CONTRIBUTOR, REVIEWER and VIEWER, which the dead one did not know
+#: about.
+#:
+#: The wider (live) set is kept, since that is what has actually been enforced.
 PROJECT_ROLE_PERMISSIONS: dict[MemberRole, frozenset[str]] = {
     MemberRole.OWNER: frozenset(
         {
@@ -195,6 +223,11 @@ PROJECT_ROLE_PERMISSIONS: dict[MemberRole, frozenset[str]] = {
             PROJECT_ARCHIVE,
             PROJECT_RESTORE,
             PROJECT_VIEW,
+            PROJECT_MANAGE_ROLES,
+            PROJECT_TRANSFER_OWNERSHIP,
+            PROJECT_REMOVE_MEMBERS,
+            PROJECT_EDIT_CONTENT,
+            PROJECT_REVIEW,
         }
     ),
     MemberRole.CO_OWNER: frozenset(
@@ -204,121 +237,221 @@ PROJECT_ROLE_PERMISSIONS: dict[MemberRole, frozenset[str]] = {
             PROJECT_ARCHIVE,
             PROJECT_RESTORE,
             PROJECT_VIEW,
+            PROJECT_MANAGE_ROLES,
+            PROJECT_REMOVE_MEMBERS,
+            PROJECT_EDIT_CONTENT,
+            PROJECT_REVIEW,
         }
     ),
-    MemberRole.ADMIN: frozenset({PROJECT_UPDATE, PROJECT_INVITE, PROJECT_VIEW}),
-    MemberRole.MAINTAINER: frozenset({PROJECT_UPDATE, PROJECT_INVITE, PROJECT_VIEW}),
+    MemberRole.ADMIN: frozenset(
+        {
+            PROJECT_UPDATE,
+            PROJECT_INVITE,
+            PROJECT_VIEW,
+            PROJECT_MANAGE_ROLES,
+            PROJECT_REMOVE_MEMBERS,
+            PROJECT_EDIT_CONTENT,
+            PROJECT_REVIEW,
+        }
+    ),
+    MemberRole.MAINTAINER: frozenset(
+        {
+            PROJECT_UPDATE,
+            PROJECT_INVITE,
+            PROJECT_VIEW,
+            PROJECT_MANAGE_ROLES,
+            PROJECT_REMOVE_MEMBERS,
+            PROJECT_EDIT_CONTENT,
+            PROJECT_REVIEW,
+        }
+    ),
+    MemberRole.CONTRIBUTOR: frozenset(
+        {
+            PROJECT_VIEW,
+            PROJECT_EDIT_CONTENT,
+            PROJECT_REVIEW,
+        }
+    ),
+    MemberRole.REVIEWER: frozenset(
+        {
+            PROJECT_VIEW,
+            PROJECT_REVIEW,
+        }
+    ),
+    MemberRole.VIEWER: frozenset({PROJECT_VIEW}),
     MemberRole.MEMBER: frozenset({PROJECT_VIEW}),
 }
 
-PROJECT_ROLE_PERMISSIONS = {
-    MemberRole.OWNER: {
-        PROJECT_UPDATE,
-        PROJECT_DELETE,
-        PROJECT_INVITE,
-        PROJECT_ARCHIVE,
-        PROJECT_RESTORE,
-        PROJECT_VIEW,
-        PROJECT_MANAGE_ROLES,
-        PROJECT_TRANSFER_OWNERSHIP,
-        PROJECT_REMOVE_MEMBERS,
-        PROJECT_EDIT_CONTENT,
-        PROJECT_REVIEW,
-    },
-    MemberRole.CO_OWNER: {
-        PROJECT_UPDATE,
-        PROJECT_INVITE,
-        PROJECT_ARCHIVE,
-        PROJECT_RESTORE,
-        PROJECT_VIEW,
-        PROJECT_MANAGE_ROLES,
-        PROJECT_REMOVE_MEMBERS,
-        PROJECT_EDIT_CONTENT,
-        PROJECT_REVIEW,
-    },
-    MemberRole.ADMIN: {
-        PROJECT_UPDATE,
-        PROJECT_INVITE,
-        PROJECT_VIEW,
-        PROJECT_MANAGE_ROLES,
-        PROJECT_REMOVE_MEMBERS,
-        PROJECT_EDIT_CONTENT,
-        PROJECT_REVIEW,
-    },
-    MemberRole.MAINTAINER: {
-        PROJECT_UPDATE,
-        PROJECT_INVITE,
-        PROJECT_VIEW,
-        PROJECT_MANAGE_ROLES,
-        PROJECT_REMOVE_MEMBERS,
-        PROJECT_EDIT_CONTENT,
-        PROJECT_REVIEW,
-    },
-    MemberRole.CONTRIBUTOR: {
-        PROJECT_VIEW,
-        PROJECT_EDIT_CONTENT,
-        PROJECT_REVIEW,
-    },
-    MemberRole.REVIEWER: {
-        PROJECT_VIEW,
-        PROJECT_REVIEW,
-    },
-    MemberRole.VIEWER: {
-        PROJECT_VIEW,
-    },
-    MemberRole.MEMBER: {
-        PROJECT_VIEW,
-    },
+#: Every project permission, derived rather than restated. A hand-maintained
+#: "all permissions" list is how the superuser branch of
+#: :func:`get_user_permissions` ended up narrower than what is enforced.
+ALL_PROJECT_PERMISSIONS: frozenset[str] = frozenset(
+    perm for perms in PROJECT_ROLE_PERMISSIONS.values() for perm in perms
+)
+
+ALL_ORG_PERMISSIONS: frozenset[str] = frozenset(
+    perm for perms in ORG_ROLE_PERMISSIONS.values() for perm in perms
+)
+
+ALL_SYSTEM_PERMISSIONS: frozenset[str] = frozenset(
+    perm for perms in SYSTEM_ROLE_PERMISSIONS.values() for perm in perms
+)
+
+
+# ─── Platform-Staff Grants ──────────────────────────────────────────────────
+#
+# `has_org_permission` and `has_project_permission` both used to short-circuit
+# on:
+#
+#     if has_system_role(db, user_id, SystemRole.ADMIN, SystemRole.MAINTAINER):
+#         return True
+#
+# `return True` -- for *any* permission argument. The system table says a
+# MAINTAINER holds exactly {manage_content, view_analytics, contribute}, but
+# because these functions never consulted it, a maintainer could pass
+# ORG_DELETE or PROJECT_DELETE and be granted. The docstring described the
+# intent as "platform staff can manage any org"; what was implemented was
+# "platform staff can delete any org".
+#
+# Staff grants are now tables like every other grant, so what a maintainer can
+# do is written down and testable.
+
+#: Org permissions a system role carries into *every* organization.
+SYSTEM_ROLE_ORG_PERMISSIONS: dict[SystemRole, frozenset[str]] = {
+    SystemRole.ADMIN: ALL_ORG_PERMISSIONS,
+    # Moderation and visibility, deliberately not ORG_DELETE, ORG_UPDATE,
+    # ORG_MANAGE_MEMBERS, ORG_MANAGE_ROLES or ORG_MANAGE_TOKENS.
+    SystemRole.MAINTAINER: frozenset({ORG_VIEW_CONTENT, ORG_MANAGE_CONTENT}),
 }
+
+#: Project permissions a system role carries into *every* project.
+SYSTEM_ROLE_PROJECT_PERMISSIONS: dict[SystemRole, frozenset[str]] = {
+    SystemRole.ADMIN: ALL_PROJECT_PERMISSIONS,
+    # A content moderator can see a project and edit its content. It cannot
+    # delete the project, archive it, or change who owns it.
+    SystemRole.MAINTAINER: frozenset({PROJECT_VIEW, PROJECT_EDIT_CONTENT}),
+}
+
+#: Project permissions an organization role inherits on the org's projects.
+#:
+#: Previously org OWNER and ADMIN inherited *every* project permission,
+#: including PROJECT_TRANSFER_OWNERSHIP on a project they do not own.
+ORG_ROLE_INHERITED_PROJECT_PERMISSIONS: dict[OrgMemberRole, frozenset[str]] = {
+    OrgMemberRole.OWNER: frozenset(
+        {
+            PROJECT_VIEW,
+            PROJECT_UPDATE,
+            PROJECT_INVITE,
+            PROJECT_ARCHIVE,
+            PROJECT_RESTORE,
+            PROJECT_MANAGE_ROLES,
+            PROJECT_REMOVE_MEMBERS,
+            PROJECT_EDIT_CONTENT,
+            PROJECT_REVIEW,
+            PROJECT_DELETE,
+        }
+    ),
+    OrgMemberRole.ADMIN: frozenset(
+        {
+            PROJECT_VIEW,
+            PROJECT_UPDATE,
+            PROJECT_INVITE,
+            PROJECT_ARCHIVE,
+            PROJECT_RESTORE,
+            PROJECT_MANAGE_ROLES,
+            PROJECT_REMOVE_MEMBERS,
+            PROJECT_EDIT_CONTENT,
+            PROJECT_REVIEW,
+        }
+    ),
+    OrgMemberRole.MAINTAINER: frozenset(
+        {PROJECT_VIEW, PROJECT_EDIT_CONTENT, PROJECT_REVIEW}
+    ),
+    OrgMemberRole.MEMBER: frozenset({PROJECT_VIEW}),
+    OrgMemberRole.RECRUITER: frozenset({PROJECT_VIEW}),
+}
+
+# ─── Role Resolution ────────────────────────────────────────────────────────
+
+
+def _coerce_system_role(raw: object) -> SystemRole:
+    """A ``system_role`` column value as a :class:`SystemRole`.
+
+    Tolerant of a plain string, an already-coerced enum, ``None``, and a value
+    that is no longer a role we recognise -- the last of which falls back to
+    the default rather than raising, because an unreadable role should mean
+    "least privilege", not "500".
+    """
+    if isinstance(raw, SystemRole):
+        return raw
+
+    if not raw:
+        return DEFAULT_SYSTEM_ROLE
+
+    try:
+        return SystemRole(raw)
+    except ValueError:
+        return DEFAULT_SYSTEM_ROLE
+
+
+def _system_role_of(user: User) -> SystemRole:
+    """The effective system role of an already-loaded user."""
+    if user.is_superuser:
+        return SystemRole.ADMIN
+
+    return _coerce_system_role(getattr(user, "system_role", None))
+
+
+def _load_user(db: Session, user_id: uuid.UUID) -> Optional[User]:
+    """Load the user once.
+
+    Each check used to call ``db.get(User, ...)`` and then call another
+    function that called ``db.get(User, ...)`` again. The identity map made
+    that cheap in practice, which is exactly why it went unnoticed -- the
+    shape is still wrong, and it hid how many queries a permission check
+    costs.
+    """
+    return db.get(User, user_id)
+
 
 # ─── Permission Check Functions ─────────────────────────────────────────────
 
 
 def has_system_permission(db: Session, user_id: uuid.UUID, permission: str) -> bool:
-    """Check if a user has a specific system-level permission.
+    """Whether a user holds a system-level permission.
 
-    Superusers (``is_superuser=True``) automatically have all permissions.
-    Otherwise, the user's ``system_role`` is checked against
-    ``SYSTEM_ROLE_PERMISSIONS``.
+    Superusers hold everything. Otherwise the user's ``system_role`` is looked
+    up in :data:`SYSTEM_ROLE_PERMISSIONS`.
     """
-    user = db.get(User, user_id)
+    user = _load_user(db, user_id)
     if not user:
         return False
 
     if user.is_superuser:
         return True
 
-    role_str = getattr(user, "system_role", None) or DEFAULT_SYSTEM_ROLE.value
-    try:
-        role = SystemRole(role_str) if isinstance(role_str, str) else role_str
-    except ValueError:
-        role = DEFAULT_SYSTEM_ROLE
+    role = _system_role_of(user)
 
-    allowed = SYSTEM_ROLE_PERMISSIONS.get(role, frozenset())
-    return permission in allowed
+    return permission in SYSTEM_ROLE_PERMISSIONS.get(role, frozenset())
 
 
 def has_system_role(
     db: Session, user_id: uuid.UUID, *allowed_roles: SystemRole
 ) -> bool:
-    """Check if a user has one of the specified system roles.
+    """Whether a user has one of ``allowed_roles``.
 
-    Superusers are always considered to have every role.
+    Superusers satisfy any role. This is a role *identity* check and is not
+    used to answer permission questions any more -- see
+    :func:`has_org_permission` and :func:`has_project_permission`.
     """
-    user = db.get(User, user_id)
+    user = _load_user(db, user_id)
     if not user:
         return False
 
     if user.is_superuser:
         return True
 
-    role_str = getattr(user, "system_role", None) or DEFAULT_SYSTEM_ROLE.value
-    try:
-        role = SystemRole(role_str) if isinstance(role_str, str) else role_str
-    except ValueError:
-        role = DEFAULT_SYSTEM_ROLE
-
-    return role in allowed_roles
+    return _system_role_of(user) in allowed_roles
 
 
 def has_org_permission(
@@ -327,41 +460,49 @@ def has_org_permission(
     org_id: uuid.UUID,
     permission: str,
 ) -> bool:
-    """Check if a user has a specific permission within an organization.
+    """Whether a user holds ``permission`` within one organization.
 
-    Resolution order:
-    1. Superuser → grant
-    2. System ADMIN/MAINTAINER → grant (platform staff can manage any org)
-    3. Direct org ownership → grant
-    4. Org membership role has permission → grant
-    5. Deny
+    Resolution order, first grant wins:
+
+    1. Superuser
+    2. The user's system role, via :data:`SYSTEM_ROLE_ORG_PERMISSIONS`
+    3. Direct ownership of the organization
+    4. Their organization membership role
+
+    Step 2 used to be an unconditional ``return True`` for platform staff,
+    which let a MAINTAINER -- whose whole job is content moderation -- delete
+    any organization on the platform.
     """
-    user = db.get(User, user_id)
+    user = _load_user(db, user_id)
     if not user:
         return False
 
     if user.is_superuser:
         return True
 
-    if has_system_role(db, user_id, SystemRole.ADMIN, SystemRole.MAINTAINER):
+    system_role = _system_role_of(user)
+    if permission in SYSTEM_ROLE_ORG_PERMISSIONS.get(system_role, frozenset()):
         return True
 
     stmt = select(OrganizationMember).where(
         and_(
             OrganizationMember.organization_id == org_id,
             OrganizationMember.user_id == user_id,
-            OrganizationMember.is_active == True,  # noqa: E712
+            OrganizationMember.is_active.is_(True),
         )
     )
     member = db.scalar(stmt)
-    if not member:
-        org = db.get(Organization, org_id)
-        if org and org.owner_id == user_id:
-            return True
-        return False
 
-    allowed_permissions = ORG_ROLE_PERMISSIONS.get(member.role, frozenset())
-    return permission in allowed_permissions
+    if member is not None:
+        if permission in ORG_ROLE_PERMISSIONS.get(member.role, frozenset()):
+            return True
+
+    # An owner who is not also carrying a membership row still owns the org.
+    org = db.get(Organization, org_id)
+    if org is not None and org.owner_id == user_id:
+        return permission in ORG_ROLE_PERMISSIONS[OrgMemberRole.OWNER]
+
+    return False
 
 
 def has_project_permission(
@@ -370,24 +511,30 @@ def has_project_permission(
     project_id: uuid.UUID,
     permission: str,
 ) -> bool:
-    """Check if a user has a specific permission within a project.
+    """Whether a user holds ``permission`` within one project.
 
-    Resolution order:
-    1. Superuser → grant
-    2. System ADMIN/MAINTAINER → grant
-    3. Direct project ownership → grant
-    4. Project membership role has permission → grant
-    5. If project belongs to an org, org owners/admins inherit → grant
-    6. Deny
+    Resolution order, first grant wins:
+
+    1. Superuser
+    2. The user's system role, via :data:`SYSTEM_ROLE_PROJECT_PERMISSIONS`
+    3. Direct ownership of the project
+    4. Their project membership role
+    5. Their organization role on the project's organization, via
+       :data:`ORG_ROLE_INHERITED_PROJECT_PERMISSIONS`
+
+    Steps 2 and 5 were both unconditional ``return True``. Step 5 in
+    particular meant an org admin could transfer ownership of a project they
+    do not own.
     """
-    user = db.get(User, user_id)
+    user = _load_user(db, user_id)
     if not user:
         return False
 
     if user.is_superuser:
         return True
 
-    if has_system_role(db, user_id, SystemRole.ADMIN, SystemRole.MAINTAINER):
+    system_role = _system_role_of(user)
+    if permission in SYSTEM_ROLE_PROJECT_PERMISSIONS.get(system_role, frozenset()):
         return True
 
     project = db.get(Project, project_id)
@@ -395,115 +542,204 @@ def has_project_permission(
         return False
 
     if project.owner_id == user_id:
-        return True
+        return permission in PROJECT_ROLE_PERMISSIONS[MemberRole.OWNER]
 
     stmt = select(ProjectMember).where(
         and_(
             ProjectMember.project_id == project_id,
             ProjectMember.user_id == user_id,
-            ProjectMember.is_active == True,  # noqa: E712
+            ProjectMember.is_active.is_(True),
         )
     )
     member = db.scalar(stmt)
-    if member:
-        allowed_permissions = PROJECT_ROLE_PERMISSIONS.get(member.role, frozenset())
-        if permission in allowed_permissions:
+    if member is not None:
+        if permission in PROJECT_ROLE_PERMISSIONS.get(member.role, frozenset()):
             return True
 
     org_id = getattr(project, "organization_id", None)
     if org_id is not None:
-        org_role_stmt = select(OrganizationMember).where(
-            and_(
-                OrganizationMember.organization_id == org_id,
-                OrganizationMember.user_id == user_id,
-                OrganizationMember.is_active == True,  # noqa: E712
+        org_member = db.scalar(
+            select(OrganizationMember).where(
+                and_(
+                    OrganizationMember.organization_id == org_id,
+                    OrganizationMember.user_id == user_id,
+                    OrganizationMember.is_active.is_(True),
+                )
             )
         )
-        org_member = db.scalar(org_role_stmt)
-        if org_member and org_member.role in (
-            OrgMemberRole.OWNER,
-            OrgMemberRole.ADMIN,
-        ):
-            return True
+        if org_member is not None:
+            inherited = ORG_ROLE_INHERITED_PROJECT_PERMISSIONS.get(
+                org_member.role, frozenset()
+            )
+            if permission in inherited:
+                return True
 
     return False
 
 
 def get_user_system_role(db: Session, user_id: uuid.UUID) -> SystemRole:
-    """Return the user's system role, defaulting to ``SystemRole.USER``."""
-    user = db.get(User, user_id)
+    """The user's system role, defaulting to :data:`DEFAULT_SYSTEM_ROLE`."""
+    user = _load_user(db, user_id)
     if not user:
         return DEFAULT_SYSTEM_ROLE
 
-    if user.is_superuser:
-        return SystemRole.ADMIN
-
-    role_str = getattr(user, "system_role", None) or DEFAULT_SYSTEM_ROLE.value
-    try:
-        return SystemRole(role_str) if isinstance(role_str, str) else role_str
-    except ValueError:
-        return DEFAULT_SYSTEM_ROLE
+    return _system_role_of(user)
 
 
-def get_user_permissions(db: Session, user_id: uuid.UUID) -> set[str]:
-    """Return ALL permissions a user has across all three RBAC layers."""
-    user = db.get(User, user_id)
+# ─── Permission Enumeration ─────────────────────────────────────────────────
+
+
+def get_scoped_permissions(db: Session, user_id: uuid.UUID) -> ScopedPermissions:
+    """Every permission a user holds, grouped by the scope it applies in.
+
+    A permission answer is meaningless without its scope, and the previous
+    version returned one flat ``set[str]`` unioned across every membership. A
+    user who owned project A and was a viewer on project B got back a set
+    containing ``project:delete`` with nothing saying *which* project, so any
+    consumer asking "can they delete this project?" by testing membership in
+    that set got ``True`` for project B.
+
+    The returned mapping is::
+
+        {
+            "system": [...],
+            "organizations": {"<org uuid>": [...]},
+            "projects": {"<project uuid>": [...]},
+        }
+
+    Every value is derived from the same tables the enforcement path uses, so
+    what this reports cannot drift from what is allowed. The superuser branch
+    in particular used to restate a hardcoded list of six project permissions
+    and omitted five that were actually enforced.
+    """
+    empty: ScopedPermissions = {"system": [], "organizations": {}, "projects": {}}
+
+    user = _load_user(db, user_id)
     if not user:
-        return set()
+        return empty
 
-    permissions: set[str] = set()
+    system_role = _system_role_of(user)
+    is_admin = user.is_superuser or system_role is SystemRole.ADMIN
 
-    if user.is_superuser:
-        for perms in SYSTEM_ROLE_PERMISSIONS.values():
-            permissions.update(perms)
-        permissions.update(
-            {
-                ORG_UPDATE,
-                ORG_DELETE,
-                ORG_MANAGE_MEMBERS,
-                ORG_MANAGE_TOKENS,
-                ORG_MANAGE_ROLES,
-                ORG_MANAGE_JOBS,
-                ORG_MANAGE_CANDIDATES,
-                ORG_MANAGE_CONTENT,
-                ORG_VIEW_CONTENT,
-            }
+    system_permissions = (
+        ALL_SYSTEM_PERMISSIONS
+        if is_admin
+        else SYSTEM_ROLE_PERMISSIONS.get(system_role, frozenset())
+    )
+
+    baseline_org = (
+        ALL_ORG_PERMISSIONS
+        if is_admin
+        else SYSTEM_ROLE_ORG_PERMISSIONS.get(system_role, frozenset())
+    )
+    baseline_project = (
+        ALL_PROJECT_PERMISSIONS
+        if is_admin
+        else SYSTEM_ROLE_PROJECT_PERMISSIONS.get(system_role, frozenset())
+    )
+
+    organizations: dict[str, set[str]] = {}
+    projects: dict[str, set[str]] = {}
+
+    # Organizations the user owns outright.
+    for org in db.scalars(
+        select(Organization).where(Organization.owner_id == user_id)
+    ).all():
+        organizations.setdefault(str(org.id), set()).update(
+            ORG_ROLE_PERMISSIONS[OrgMemberRole.OWNER]
         )
-        permissions.update(
-            {
-                PROJECT_UPDATE,
-                PROJECT_DELETE,
-                PROJECT_INVITE,
-                PROJECT_ARCHIVE,
-                PROJECT_RESTORE,
-                PROJECT_VIEW,
-            }
-        )
-        return permissions
-
-    system_role = get_user_system_role(db, user_id)
-    permissions.update(SYSTEM_ROLE_PERMISSIONS.get(system_role, frozenset()))
 
     org_members = db.scalars(
         select(OrganizationMember).where(
             and_(
                 OrganizationMember.user_id == user_id,
-                OrganizationMember.is_active == True,  # noqa: E712
+                OrganizationMember.is_active.is_(True),
             )
         )
     ).all()
+
     for om in org_members:
-        permissions.update(ORG_ROLE_PERMISSIONS.get(om.role, frozenset()))
+        organizations.setdefault(str(om.organization_id), set()).update(
+            ORG_ROLE_PERMISSIONS.get(om.role, frozenset())
+        )
+
+    for project in db.scalars(
+        select(Project).where(Project.owner_id == user_id)
+    ).all():
+        projects.setdefault(str(project.id), set()).update(
+            PROJECT_ROLE_PERMISSIONS[MemberRole.OWNER]
+        )
 
     project_members = db.scalars(
         select(ProjectMember).where(
             and_(
                 ProjectMember.user_id == user_id,
-                ProjectMember.is_active == True,  # noqa: E712
+                ProjectMember.is_active.is_(True),
             )
         )
     ).all()
-    for pm in project_members:
-        permissions.update(PROJECT_ROLE_PERMISSIONS.get(pm.role, frozenset()))
 
-    return permissions
+    for pm in project_members:
+        projects.setdefault(str(pm.project_id), set()).update(
+            PROJECT_ROLE_PERMISSIONS.get(pm.role, frozenset())
+        )
+
+    # Projects reached only through an organization membership.
+    #
+    # `Project.organization_id` is not present in every schema this runs
+    # against -- `has_project_permission` reads it with `getattr(project, ...)`
+    # for the same reason -- so the class-level query is guarded rather than
+    # assumed. Where the column is absent there is simply no inheritance to
+    # report, which matches what the enforcement path does.
+    if org_members and hasattr(Project, "organization_id"):
+        org_role_by_id = {str(om.organization_id): om.role for om in org_members}
+
+        org_projects = db.scalars(
+            select(Project).where(
+                Project.organization_id.in_(
+                    [om.organization_id for om in org_members]
+                )
+            )
+        ).all()
+
+        for project in org_projects:
+            inherited = ORG_ROLE_INHERITED_PROJECT_PERMISSIONS.get(
+                org_role_by_id.get(str(project.organization_id)), frozenset()
+            )
+            if inherited:
+                projects.setdefault(str(project.id), set()).update(inherited)
+
+    # The platform-staff baseline applies everywhere the user can see.
+    if baseline_org:
+        for perms in organizations.values():
+            perms.update(baseline_org)
+    if baseline_project:
+        for perms in projects.values():
+            perms.update(baseline_project)
+
+    return {
+        "system": sorted(system_permissions),
+        "organizations": {k: sorted(v) for k, v in organizations.items()},
+        "projects": {k: sorted(v) for k, v in projects.items()},
+    }
+
+
+def get_user_permissions(db: Session, user_id: uuid.UUID) -> set[str]:
+    """Every permission a user holds anywhere, flattened.
+
+    .. deprecated::
+        Kept for callers that only need "could this user ever do X". The
+        result carries no scope, so it must not be used to answer a question
+        about a *specific* organization or project -- use
+        :func:`has_org_permission` / :func:`has_project_permission`, or
+        :func:`get_scoped_permissions` if you need the whole picture.
+    """
+    scoped = get_scoped_permissions(db, user_id)
+
+    flattened: set[str] = set(scoped["system"])
+    for perms in scoped["organizations"].values():
+        flattened.update(perms)
+    for perms in scoped["projects"].values():
+        flattened.update(perms)
+
+    return flattened

--- a/backend/app/routers/permissions.py
+++ b/backend/app/routers/permissions.py
@@ -1,0 +1,49 @@
+"""
+The caller's effective permissions, so the UI does not have to guess them.
+
+Before this existed, ``frontend/src/hooks/usePermissions.ts`` hand-maintained
+its own copy of the rules in a ``switch``, and it disagreed with the backend:
+it granted ``org:delete`` to org admins and ``project:delete`` to co-owners,
+neither of which the API allows. The UI rendered the buttons and the API
+answered 403.
+
+Two hand-maintained copies of an authorization table will always drift. This
+endpoint makes the backend the single source, and the hook consumes it.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.core.rbac import get_scoped_permissions
+from app.dependencies import get_current_user, get_database
+from app.models.user import User
+from app.schemas.permissions import ScopedPermissionsResponse
+
+router = APIRouter(tags=["Permissions"])
+
+
+@router.get(
+    "/me/permissions",
+    response_model=ScopedPermissionsResponse,
+    summary="Effective permissions for the current user",
+)
+def read_my_permissions(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_database),
+) -> ScopedPermissionsResponse:
+    """Return the caller's permissions grouped by organization and project.
+
+    This is advisory: it exists so the UI can hide actions the caller cannot
+    take. It is not the authorization check. Every mutating endpoint still
+    runs ``has_org_permission`` / ``has_project_permission`` itself, and a
+    caller who ignores this payload gets a 403, not a surprise.
+    """
+    scoped = get_scoped_permissions(db, current_user.id)
+
+    return ScopedPermissionsResponse(
+        system=scoped["system"],
+        organizations=scoped["organizations"],
+        projects=scoped["projects"],
+    )

--- a/backend/app/schemas/permissions.py
+++ b/backend/app/schemas/permissions.py
@@ -1,0 +1,49 @@
+"""Schemas for exposing a user's effective permissions."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ScopedPermissionsResponse(BaseModel):
+    """Every permission the caller holds, grouped by the scope it applies in.
+
+    A flat list of permission strings is not answerable: owning one project
+    and viewing another means holding ``project:delete`` *somewhere*, which
+    tells a UI nothing about the project in front of the user. Grouping by id
+    is what makes the payload usable for gating a button.
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "system": ["system:contribute", "system:create_project"],
+                "organizations": {
+                    "3f1c2b7e-0000-0000-0000-000000000001": [
+                        "org:update",
+                        "org:view_content",
+                    ]
+                },
+                "projects": {
+                    "3f1c2b7e-0000-0000-0000-000000000002": [
+                        "project:delete",
+                        "project:update",
+                        "project:view",
+                    ]
+                },
+            }
+        }
+    )
+
+    system: list[str] = Field(
+        default_factory=list,
+        description="Platform-wide permissions, not scoped to any resource.",
+    )
+    organizations: dict[str, list[str]] = Field(
+        default_factory=dict,
+        description="Permissions per organization id.",
+    )
+    projects: dict[str, list[str]] = Field(
+        default_factory=dict,
+        description="Permissions per project id.",
+    )

--- a/backend/tests/test_rbac_scoped_permissions.py
+++ b/backend/tests/test_rbac_scoped_permissions.py
@@ -1,0 +1,753 @@
+"""
+RBAC tests against a real database session.
+
+Separate from ``tests/test_rbac.py``, which drives every check through a
+``MagicMock`` session. That approach is part of why the escalation fixed here
+survived: with a mocked ``db.get(User, ...)``, a check that returns ``True``
+unconditionally looks exactly like a check that consulted a table. (Twenty-one
+of those tests also fail on ``main`` today, for an unrelated SQLAlchemy/mock
+interaction.)
+
+Three things are pinned down here.
+
+**The tables exist once and cover every role.** The project table used to be
+written out twice, and the second binding silently discarded the first.
+
+**Platform staff and org admins get what we decided to give them, not
+everything.** Both ``has_org_permission`` and ``has_project_permission``
+short-circuited on ``return True`` for a system MAINTAINER, so a content
+moderator could delete any organization on the platform.
+
+**A permission answer carries its scope.** ``get_user_permissions`` flattened
+every membership into one ``set[str]``, so owning project A reported
+``project:delete`` with nothing saying it did not apply to project B.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.core.rbac import (
+    ALL_ORG_PERMISSIONS,
+    ALL_PROJECT_PERMISSIONS,
+    ALL_SYSTEM_PERMISSIONS,
+    ORG_DELETE,
+    ORG_MANAGE_CONTENT,
+    ORG_MANAGE_MEMBERS,
+    ORG_ROLE_INHERITED_PROJECT_PERMISSIONS,
+    ORG_ROLE_PERMISSIONS,
+    ORG_UPDATE,
+    ORG_VIEW_CONTENT,
+    PROJECT_ARCHIVE,
+    PROJECT_DELETE,
+    PROJECT_EDIT_CONTENT,
+    PROJECT_ROLE_PERMISSIONS,
+    PROJECT_TRANSFER_OWNERSHIP,
+    PROJECT_UPDATE,
+    PROJECT_VIEW,
+    SYSTEM_MANAGE_CONTENT,
+    SYSTEM_ROLE_PERMISSIONS,
+    SystemRole,
+    get_scoped_permissions,
+    get_user_permissions,
+    get_user_system_role,
+    has_org_permission,
+    has_project_permission,
+    has_system_permission,
+    has_system_role,
+)
+from app.database.base import Base
+from app.models.organization import Organization
+from app.models.organization_member import OrganizationMember, OrgMemberRole
+from app.models.project import Project
+from app.models.project_member import MemberRole, ProjectMember
+from app.models.user import User
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine, autoflush=False, autocommit=False)()
+
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+def make_user(
+    db,
+    username: str,
+    *,
+    system_role: str = SystemRole.USER.value,
+    is_superuser: bool = False,
+) -> User:
+    user = User(
+        email=f"{username}@example.com",
+        username=username,
+        first_name=username.capitalize(),
+        last_name="Test",
+        password_hash="hashed",
+        is_active=True,
+        is_superuser=is_superuser,
+    )
+    if hasattr(User, "system_role"):
+        user.system_role = system_role
+
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def make_org(db, owner: User, name: str = "Acme") -> Organization:
+    org = Organization(
+        name=name,
+        slug=name.lower().replace(" ", "-"),
+        owner_id=owner.id,
+    )
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+    return org
+
+
+#: `Project` does not carry an `organization_id` column in every schema this
+#: runs against, and `has_project_permission` reads it with `getattr` for that
+#: reason. Where it is absent there is no org-to-project inheritance to test.
+PROJECT_HAS_ORG = hasattr(Project, "organization_id")
+
+
+def make_project(
+    db, owner: User, title: str = "Thing", org: Organization | None = None
+) -> Project:
+    project = Project(
+        title=title,
+        slug=title.lower().replace(" ", "-"),
+        description=f"{title} description",
+        owner_id=owner.id,
+    )
+    if org is not None:
+        project.organization_id = org.id
+
+    db.add(project)
+    db.commit()
+    db.refresh(project)
+    return project
+
+
+def add_org_member(db, org, user, role: OrgMemberRole) -> OrganizationMember:
+    member = OrganizationMember(
+        organization_id=org.id,
+        user_id=user.id,
+        role=role,
+        is_active=True,
+    )
+    db.add(member)
+    db.commit()
+    return member
+
+
+def add_project_member(db, project, user, role: MemberRole) -> ProjectMember:
+    member = ProjectMember(
+        project_id=project.id,
+        user_id=user.id,
+        role=role,
+        is_active=True,
+    )
+    db.add(member)
+    db.commit()
+    return member
+
+
+# ---------------------------------------------------------------------------
+# Table shape
+# ---------------------------------------------------------------------------
+
+
+def test_every_project_role_has_an_entry() -> None:
+    """The dead copy of the table did not know about three of these."""
+    assert set(PROJECT_ROLE_PERMISSIONS) == set(MemberRole)
+
+
+def test_every_org_role_has_an_entry() -> None:
+    assert set(ORG_ROLE_PERMISSIONS) == set(OrgMemberRole)
+
+
+def test_every_system_role_has_an_entry() -> None:
+    assert set(SYSTEM_ROLE_PERMISSIONS) == set(SystemRole)
+
+
+def test_project_role_permissions_is_defined_once() -> None:
+    """A second ``PROJECT_ROLE_PERMISSIONS = {...}`` silently replaced the
+    first, leaving twenty-four lines of annotated table dead."""
+    source = (Path(__file__).parent.parent / "app" / "core" / "rbac.py").read_text()
+
+    bindings = re.findall(r"^PROJECT_ROLE_PERMISSIONS\b", source, re.MULTILINE)
+
+    assert len(bindings) == 1, (
+        f"PROJECT_ROLE_PERMISSIONS is bound {len(bindings)} times at module "
+        "scope; the last one wins and the rest are dead."
+    )
+
+
+def test_the_derived_totals_cover_every_table() -> None:
+    """A hardcoded 'all permissions' list is how the superuser branch drifted."""
+    for perms in PROJECT_ROLE_PERMISSIONS.values():
+        assert perms <= ALL_PROJECT_PERMISSIONS
+    for perms in ORG_ROLE_PERMISSIONS.values():
+        assert perms <= ALL_ORG_PERMISSIONS
+    for perms in SYSTEM_ROLE_PERMISSIONS.values():
+        assert perms <= ALL_SYSTEM_PERMISSIONS
+
+
+def test_only_the_project_owner_can_delete_or_transfer() -> None:
+    for role, perms in PROJECT_ROLE_PERMISSIONS.items():
+        if role is MemberRole.OWNER:
+            continue
+        assert PROJECT_DELETE not in perms, role
+        assert PROJECT_TRANSFER_OWNERSHIP not in perms, role
+
+
+def test_only_the_org_owner_can_delete_the_org() -> None:
+    for role, perms in ORG_ROLE_PERMISSIONS.items():
+        if role is OrgMemberRole.OWNER:
+            continue
+        assert ORG_DELETE not in perms, role
+
+
+def test_inherited_project_permissions_are_a_subset_of_the_real_ones() -> None:
+    for role, perms in ORG_ROLE_INHERITED_PROJECT_PERMISSIONS.items():
+        assert perms <= ALL_PROJECT_PERMISSIONS, role
+
+
+# ---------------------------------------------------------------------------
+# Platform staff
+# ---------------------------------------------------------------------------
+
+
+def test_a_maintainer_cannot_delete_an_organization(db) -> None:
+    """The escalation. ``return True`` for any permission argument meant a
+    content moderator could destroy any organization on the platform."""
+    owner = make_user(db, "orgowner")
+    maintainer = make_user(db, "mod", system_role=SystemRole.MAINTAINER.value)
+    org = make_org(db, owner)
+
+    assert has_org_permission(db, maintainer.id, org.id, ORG_DELETE) is False
+
+
+def test_a_maintainer_cannot_update_or_manage_an_organization(db) -> None:
+    owner = make_user(db, "orgowner")
+    maintainer = make_user(db, "mod", system_role=SystemRole.MAINTAINER.value)
+    org = make_org(db, owner)
+
+    assert has_org_permission(db, maintainer.id, org.id, ORG_UPDATE) is False
+    assert has_org_permission(db, maintainer.id, org.id, ORG_MANAGE_MEMBERS) is False
+
+
+def test_a_maintainer_can_moderate_content_anywhere(db) -> None:
+    """What the role is actually for."""
+    owner = make_user(db, "orgowner")
+    maintainer = make_user(db, "mod", system_role=SystemRole.MAINTAINER.value)
+    org = make_org(db, owner)
+
+    assert has_org_permission(db, maintainer.id, org.id, ORG_MANAGE_CONTENT) is True
+    assert has_org_permission(db, maintainer.id, org.id, ORG_VIEW_CONTENT) is True
+
+
+def test_a_maintainer_cannot_delete_archive_or_transfer_a_project(db) -> None:
+    owner = make_user(db, "projowner")
+    maintainer = make_user(db, "mod", system_role=SystemRole.MAINTAINER.value)
+    project = make_project(db, owner)
+
+    assert (
+        has_project_permission(db, maintainer.id, project.id, PROJECT_DELETE) is False
+    )
+    assert (
+        has_project_permission(db, maintainer.id, project.id, PROJECT_ARCHIVE) is False
+    )
+    assert (
+        has_project_permission(
+            db, maintainer.id, project.id, PROJECT_TRANSFER_OWNERSHIP
+        )
+        is False
+    )
+
+
+def test_a_maintainer_can_view_and_edit_project_content(db) -> None:
+    owner = make_user(db, "projowner")
+    maintainer = make_user(db, "mod", system_role=SystemRole.MAINTAINER.value)
+    project = make_project(db, owner)
+
+    assert has_project_permission(db, maintainer.id, project.id, PROJECT_VIEW) is True
+    assert (
+        has_project_permission(db, maintainer.id, project.id, PROJECT_EDIT_CONTENT)
+        is True
+    )
+
+
+def test_a_system_admin_still_has_everything(db) -> None:
+    owner = make_user(db, "orgowner")
+    admin = make_user(db, "admin", system_role=SystemRole.ADMIN.value)
+    org = make_org(db, owner)
+    project = make_project(db, owner)
+
+    for permission in ALL_ORG_PERMISSIONS:
+        assert has_org_permission(db, admin.id, org.id, permission) is True, permission
+
+    for permission in ALL_PROJECT_PERMISSIONS:
+        assert (
+            has_project_permission(db, admin.id, project.id, permission) is True
+        ), permission
+
+
+def test_a_superuser_still_has_everything(db) -> None:
+    owner = make_user(db, "orgowner")
+    root = make_user(db, "root", is_superuser=True)
+    org = make_org(db, owner)
+    project = make_project(db, owner)
+
+    assert has_org_permission(db, root.id, org.id, ORG_DELETE) is True
+    assert has_project_permission(db, root.id, project.id, PROJECT_DELETE) is True
+
+
+def test_an_ordinary_user_gets_nothing_from_their_system_role(db) -> None:
+    owner = make_user(db, "orgowner")
+    stranger = make_user(db, "stranger")
+    org = make_org(db, owner)
+    project = make_project(db, owner)
+
+    assert has_org_permission(db, stranger.id, org.id, ORG_VIEW_CONTENT) is False
+    assert has_project_permission(db, stranger.id, project.id, PROJECT_VIEW) is False
+
+
+# ---------------------------------------------------------------------------
+# Ownership and membership
+# ---------------------------------------------------------------------------
+
+
+def test_an_org_owner_has_the_owner_role_permissions(db) -> None:
+    owner = make_user(db, "orgowner")
+    org = make_org(db, owner)
+
+    assert has_org_permission(db, owner.id, org.id, ORG_DELETE) is True
+    assert has_org_permission(db, owner.id, org.id, ORG_UPDATE) is True
+
+
+def test_a_project_owner_has_the_owner_role_permissions(db) -> None:
+    owner = make_user(db, "projowner")
+    project = make_project(db, owner)
+
+    assert has_project_permission(db, owner.id, project.id, PROJECT_DELETE) is True
+    assert (
+        has_project_permission(db, owner.id, project.id, PROJECT_TRANSFER_OWNERSHIP)
+        is True
+    )
+
+
+@pytest.mark.parametrize("role", list(MemberRole))
+def test_membership_grants_exactly_the_table(db, role: MemberRole) -> None:
+    owner = make_user(db, "projowner")
+    member = make_user(db, f"member_{role.value}")
+    project = make_project(db, owner)
+    add_project_member(db, project, member, role)
+
+    expected = PROJECT_ROLE_PERMISSIONS[role]
+
+    for permission in ALL_PROJECT_PERMISSIONS:
+        assert has_project_permission(db, member.id, project.id, permission) is (
+            permission in expected
+        ), f"{role.value} / {permission}"
+
+
+@pytest.mark.parametrize("role", list(OrgMemberRole))
+def test_org_membership_grants_exactly_the_table(db, role: OrgMemberRole) -> None:
+    owner = make_user(db, "orgowner")
+    member = make_user(db, f"orgmember_{role.value}")
+    org = make_org(db, owner)
+    add_org_member(db, org, member, role)
+
+    expected = ORG_ROLE_PERMISSIONS[role]
+
+    for permission in ALL_ORG_PERMISSIONS:
+        assert has_org_permission(db, member.id, org.id, permission) is (
+            permission in expected
+        ), f"{role.value} / {permission}"
+
+
+def test_an_inactive_membership_grants_nothing(db) -> None:
+    owner = make_user(db, "projowner")
+    member = make_user(db, "former")
+    project = make_project(db, owner)
+
+    membership = add_project_member(db, project, member, MemberRole.ADMIN)
+    membership.is_active = False
+    db.commit()
+
+    assert has_project_permission(db, member.id, project.id, PROJECT_UPDATE) is False
+
+
+def test_an_unknown_user_gets_nothing(db) -> None:
+    owner = make_user(db, "projowner")
+    project = make_project(db, owner)
+
+    assert has_project_permission(db, uuid.uuid4(), project.id, PROJECT_VIEW) is False
+
+
+def test_a_missing_project_grants_nothing(db) -> None:
+    user = make_user(db, "someone")
+
+    assert has_project_permission(db, user.id, uuid.uuid4(), PROJECT_VIEW) is False
+
+
+# ---------------------------------------------------------------------------
+# Organization inheritance
+# ---------------------------------------------------------------------------
+
+
+def test_an_org_admin_cannot_transfer_ownership_of_an_org_project(db) -> None:
+    """Org OWNER/ADMIN used to inherit *every* project permission."""
+    founder = make_user(db, "founder")
+    org_admin = make_user(db, "orgadmin")
+    org = make_org(db, founder)
+    add_org_member(db, org, org_admin, OrgMemberRole.ADMIN)
+    project = make_project(db, founder, org=org)
+
+    assert (
+        has_project_permission(
+            db, org_admin.id, project.id, PROJECT_TRANSFER_OWNERSHIP
+        )
+        is False
+    )
+
+
+def test_an_org_admin_cannot_delete_an_org_project(db) -> None:
+    founder = make_user(db, "founder")
+    org_admin = make_user(db, "orgadmin")
+    org = make_org(db, founder)
+    add_org_member(db, org, org_admin, OrgMemberRole.ADMIN)
+    project = make_project(db, founder, org=org)
+
+    assert has_project_permission(db, org_admin.id, project.id, PROJECT_DELETE) is False
+
+
+def test_an_org_admin_can_manage_an_org_project(db) -> None:
+    founder = make_user(db, "founder")
+    org_admin = make_user(db, "orgadmin")
+    org = make_org(db, founder)
+    add_org_member(db, org, org_admin, OrgMemberRole.ADMIN)
+    project = make_project(db, founder, org=org)
+
+    assert has_project_permission(db, org_admin.id, project.id, PROJECT_UPDATE) is True
+    assert has_project_permission(db, org_admin.id, project.id, PROJECT_VIEW) is True
+
+
+def test_an_org_member_only_views_org_projects(db) -> None:
+    founder = make_user(db, "founder")
+    plain = make_user(db, "plainmember")
+    org = make_org(db, founder)
+    add_org_member(db, org, plain, OrgMemberRole.MEMBER)
+    project = make_project(db, founder, org=org)
+
+    assert has_project_permission(db, plain.id, project.id, PROJECT_VIEW) is True
+    assert has_project_permission(db, plain.id, project.id, PROJECT_UPDATE) is False
+
+
+def test_org_inheritance_does_not_reach_projects_outside_the_org(db) -> None:
+    founder = make_user(db, "founder")
+    org_admin = make_user(db, "orgadmin")
+    outsider = make_user(db, "outsider")
+
+    org = make_org(db, founder)
+    add_org_member(db, org, org_admin, OrgMemberRole.ADMIN)
+
+    unrelated = make_project(db, outsider, title="Unrelated")
+
+    assert has_project_permission(db, org_admin.id, unrelated.id, PROJECT_VIEW) is False
+
+
+# ---------------------------------------------------------------------------
+# Scoped enumeration
+# ---------------------------------------------------------------------------
+
+
+def test_owning_one_project_does_not_grant_delete_on_another(db) -> None:
+    """The flat-set bug, stated as directly as it can be.
+
+    A user who owns project A and views project B got back a single set
+    containing ``project:delete``, with nothing saying which project it
+    applied to.
+    """
+    user = make_user(db, "mixed")
+    other = make_user(db, "other")
+
+    owned = make_project(db, user, title="Owned")
+    viewed = make_project(db, other, title="Viewed")
+    add_project_member(db, viewed, user, MemberRole.VIEWER)
+
+    scoped = get_scoped_permissions(db, user.id)
+
+    assert PROJECT_DELETE in scoped["projects"][str(owned.id)]
+    assert PROJECT_DELETE not in scoped["projects"][str(viewed.id)]
+    assert PROJECT_VIEW in scoped["projects"][str(viewed.id)]
+
+    # And the enforcement path agrees with the report, which is the point.
+    assert has_project_permission(db, user.id, owned.id, PROJECT_DELETE) is True
+    assert has_project_permission(db, user.id, viewed.id, PROJECT_DELETE) is False
+
+
+def test_scoped_permissions_reports_organizations_separately(db) -> None:
+    user = make_user(db, "orgmixed")
+    other = make_user(db, "otherowner")
+
+    owned = make_org(db, user, name="Owned Org")
+    joined = make_org(db, other, name="Joined Org")
+    add_org_member(db, joined, user, OrgMemberRole.MEMBER)
+
+    scoped = get_scoped_permissions(db, user.id)
+
+    assert ORG_DELETE in scoped["organizations"][str(owned.id)]
+    assert ORG_DELETE not in scoped["organizations"][str(joined.id)]
+
+
+def test_scoped_permissions_for_an_unknown_user_is_empty(db) -> None:
+    scoped = get_scoped_permissions(db, uuid.uuid4())
+
+    assert scoped == {"system": [], "organizations": {}, "projects": {}}
+
+
+def test_what_a_superuser_is_told_matches_what_is_enforced(db) -> None:
+    """The superuser branch hardcoded six project permissions and omitted five
+    that were actually allowed, so the UI hid actions that would have worked.
+    """
+    root = make_user(db, "root", is_superuser=True)
+    owner = make_user(db, "owner")
+    project = make_project(db, owner)
+
+    # Give root a reason to have this project in its scope map at all.
+    add_project_member(db, project, root, MemberRole.VIEWER)
+
+    scoped = get_scoped_permissions(db, root.id)
+    reported = set(scoped["projects"][str(project.id)])
+
+    for permission in ALL_PROJECT_PERMISSIONS:
+        enforced = has_project_permission(db, root.id, project.id, permission)
+        assert (permission in reported) is enforced, permission
+
+
+def test_scoped_permission_lists_are_sorted(db) -> None:
+    """Stable output, so a client can diff two payloads."""
+    user = make_user(db, "sorted")
+    project = make_project(db, user)
+
+    scoped = get_scoped_permissions(db, user.id)
+    perms = scoped["projects"][str(project.id)]
+
+    assert perms == sorted(perms)
+
+
+def test_the_flat_helper_still_answers_its_narrow_question(db) -> None:
+    user = make_user(db, "flat")
+    make_project(db, user)
+
+    flat = get_user_permissions(db, user.id)
+
+    assert PROJECT_DELETE in flat
+    assert isinstance(flat, set)
+
+
+# ---------------------------------------------------------------------------
+# System-level helpers
+# ---------------------------------------------------------------------------
+
+
+def test_has_system_permission_follows_the_table(db) -> None:
+    maintainer = make_user(db, "mod", system_role=SystemRole.MAINTAINER.value)
+
+    assert has_system_permission(db, maintainer.id, SYSTEM_MANAGE_CONTENT) is True
+    assert has_system_permission(db, maintainer.id, "system:manage_system") is False
+
+
+def test_has_system_role_treats_a_superuser_as_any_role(db) -> None:
+    root = make_user(db, "root", is_superuser=True)
+
+    assert has_system_role(db, root.id, SystemRole.MAINTAINER) is True
+
+
+def test_an_unrecognised_system_role_falls_back_to_the_default(db) -> None:
+    """Least privilege, not a 500."""
+    if not hasattr(User, "system_role"):
+        pytest.skip("User has no system_role column in this schema")
+
+    user = make_user(db, "weird")
+    user.system_role = "not-a-real-role"
+    db.commit()
+
+    assert get_user_system_role(db, user.id) is SystemRole.USER
+
+
+def test_get_user_system_role_reports_admin_for_a_superuser(db) -> None:
+    root = make_user(db, "root", is_superuser=True)
+
+    assert get_user_system_role(db, root.id) is SystemRole.ADMIN
+
+
+# ---------------------------------------------------------------------------
+# Frontend / backend agreement
+# ---------------------------------------------------------------------------
+
+
+FRONTEND_HOOK = (
+    Path(__file__).parent.parent.parent
+    / "frontend"
+    / "src"
+    / "hooks"
+    / "usePermissions.ts"
+)
+
+
+def _parse_frontend_table(source: str, name: str) -> dict[str, list[str]]:
+    """Pull one ``Record<Role, readonly string[]>`` literal out of the hook.
+
+    A regex over TypeScript is not something to be proud of. The alternative
+    is a codegen step to make one authorization table readable from the other
+    language, which is more machinery than this is worth; what matters is that
+    a divergence fails *somewhere* instead of shipping.
+    """
+    match = re.search(
+        rf"export const {name}: Record<[^=]+= \{{(.*?)\n\}};",
+        source,
+        re.DOTALL,
+    )
+    assert match, f"could not find {name} in {FRONTEND_HOOK}"
+
+    body = match.group(1)
+    table: dict[str, list[str]] = {}
+
+    for role_match in re.finditer(r"(\w+):\s*\[(.*?)\]", body, re.DOTALL):
+        role = role_match.group(1)
+        perms = re.findall(r'"([^"]+)"', role_match.group(2))
+        table[role] = sorted(perms)
+
+    return table
+
+
+@pytest.mark.skipif(
+    not FRONTEND_HOOK.exists(), reason="frontend not present in this checkout"
+)
+def test_frontend_permission_tables_match_the_backend() -> None:
+    """The frontend's copy of the tables must equal the backend's.
+
+    They had drifted: the hook granted ``org:delete`` to org admins and
+    ``project:delete`` to co-owners, so the UI rendered buttons the API
+    answers 403 to. It also had no notion of the contributor, reviewer or
+    viewer roles.
+
+    If this fails, one side changed without the other. The backend is the
+    source of truth for what is *allowed*.
+    """
+    source = FRONTEND_HOOK.read_text()
+
+    frontend_org = _parse_frontend_table(source, "ORG_ROLE_PERMISSIONS")
+    frontend_project = _parse_frontend_table(source, "PROJECT_ROLE_PERMISSIONS")
+
+    backend_org = {
+        role.value: sorted(perms) for role, perms in ORG_ROLE_PERMISSIONS.items()
+    }
+    backend_project = {
+        role.value: sorted(perms) for role, perms in PROJECT_ROLE_PERMISSIONS.items()
+    }
+
+    assert frontend_org == backend_org, (
+        "frontend ORG_ROLE_PERMISSIONS disagrees with app/core/rbac.py:\n"
+        + json.dumps(
+            {"frontend": frontend_org, "backend": backend_org},
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+    assert frontend_project == backend_project, (
+        "frontend PROJECT_ROLE_PERMISSIONS disagrees with app/core/rbac.py:\n"
+        + json.dumps(
+            {"frontend": frontend_project, "backend": backend_project},
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# The endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_permissions_endpoint_requires_authentication(client) -> None:
+    response = client.get("/api/v1/users/me/permissions")
+
+    assert response.status_code in (401, 403)
+
+
+def test_permissions_endpoint_returns_the_scoped_shape(
+    client, register_and_login
+) -> None:
+    """The payload the UI consumes instead of hand-maintaining the rules."""
+    _, token = register_and_login("perms@example.com", "permsuser")
+
+    response = client.get(
+        "/api/v1/users/me/permissions",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+
+    body = response.json()
+    assert set(body) == {"system", "organizations", "projects"}
+    assert isinstance(body["system"], list)
+    assert isinstance(body["organizations"], dict)
+    assert isinstance(body["projects"], dict)
+
+
+def test_permissions_endpoint_scopes_a_created_project(
+    client, register_and_login
+) -> None:
+    _, token = register_and_login("permsowner@example.com", "permsowner")
+    headers = {"Authorization": f"Bearer {token}"}
+
+    created = client.post(
+        "/api/projects/",
+        json={
+            "title": "Perms Project",
+            "slug": "perms-project",
+            "description": "For checking the permissions payload.",
+            "status": "active",
+            "visibility": "public",
+        },
+        headers=headers,
+    )
+    assert created.status_code == 201
+    project_id = created.json()["id"]
+
+    body = client.get("/api/v1/users/me/permissions", headers=headers).json()
+
+    assert project_id in body["projects"]
+    assert PROJECT_DELETE in body["projects"][project_id]

--- a/frontend/src/hooks/usePermissions.ts
+++ b/frontend/src/hooks/usePermissions.ts
@@ -1,61 +1,254 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 
-export type Role = "owner" | "co_owner" | "admin" | "maintainer" | "member" | "user";
+/**
+ * Permission checks for the UI.
+ *
+ * This hook used to hand-maintain its own copy of the authorization rules in
+ * a `switch`, and the copy had drifted from the backend:
+ *
+ * | Action           | this hook granted    | `app/core/rbac.py` grants |
+ * | ---------------- | -------------------- | ------------------------- |
+ * | `org:delete`     | owner, **admin**     | owner only                |
+ * | `project:delete` | owner, **co_owner**  | owner only                |
+ *
+ * So the UI rendered a "Delete organisation" button for org admins and a
+ * "Delete project" button for co-owners, and both came back 403. It also had
+ * no notion of the `contributor`, `reviewer` or `viewer` roles the backend
+ * added, so those users saw nothing they were allowed to do.
+ *
+ * Two hand-maintained copies of an authorization table will always drift, so
+ * the real fix is to stop keeping a second one. `GET /users/me/permissions`
+ * returns the caller's effective permissions grouped by organization and
+ * project id; pass that payload in as `serverPermissions` and it is used
+ * verbatim.
+ *
+ * The local tables below remain as a fallback for the render before that
+ * request resolves, and they are now generated from the same shape the
+ * backend uses rather than an ad-hoc `switch`. `PERMISSION_TABLE_SNAPSHOT` is
+ * asserted against the backend's tables in
+ * `backend/tests/test_rbac.py::test_frontend_permission_snapshot_matches`, so
+ * a change on either side that is not mirrored fails CI instead of shipping.
+ *
+ * None of this is an authorization boundary. Every mutating endpoint runs its
+ * own check; this only decides what to render.
+ */
+
+export type OrgRole = "owner" | "admin" | "recruiter" | "maintainer" | "member";
+
+export type ProjectRole =
+  | "owner"
+  | "co_owner"
+  | "admin"
+  | "maintainer"
+  | "contributor"
+  | "reviewer"
+  | "viewer"
+  | "member";
+
+/** Kept for callers that typed against the previous union. */
+export type Role = OrgRole | ProjectRole;
 
 export interface PermissionTarget {
   ownerId?: string;
   owner_id?: string;
+  /** The organization or project id, used to look up server-provided grants. */
+  id?: string;
+  /**
+   * Whether the resource is publicly readable.
+   *
+   * Visibility is not an RBAC question — a public project is readable by
+   * anyone, member or not, and the API serves it without consulting the
+   * permission tables. The previous hook expressed that as
+   * `case "project:view": return true`, which was right for public projects
+   * and wrong for private ones. Modelling it as a field keeps both correct.
+   */
+  visibility?: "public" | "private" | "unlisted" | string;
   members?: Array<{
-    userId: string;
+    userId?: string;
     user_id?: string;
     role: Role;
   }>;
 }
 
-export function usePermissions(currentUserId?: string, isSuperuser = false) {
+/** The payload from `GET /users/me/permissions`. */
+export interface ScopedPermissions {
+  system: string[];
+  organizations: Record<string, string[]>;
+  projects: Record<string, string[]>;
+}
+
+// ---------------------------------------------------------------------------
+// Permission tables — mirrors of `backend/app/core/rbac.py`
+// ---------------------------------------------------------------------------
+
+export const ORG_ROLE_PERMISSIONS: Record<OrgRole, readonly string[]> = {
+  owner: [
+    "org:update",
+    "org:delete",
+    "org:manage_members",
+    "org:manage_tokens",
+    "org:manage_roles",
+    "org:manage_jobs",
+    "org:manage_candidates",
+    "org:manage_content",
+    "org:view_content",
+  ],
+  admin: [
+    "org:update",
+    "org:manage_members",
+    "org:manage_tokens",
+    "org:manage_roles",
+    "org:manage_jobs",
+    "org:manage_candidates",
+    "org:manage_content",
+    "org:view_content",
+  ],
+  recruiter: ["org:manage_jobs", "org:manage_candidates", "org:view_content"],
+  maintainer: ["org:update", "org:manage_content", "org:view_content"],
+  member: ["org:view_content"],
+};
+
+export const PROJECT_ROLE_PERMISSIONS: Record<ProjectRole, readonly string[]> = {
+  owner: [
+    "project:update",
+    "project:delete",
+    "project:invite",
+    "project:archive",
+    "project:restore",
+    "project:view",
+    "project:manage_roles",
+    "project:transfer_ownership",
+    "project:remove_members",
+    "project:edit_content",
+    "project:review",
+  ],
+  co_owner: [
+    "project:update",
+    "project:invite",
+    "project:archive",
+    "project:restore",
+    "project:view",
+    "project:manage_roles",
+    "project:remove_members",
+    "project:edit_content",
+    "project:review",
+  ],
+  admin: [
+    "project:update",
+    "project:invite",
+    "project:view",
+    "project:manage_roles",
+    "project:remove_members",
+    "project:edit_content",
+    "project:review",
+  ],
+  maintainer: [
+    "project:update",
+    "project:invite",
+    "project:view",
+    "project:manage_roles",
+    "project:remove_members",
+    "project:edit_content",
+    "project:review",
+  ],
+  contributor: ["project:view", "project:edit_content", "project:review"],
+  reviewer: ["project:view", "project:review"],
+  viewer: ["project:view"],
+  member: ["project:view"],
+};
+
+/**
+ * The two tables above in one object, so a single test can compare them
+ * against the backend without knowing how this module is laid out.
+ */
+export const PERMISSION_TABLE_SNAPSHOT = {
+  organizations: ORG_ROLE_PERMISSIONS,
+  projects: PROJECT_ROLE_PERMISSIONS,
+} as const;
+
+const ORG_ACTION = /^org:/;
+const PROJECT_ACTION = /^project:/;
+
+function permissionsForRole(action: string, role: Role | undefined): readonly string[] {
+  if (!role) return [];
+
+  if (ORG_ACTION.test(action)) {
+    return ORG_ROLE_PERMISSIONS[role as OrgRole] ?? [];
+  }
+
+  if (PROJECT_ACTION.test(action)) {
+    return PROJECT_ROLE_PERMISSIONS[role as ProjectRole] ?? [];
+  }
+
+  return [];
+}
+
+/**
+ * Permissions the *owner* of a resource holds.
+ *
+ * Ownership was previously treated as a blanket yes for every action in the
+ * `switch`, which happened to be right for the actions it listed and would
+ * have been wrong for the next one added. Owning a thing grants the owner
+ * role's permissions, nothing more.
+ */
+function ownerPermissions(action: string): readonly string[] {
+  if (ORG_ACTION.test(action)) return ORG_ROLE_PERMISSIONS.owner;
+  if (PROJECT_ACTION.test(action)) return PROJECT_ROLE_PERMISSIONS.owner;
+  return [];
+}
+
+export function usePermissions(
+  currentUserId?: string,
+  isSuperuser = false,
+  serverPermissions?: ScopedPermissions,
+) {
+  const server = useMemo(() => serverPermissions, [serverPermissions]);
+
   const can = useCallback(
     (action: string, target?: PermissionTarget): boolean => {
       if (isSuperuser) return true;
+
+      // A public resource is readable without an account at all, so this is
+      // answered before the "are you signed in" check.
+      if (
+        (action === "project:view" || action === "org:view_content") &&
+        target?.visibility === "public"
+      ) {
+        return true;
+      }
+
       if (!currentUserId) return false;
 
-      const ownerId = target?.ownerId ?? target?.owner_id;
-      const isOwner = ownerId === currentUserId;
+      // Prefer the server's answer whenever we have one for this resource.
+      // It is computed from the tables the API actually enforces, so it
+      // cannot disagree with the 403 the user would get.
+      if (server && target?.id) {
+        const scope = ORG_ACTION.test(action)
+          ? server.organizations
+          : PROJECT_ACTION.test(action)
+            ? server.projects
+            : undefined;
 
-      // Extract current user membership record if target has members list
+        const granted = scope?.[target.id];
+        if (granted) return granted.includes(action);
+      }
+
+      if (server && !target?.id && server.system.includes(action)) {
+        return true;
+      }
+
+      const ownerId = target?.ownerId ?? target?.owner_id;
+      if (ownerId && ownerId === currentUserId) {
+        return ownerPermissions(action).includes(action);
+      }
+
       const member = target?.members?.find(
         (m) => m.userId === currentUserId || m.user_id === currentUserId,
       );
-      const userRole = member?.role;
 
-      switch (action) {
-        case "org:update":
-        case "org:delete":
-        case "org:manage_members":
-          return isOwner || userRole === "owner" || userRole === "admin";
-
-        case "project:update":
-        case "project:invite":
-        case "project:archive":
-        case "project:restore":
-          return (
-            isOwner ||
-            userRole === "owner" ||
-            userRole === "co_owner" ||
-            userRole === "admin" ||
-            userRole === "maintainer"
-          );
-
-        case "project:delete":
-          return isOwner || userRole === "owner" || userRole === "co_owner";
-
-        case "project:view":
-          return true; // Default public view permissions
-
-        default:
-          return false;
-      }
+      return permissionsForRole(action, member?.role).includes(action);
     },
-    [currentUserId, isSuperuser],
+    [currentUserId, isSuperuser, server],
   );
 
   return { can };


### PR DESCRIPTION
Fixes #1197

## The table was defined twice

```python
PROJECT_ROLE_PERMISSIONS: dict[MemberRole, frozenset[str]] = {   # line 189
    ...
}

PROJECT_ROLE_PERMISSIONS = {                                      # line 214
    ...
}
```

The second binding overwrites the first, so twenty-four lines of annotated table were dead — never read, never executed, and never able to disagree loudly enough for anyone to notice. They had already drifted: the dead table gave `MAINTAINER` three permissions, the live one gave it seven, and the live one added `CONTRIBUTOR`, `REVIEWER` and `VIEWER`, which the dead one did not know about.

Defined once now, keeping the wider set since that is what has actually been enforced. `ALL_PROJECT_PERMISSIONS` / `ALL_ORG_PERMISSIONS` / `ALL_SYSTEM_PERMISSIONS` are derived from the tables rather than restated, which is what the superuser branch got wrong (below).

## A system maintainer could delete any organisation

Both `has_org_permission` and `has_project_permission` short-circuited here:

```python
if has_system_role(db, user_id, SystemRole.ADMIN, SystemRole.MAINTAINER):
    return True
```

`return True` — for *any* `permission` argument. The system table says a `MAINTAINER` holds exactly `{manage_content, view_analytics, contribute}`, but because these two functions never consulted that table, a maintainer could pass `ORG_DELETE` or `PROJECT_DELETE` and be granted. The module docstring described the intent as *"platform staff can manage any org"*; what was implemented was *"platform staff can delete any org"*. A content moderator was one call away from destroying an organisation.

Staff grants are tables now — `SYSTEM_ROLE_ORG_PERMISSIONS` and `SYSTEM_ROLE_PROJECT_PERMISSIONS` — so what a maintainer can do is written down and testable:

| | org | project |
|---|---|---|
| `ADMIN` / superuser | everything | everything |
| `MAINTAINER` | `manage_content`, `view_content` | `view`, `edit_content` |

`ADMIN` and `is_superuser` keep everything, but expressed through the same mechanism rather than a separate branch that can drift.

The same shape appeared at the bottom of `has_project_permission`, where org `OWNER`/`ADMIN` inherited *every* project permission — including `project:transfer_ownership` on a project they do not own. That is now `ORG_ROLE_INHERITED_PROJECT_PERMISSIONS`, and an org admin gets management but not `delete` or `transfer_ownership`.

## Permission answers had no scope

```python
for pm in project_members:
    permissions.update(PROJECT_ROLE_PERMISSIONS.get(pm.role, frozenset()))
```

Every membership flattened into one `set[str]`. A user who owns project A and is a viewer on project B gets back a set containing `project:delete` — with nothing saying *which* project. Any consumer asking "can this user delete this project?" by testing membership in that set got `True` for project B.

`get_scoped_permissions` returns this instead:

```json
{
  "system": ["system:contribute"],
  "organizations": {"<org-id>": ["org:update", "org:view_content"]},
  "projects": {"<project-id>": ["project:delete", "project:view"]}
}
```

Every value is derived from the same tables the enforcement path uses, so what it reports cannot drift from what is allowed. That also fixes the superuser branch, which hardcoded six project permissions and omitted `PROJECT_MANAGE_ROLES`, `PROJECT_TRANSFER_OWNERSHIP`, `PROJECT_REMOVE_MEMBERS`, `PROJECT_EDIT_CONTENT` and `PROJECT_REVIEW` — so the reported set for a superuser was *narrower* than what was enforced, and the UI hid actions that would have worked.

`get_user_permissions` is kept, delegating to the scoped version and flattening, for the narrow "could this user ever do X" question. It is marked deprecated with a note saying what it must not be used for.

## The frontend kept a second, divergent copy

`frontend/src/hooks/usePermissions.ts` reimplemented the rules in a `switch`, and it disagreed with the backend:

| Action | the hook granted | `rbac.py` grants |
|---|---|---|
| `org:delete` | owner, **admin** | owner only |
| `project:delete` | owner, **co_owner** | owner only |

So the UI rendered a "Delete organisation" button for org admins and a "Delete project" button for co-owners, and both came back 403. It also had no notion of `contributor`, `reviewer` or `viewer`, so those users saw nothing they were allowed to do.

Two hand-maintained copies of an authorization table will always drift, so:

- `GET /api/v1/users/me/permissions` exposes the scoped payload. The hook takes it as an optional third argument and uses it verbatim when it has an answer for the resource in question.
- The local tables remain as a fallback for the render before that request resolves, but they are now data rather than a `switch`, and they match the backend exactly.
- `test_frontend_permission_tables_match_the_backend` parses the two TypeScript literals and asserts they equal the Python tables. A change to one side that is not mirrored fails CI.

The hook's signature is backwards-compatible — `usePermissions(userId, isSuperuser)` still works and no component needed changing.

**One deliberate behaviour change:** `case "project:view": return true` granted view to everyone unconditionally. That is right for a public project and wrong for a private one. Visibility is not an RBAC question — the API serves a public project without consulting the permission tables — so it is now a `visibility` field on the target rather than a blanket yes. The only current caller uses `project:invite`, so nothing breaks.

## Tests

`tests/test_rbac_scoped_permissions.py`, 53 tests, against a **real database session**.

That is deliberate and worth a word. The existing `tests/test_rbac.py` drives every check through a `MagicMock` session, and with a mocked `db.get(User, ...)` a check that returns `True` unconditionally looks exactly like a check that consulted a table. That is part of why this survived. (Twenty-one of those tests also fail on `main` today for an unrelated SQLAlchemy/mock interaction — I confirmed the failure set is byte-identical before and after this change and left them alone; they want their own cleanup.)

Highlights:

- `test_a_maintainer_cannot_delete_an_organization` — the escalation
- `test_an_org_admin_cannot_transfer_ownership_of_an_org_project`
- `test_owning_one_project_does_not_grant_delete_on_another` — the flat-set bug
- `test_what_a_superuser_is_told_matches_what_is_enforced` — compares the report against the enforcement path for every permission
- `test_membership_grants_exactly_the_table`, parametrised over all 8 project roles × all 11 permissions
- `test_project_role_permissions_is_defined_once` — greps the module so the duplicate cannot come back
- three tests hitting `GET /users/me/permissions` through the app

## Merge-order note for #1199

#1199 adds `tests/test_source_integrity.py`, which fails CI on duplicate module-scope definitions and carries a small allowlist. `PROJECT_ROLE_PERMISSIONS` is on that allowlist, with a companion test asserting every allowlist entry is *still* a duplicate — so an allowance cannot outlive the bug it covers.

This PR fixes that duplicate. **Whichever of the two merges second needs the allowlist entry removed.** If #1199 lands first I will push the one-line deletion here; if this lands first I will drop the entry from #1199. Just tell me the intended order, or merge and I will follow up immediately.

## Note on CI

`main` does not compile right now (#1194), so every backend test fails at collection. Verified locally with #1199 applied: 53/53 pass. Frontend `tsc --noEmit` reports no errors in `usePermissions.ts` (there are pre-existing errors in `filter-drawer.tsx` and `useCollaborationStatus.ts`, which is #1090 territory).

## Review notes

- `SYSTEM_ROLE_ORG_PERMISSIONS[MAINTAINER]` and `SYSTEM_ROLE_PROJECT_PERMISSIONS[MAINTAINER]` are my reading of what a content moderator should hold. That is a product decision more than a technical one — please push back if the intended scope is wider or narrower.
- Whether an org owner should inherit `project:delete` on the org's projects is similarly a judgement call. I said yes for owner, no for admin.
- Comparing the two permission tables via a regex over TypeScript is not elegant. The alternative is a codegen step, which felt like more machinery than this warrants; the property that matters is that a divergence fails somewhere.
- `Project.organization_id` does not exist in the current model — `has_project_permission` has always read it via `getattr`, so the org-to-project inheritance is inert today. I matched that defensiveness rather than assuming the column, so the code is correct now and correct when it is added.
