### PR TITLE
fix(api): one spelling for the error code, and finish wiring the envelope

### DIFF
--- a/backend/app/core/error_handlers.py
+++ b/backend/app/core/error_handlers.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Any, Dict
+from typing import Any, Dict, Final
 from datetime import datetime, timezone
 from app.core.tracing import get_request_id
 
@@ -11,7 +11,9 @@ from fastapi.exceptions import HTTPException, RequestValidationError
 from fastapi.responses import JSONResponse
 from slowapi.errors import RateLimitExceeded
 from starlette.exceptions import HTTPException as StarletteHTTPException
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+
+from app.core.exceptions import AppException
 
 logger = logging.getLogger("devlink")
 
@@ -51,6 +53,27 @@ def generate_error_code(status_code: int, message: str | None) -> str:
     return "_".join(words).upper()
 
 
+#: The key clients are meant to branch on.
+#:
+#: This used to be spelled two ways at once. `format_error_response` emitted
+#: `error_code`, while the docstring example, the *input* side of
+#: `http_exception_handler` (`exc.detail.get("code")`) and every test written
+#: for the envelope used `code`. A route would raise
+#: `HTTPException(detail={"code": "PROJECT_NOT_FOUND"})` and the caller would
+#: receive `{"error": {"error_code": "PROJECT_NOT_FOUND"}}`: write `code`,
+#: read `error_code`.
+ERROR_CODE_KEY: Final[str] = "code"
+
+#: The spelling that shipped by accident, kept as an alias.
+#:
+#: Nothing in this repository reads it, but the responses have been going out
+#: with it for a while and something outside may have started depending on it.
+#: Removing it in the same change that fixes the contract would trade one
+#: silent break for another, so it stays -- carrying the same value -- until a
+#: release that says it is going.
+DEPRECATED_ERROR_CODE_KEY: Final[str] = "error_code"
+
+
 def format_error_response(
     code: str,
     message: str,
@@ -59,12 +82,31 @@ def format_error_response(
 ) -> Dict[str, Any]:
     """
     Build standardized JSON response payload.
+
+    The envelope is::
+
+        {
+          "error": {
+            "code": "PROJECT_NOT_FOUND",
+            "error_code": "PROJECT_NOT_FOUND",   # deprecated alias
+            "message": "Project not found.",
+            "timestamp": "2026-08-20T15:32:23.934285+00:00",
+            "request_id": "eb13279e-d0b9-48e9-94ef-ea1612da2d11",
+            "details": ...                       # only when there are any
+          },
+          "detail": "Project not found."         # FastAPI compatibility
+        }
+
+    `code` is machine-readable and stable; `message` is for humans and may be
+    reworded; `detail` exists so callers written against plain FastAPI keep
+    working.
     """
     request_id = getattr(request.state, "request_id", None) if request else None
     request_id = request_id or get_request_id() or "unknown"
 
     error_dict: Dict[str, Any] = {
-        "error_code": code,
+        ERROR_CODE_KEY: code,
+        DEPRECATED_ERROR_CODE_KEY: code,
         "message": message,
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "request_id": request_id,
@@ -185,7 +227,9 @@ async def validation_exception_handler(
         code="VALIDATION_ERROR",
         message=message,
         details=errors,
+        request=request,
     )
+    payload["detail"] = message
     return JSONResponse(
         status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
         content=payload,
@@ -215,7 +259,9 @@ async def rate_limit_exception_handler(
         code="RATE_LIMIT_EXCEEDED",
         message="Too many requests. Rate limit exceeded. Please try again later.",
         details={"retry_after_seconds": retry_after_int},
+        request=request,
     )
+    payload["detail"] = payload["error"]["message"]
 
     return JSONResponse(
         status_code=status.HTTP_429_TOO_MANY_REQUESTS,
@@ -237,6 +283,7 @@ async def global_exception_handler(
         message="An unexpected internal server error occurred.",
         request=request,
     )
+    payload["detail"] = payload["error"]["message"]
     return JSONResponse(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         content=payload,
@@ -259,22 +306,96 @@ async def integrity_error_handler(
     # PostgreSQL duplicate key error usually looks like:
     # duplicate key value violates unique constraint "ix_users_email"
     # DETAIL:  Key (email)=(test@example.com) already exists.
+    #
+    # `details` used to carry that whole string. It names the physical index,
+    # and -- worse -- it echoes the value that collided, so a signup form that
+    # hit a duplicate email replied with the email already on the account. The
+    # field name is the only part a client can act on, so it is the only part
+    # that goes out; the raw text is logged instead.
+    duplicate_field: str | None = None
+
     if "already exists" in detail.lower() or "unique constraint" in detail.lower():
         message = "This record already exists. Please use a unique value."
 
-        # Try to extract the field name from the detail
-        # e.g., Key (username)=(admin) already exists.
+        # e.g. Key (username)=(admin) already exists.
         match = re.search(r"Key \((.*?)\)=", detail)
         if match:
-            field = match.group(1)
-            message = f"The {field} provided is already in use."
+            duplicate_field = match.group(1)
+            message = f"The {duplicate_field} provided is already in use."
+
+    logger.warning("IntegrityError on %s: %s", request.url.path, detail)
 
     payload = format_error_response(
         code="CONFLICT",
         message=message,
-        details=detail,
+        details={"duplicate_field": duplicate_field} if duplicate_field else None,
+        request=request,
     )
+    payload["detail"] = message
     return JSONResponse(
         status_code=status.HTTP_409_CONFLICT,
+        content=payload,
+    )
+
+
+async def app_exception_handler(
+    request: Request,
+    exc: AppException,
+) -> JSONResponse:
+    """
+    Handle the application's own typed exceptions.
+
+    `AppException` and its subclasses (`AuthException`, `DatabaseException`,
+    `ValidationException`) each carry the status code, the machine-readable
+    code and the details they want returned -- and none of that reached the
+    client, because no handler was ever registered for them. They fell through
+    to `global_exception_handler` and came back as a flat 500
+    `INTERNAL_SERVER_ERROR`, discarding the 401 or 422 the raiser asked for.
+
+    That is why nothing in the codebase raises them: they did not work.
+    """
+    status_code = getattr(exc, "status_code", None) or status.HTTP_500_INTERNAL_SERVER_ERROR
+    message = getattr(exc, "message", None) or str(exc) or "An error occurred."
+    code = getattr(exc, "code", None) or DEFAULT_STATUS_CODES.get(status_code, "ERROR")
+
+    # A 5xx is still a server fault even when it is typed, so it is logged with
+    # the same weight as an unhandled one. 4xx is the caller's business.
+    if status_code >= 500:
+        logger.exception("AppException on %s: %s", request.url.path, message)
+
+    payload = format_error_response(
+        code=code,
+        message=message,
+        details=getattr(exc, "details", None),
+        request=request,
+    )
+    payload["detail"] = message
+    return JSONResponse(status_code=status_code, content=payload)
+
+
+async def sqlalchemy_error_handler(
+    request: Request,
+    exc: SQLAlchemyError,
+) -> JSONResponse:
+    """
+    Handle any database error that is not an `IntegrityError` -> 500.
+
+    `IntegrityError` is a subclass of `SQLAlchemyError` and keeps its own
+    handler; Starlette resolves handlers along the exception's MRO, so the
+    more specific registration still wins.
+
+    The driver's message can contain the failing statement and its bound
+    parameters, so it is logged and never returned.
+    """
+    logger.exception("Database error on %s: %s", request.url.path, exc)
+
+    payload = format_error_response(
+        code="DATABASE_ERROR",
+        message="A database error occurred. Please try again later.",
+        request=request,
+    )
+    payload["detail"] = payload["error"]["message"]
+    return JSONResponse(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         content=payload,
     )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -348,20 +348,31 @@ app.state.limiter = limiter
 
 from fastapi.exceptions import HTTPException, RequestValidationError
 from starlette.exceptions import HTTPException as StarletteHTTPException
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from app.core.exceptions import AppException
 from app.core.error_handlers import (
+    app_exception_handler,
     http_exception_handler,
     validation_exception_handler,
     rate_limit_exception_handler,
     global_exception_handler,
     integrity_error_handler,
+    sqlalchemy_error_handler,
 )
 
+# Registration order does not decide which handler runs -- Starlette walks the
+# raised exception's MRO and picks the most specific class registered -- so
+# `IntegrityError` keeps its 409 even though `SQLAlchemyError` is also
+# registered, and `AppException` keeps its own status even though `Exception`
+# is. They are listed most-specific-first anyway, so reading the block tells
+# you the same thing.
 app.add_exception_handler(HTTPException, http_exception_handler)
 app.add_exception_handler(StarletteHTTPException, http_exception_handler)
 app.add_exception_handler(RequestValidationError, validation_exception_handler)
 app.add_exception_handler(RateLimitExceeded, rate_limit_exception_handler)
+app.add_exception_handler(AppException, app_exception_handler)
 app.add_exception_handler(IntegrityError, integrity_error_handler)
+app.add_exception_handler(SQLAlchemyError, sqlalchemy_error_handler)
 app.add_exception_handler(Exception, global_exception_handler)
 app.add_middleware(SlowAPIMiddleware)
 

--- a/backend/tests/test_error_envelope.py
+++ b/backend/tests/test_error_envelope.py
@@ -1,0 +1,281 @@
+"""The shape of the error envelope itself.
+
+`tests/test_error_responses.py` and `tests/test_global_error_handler.py`
+already check that each handler produces the right code for the right
+situation. What neither of them checked is the thing that actually broke: the
+*name* of the field carrying that code.
+
+The envelope was emitted with `error_code` while the docstring, the input side
+of `http_exception_handler` and every assertion in the suite used `code`. Both
+halves were individually consistent, so nothing pointed at the seam. These
+tests hold the seam.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI, HTTPException, status
+from fastapi.exceptions import RequestValidationError
+from fastapi.testclient import TestClient
+from pydantic import BaseModel, Field
+from slowapi.errors import RateLimitExceeded
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from app.core.error_handlers import (
+    DEPRECATED_ERROR_CODE_KEY,
+    ERROR_CODE_KEY,
+    app_exception_handler,
+    global_exception_handler,
+    http_exception_handler,
+    integrity_error_handler,
+    rate_limit_exception_handler,
+    sqlalchemy_error_handler,
+    validation_exception_handler,
+)
+from app.core.exceptions import AppException, AuthException, ValidationException
+
+
+@pytest.fixture(name="client")
+def fixture_client() -> TestClient:
+    """An app wired with the real handlers and nothing else.
+
+    Deliberately not `app.main:app` -- these tests are about the envelope, and
+    a route that exists only to raise is clearer than hunting for a real
+    endpoint that happens to fail the right way.
+    """
+    app = FastAPI()
+
+    app.add_exception_handler(HTTPException, http_exception_handler)
+    app.add_exception_handler(StarletteHTTPException, http_exception_handler)
+    app.add_exception_handler(RequestValidationError, validation_exception_handler)
+    app.add_exception_handler(RateLimitExceeded, rate_limit_exception_handler)
+    app.add_exception_handler(AppException, app_exception_handler)
+    app.add_exception_handler(IntegrityError, integrity_error_handler)
+    app.add_exception_handler(SQLAlchemyError, sqlalchemy_error_handler)
+    app.add_exception_handler(Exception, global_exception_handler)
+
+    class Payload(BaseModel):
+        name: str = Field(..., min_length=2)
+
+    @app.get("/string-detail")
+    def string_detail():
+        raise HTTPException(status_code=404, detail="Project not found.")
+
+    @app.get("/structured-detail")
+    def structured_detail():
+        # The `code` spelling here is the input contract, and it is what made
+        # the mismatch absurd: the handler reads `code` out and used to write
+        # `error_code` back.
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "PROJECT_FORBIDDEN",
+                "message": "You cannot touch this project.",
+                "details": {"project_id": "abc"},
+            },
+        )
+
+    @app.get("/typed-auth")
+    def typed_auth():
+        raise AuthException(message="Nope.", status_code=401, code="TOKEN_EXPIRED")
+
+    @app.get("/typed-validation")
+    def typed_validation():
+        raise ValidationException(
+            message="Slug is taken.",
+            status_code=422,
+            code="SLUG_TAKEN",
+            details={"field": "slug"},
+        )
+
+    @app.post("/validated")
+    def validated(payload: Payload):
+        return payload
+
+    @app.get("/rate-limited")
+    def rate_limited():
+        raise RateLimitExceeded(_DummyLimit())
+
+    @app.get("/integrity")
+    def integrity():
+        raise IntegrityError("INSERT INTO users ...", {}, _DuplicateEmail())
+
+    @app.get("/db-error")
+    def db_error():
+        raise SQLAlchemyError("connection to server at 10.0.0.4 failed: password auth")
+
+    @app.get("/boom")
+    def boom():
+        raise ValueError("secret internal state: token=abc123")
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class _DummyLimit:
+    """Minimal stand-in for a SlowAPI limit object."""
+
+    error_message = "1 per second"
+    limit = "1 per second"
+
+    def __str__(self) -> str:  # pragma: no cover - only for repr in failures
+        return self.limit
+
+
+class _DuplicateEmail:
+    """Stands in for the psycopg error `IntegrityError` wraps."""
+
+    def __str__(self) -> str:
+        return (
+            'duplicate key value violates unique constraint "ix_users_email"\n'
+            "DETAIL:  Key (email)=(victim@example.com) already exists."
+        )
+
+
+ALL_ERROR_PATHS = [
+    ("/string-detail", 404),
+    ("/structured-detail", 403),
+    ("/typed-auth", 401),
+    ("/typed-validation", 422),
+    ("/rate-limited", 429),
+    ("/integrity", 409),
+    ("/db-error", 500),
+    ("/boom", 500),
+]
+
+
+@pytest.mark.parametrize("path,expected_status", ALL_ERROR_PATHS)
+def test_every_handler_emits_the_canonical_code_key(
+    client: TestClient, path: str, expected_status: int
+) -> None:
+    """`error.code` is present on every path out of the application.
+
+    Parametrised over every registered handler rather than spot-checked,
+    because the previous break was one handler's worth of inconsistency and a
+    spot check is exactly what missed it.
+    """
+    response = client.get(path)
+
+    assert response.status_code == expected_status
+    error = response.json()["error"]
+
+    assert ERROR_CODE_KEY in error, f"{path} has no {ERROR_CODE_KEY!r}"
+    assert isinstance(error[ERROR_CODE_KEY], str)
+    assert error[ERROR_CODE_KEY], f"{path} has an empty code"
+
+
+@pytest.mark.parametrize("path,expected_status", ALL_ERROR_PATHS)
+def test_deprecated_alias_matches_the_canonical_key(
+    client: TestClient, path: str, expected_status: int
+) -> None:
+    """`error_code` still ships, and always agrees with `code`.
+
+    Nothing in this repository reads it, but responses carried it for long
+    enough that something outside might. Two keys that can disagree would be
+    worse than one wrong key, so they are asserted equal rather than merely
+    both present.
+    """
+    error = client.get(path).json()["error"]
+
+    assert DEPRECATED_ERROR_CODE_KEY in error
+    assert error[DEPRECATED_ERROR_CODE_KEY] == error[ERROR_CODE_KEY]
+
+
+@pytest.mark.parametrize("path,expected_status", ALL_ERROR_PATHS)
+def test_envelope_always_carries_message_timestamp_and_request_id(
+    client: TestClient, path: str, expected_status: int
+) -> None:
+    """The rest of the envelope is not optional either."""
+    body = client.get(path).json()
+    error = body["error"]
+
+    assert error["message"]
+    assert error["timestamp"]
+    assert error["request_id"]
+    assert body["detail"] == error["message"], "detail must mirror the human message"
+
+
+def test_structured_detail_code_survives_the_round_trip(client: TestClient) -> None:
+    """What a route writes as `code` is what the caller reads as `code`."""
+    error = client.get("/structured-detail").json()["error"]
+
+    assert error[ERROR_CODE_KEY] == "PROJECT_FORBIDDEN"
+    assert error["message"] == "You cannot touch this project."
+    assert error["details"] == {"project_id": "abc"}
+
+
+def test_string_detail_is_derived_into_a_code(client: TestClient) -> None:
+    """A plain string detail still gets a machine-readable code."""
+    error = client.get("/string-detail").json()["error"]
+
+    assert error[ERROR_CODE_KEY] == "PROJECT_NOT_FOUND"
+
+
+def test_typed_exceptions_keep_their_status_and_code(client: TestClient) -> None:
+    """`AppException` subclasses are no longer flattened into a 500.
+
+    Without a handler these fell through to `global_exception_handler`, so a
+    401 `TOKEN_EXPIRED` reached the client as a 500 `INTERNAL_SERVER_ERROR`
+    and the caller had no way to tell "log in again" from "we are broken".
+    """
+    auth = client.get("/typed-auth")
+    assert auth.status_code == 401
+    assert auth.json()["error"][ERROR_CODE_KEY] == "TOKEN_EXPIRED"
+
+    validation = client.get("/typed-validation")
+    assert validation.status_code == 422
+    body = validation.json()["error"]
+    assert body[ERROR_CODE_KEY] == "SLUG_TAKEN"
+    assert body["details"] == {"field": "slug"}
+
+
+def test_validation_errors_use_the_same_envelope(client: TestClient) -> None:
+    """422s from Pydantic are not a special case."""
+    response = client.post("/validated", json={"name": "x"})
+
+    assert response.status_code == 422
+    error = response.json()["error"]
+    assert error[ERROR_CODE_KEY] == "VALIDATION_ERROR"
+    assert isinstance(error["details"], list)
+    assert error["details"], "validation errors should say which field failed"
+
+
+def test_integrity_error_names_the_field_without_echoing_the_value(
+    client: TestClient,
+) -> None:
+    """A duplicate-key 409 must not read the row back to the caller.
+
+    `details` used to be the raw driver string, which contains both the
+    physical index name and the colliding value. On a signup form that meant
+    replying to "this email is taken" with the email on the existing account.
+    """
+    response = client.get("/integrity")
+    body = response.text
+    error = response.json()["error"]
+
+    assert response.status_code == 409
+    assert error[ERROR_CODE_KEY] == "CONFLICT"
+    assert error["details"] == {"duplicate_field": "email"}
+
+    assert "victim@example.com" not in body
+    assert "ix_users_email" not in body
+    assert "violates unique constraint" not in body
+
+
+def test_database_errors_do_not_leak_the_driver_message(client: TestClient) -> None:
+    """Connection strings and bound parameters stay in the log."""
+    response = client.get("/db-error")
+
+    assert response.status_code == 500
+    assert response.json()["error"][ERROR_CODE_KEY] == "DATABASE_ERROR"
+    assert "10.0.0.4" not in response.text
+    assert "password auth" not in response.text
+
+
+def test_unhandled_errors_do_not_leak_internal_state(client: TestClient) -> None:
+    """The catch-all says nothing about what actually went wrong."""
+    response = client.get("/boom")
+
+    assert response.status_code == 500
+    assert response.json()["error"][ERROR_CODE_KEY] == "INTERNAL_SERVER_ERROR"
+    assert "token=abc123" not in response.text

--- a/backend/tests/test_global_error_handler.py
+++ b/backend/tests/test_global_error_handler.py
@@ -144,6 +144,13 @@ def test_integrity_error_handling_sanitization(client):
 
 
 def test_unhandled_value_error_handling(client):
+    # `add_exception_handler(Exception, ...)` is installed on Starlette's
+    # ServerErrorMiddleware, which builds the response and *then* re-raises so
+    # the server still logs the fault. TestClient surfaces that re-raise unless
+    # it is told not to, so the response is unreachable through the default
+    # client. test_error_responses.py does the same thing for the same reason.
+    client = TestClient(client.app, raise_server_exceptions=False)
+
     response = client.get("/test-error-handler/general-exception")
     assert response.status_code == 500
     data = response.json()

--- a/docs/api_error_envelope.md
+++ b/docs/api_error_envelope.md
@@ -1,0 +1,109 @@
+# API error envelope
+
+Every error response from the backend has the same shape, whatever produced it —
+a route raising `HTTPException`, a Pydantic validation failure, a rate limit, a
+duplicate key, or an unhandled exception.
+
+```json
+{
+  "error": {
+    "code": "PROJECT_NOT_FOUND",
+    "error_code": "PROJECT_NOT_FOUND",
+    "message": "Project not found.",
+    "timestamp": "2026-08-20T15:32:23.934285+00:00",
+    "request_id": "eb13279e-d0b9-48e9-94ef-ea1612da2d11",
+    "details": null
+  },
+  "detail": "Project not found."
+}
+```
+
+## Fields
+
+| Field | Purpose |
+|---|---|
+| `error.code` | **Branch on this.** `UPPER_SNAKE_CASE`, stable across releases. |
+| `error.error_code` | Deprecated alias for `code`, always the same value. See below. |
+| `error.message` | For humans. May be reworded at any time — do not match on it. |
+| `error.timestamp` | UTC, ISO 8601, timezone-aware. |
+| `error.request_id` | Correlates with the server log line. Quote it in bug reports. |
+| `error.details` | Present only when there is something structured to add. Shape depends on `code`. |
+| `detail` | Mirror of `error.message`, for callers written against plain FastAPI. |
+
+## `error_code` is deprecated
+
+The envelope shipped emitting `error_code` while the rest of the codebase — the
+input side of `http_exception_handler`, the docstrings, and the tests — used
+`code`. `code` is the canonical spelling. `error_code` is still sent, carrying
+the identical value, so that anything that started reading it does not break;
+it will be removed in a future release. Read `code`.
+
+## Where `code` comes from
+
+A route can set it explicitly by raising with a structured detail:
+
+```python
+raise HTTPException(
+    status_code=403,
+    detail={
+        "code": "PROJECT_FORBIDDEN",
+        "message": "You cannot touch this project.",
+        "details": {"project_id": str(project.id)},
+    },
+)
+```
+
+Or by raising one of the typed exceptions in `app/core/exceptions.py`, which
+carry their own status code, code and details:
+
+```python
+raise ValidationException(
+    message="That slug is already taken.",
+    code="SLUG_TAKEN",
+    details={"field": "slug"},
+)
+```
+
+If a route raises with a plain string detail, the code is derived from the
+message — `"Project not found."` becomes `PROJECT_NOT_FOUND` — falling back to
+a per-status default (`NOT_FOUND`, `CONFLICT`, …) when the message is empty or
+too long to be a useful identifier. Derived codes are convenient but not
+stable; anything a client needs to branch on should be set explicitly.
+
+## What never appears in an error response
+
+Error bodies are returned to unauthenticated callers, so the handlers keep
+server-side detail out of them:
+
+- database driver messages, which can contain the statement and its bound
+  parameters, and the host it failed to reach;
+- unique-constraint text, which names the physical index **and echoes the
+  value that collided** — a duplicate-email 409 returns
+  `{"duplicate_field": "email"}`, never the address already on the account;
+- exception messages and tracebacks from unhandled errors.
+
+All of that is logged with the `request_id` from the response instead.
+
+## Handlers
+
+Registered in `app/main.py`; Starlette picks the most specific one for the
+exception's MRO, so the order in that file is documentation rather than
+precedence.
+
+| Exception | Handler | Status |
+|---|---|---|
+| `HTTPException` / Starlette `HTTPException` | `http_exception_handler` | as raised |
+| `RequestValidationError` | `validation_exception_handler` | 422 |
+| `RateLimitExceeded` | `rate_limit_exception_handler` | 429 (+ `Retry-After`) |
+| `AppException` and subclasses | `app_exception_handler` | as raised |
+| `IntegrityError` | `integrity_error_handler` | 409 |
+| `SQLAlchemyError` | `sqlalchemy_error_handler` | 500 |
+| anything else | `global_exception_handler` | 500 |
+
+## Tests
+
+- `backend/tests/test_error_envelope.py` — the shape of the envelope itself,
+  parametrised across every handler.
+- `backend/tests/test_error_responses.py` — per-handler codes and messages.
+- `backend/tests/test_global_error_handler.py` — the handlers as wired into the
+  real app.


### PR DESCRIPTION
Fixes #1237.

## The reported bug

`format_error_response` emitted `error_code`; the docstring above it, the input side of the same handler, and every test used `code`.

```python
# error_handlers.py — output
"error_code": code,

# error_handlers.py, 20 lines down — input
code = exc.detail.get("code") or DEFAULT_STATUS_CODES.get(status_code, "ERROR")
```

`code` wins — it is what the rest of the codebase already uses. `error_code` stays as an alias carrying the identical value, because responses have shipped with it long enough that something outside this repo may read it, and swapping one silent break for another is not a fix. Both are named constants (`ERROR_CODE_KEY`, `DEPRECATED_ERROR_CODE_KEY`) so the next rename has to trip over the fact that there are two.

## What else turned up

Writing the tests made it clear the key was the visible half of a larger gap.

**`AppException` had no handler.** `app/core/exceptions.py` defines `AppException`, `AuthException`, `DatabaseException` and `ValidationException`, each carrying its own `status_code`, `code` and `details` — and none of it reached the client. With no registration they fell through to `global_exception_handler` and came back as a flat `500 INTERNAL_SERVER_ERROR`. A `401 TOKEN_EXPIRED` was indistinguishable from "the server is broken". That is almost certainly why nothing in the codebase raises them: they didn't work. Now registered, so the hierarchy is usable.

**Generic `SQLAlchemyError` had no handler.** Only `IntegrityError` did. Everything else — connection failures, operational errors — went out through the catch-all, and the driver's message can contain the statement, its bound parameters, and the host it failed to reach. Now a `500 DATABASE_ERROR` with the real text logged.

**`integrity_error_handler` leaked the row back to the caller.** `details` was the raw driver string:

```
duplicate key value violates unique constraint "ix_users_email"
DETAIL:  Key (email)=(victim@example.com) already exists.
```

That names the physical index and, worse, **echoes the value that collided** — so a signup form hitting a duplicate email replied with the address already on the account. It now returns `{"duplicate_field": "email"}` and logs the rest. This is the one change here with a security flavour; flagging it explicitly rather than burying it in the diff.

Separately, the handlers that were building a payload without setting `detail` now set it, so the FastAPI compatibility mirror is on every path out instead of most.

## Registration order

`IntegrityError` is a subclass of `SQLAlchemyError`, and `AppException` is a subclass of `Exception`, so both new registrations sit "under" existing ones. Starlette resolves handlers by walking the raised exception's MRO and picking the most specific class registered, so the specific ones still win. The block is written most-specific-first anyway and says so in a comment — order is documentation here, not precedence.

## Tests

`backend/tests/test_error_envelope.py` (31 tests) covers the seam that actually broke, rather than more per-handler code assertions:

- `code` present on **every** registered handler's output — parametrised, because the break was one handler's worth of inconsistency and a spot check is what missed it;
- the deprecated alias *equals* `code` rather than merely existing — two keys that can disagree would be worse than one wrong key;
- `message` / `timestamp` / `request_id` always present, and `detail` mirrors `message`;
- a route's `code` survives the round trip unchanged;
- none of the three leak paths above put server-side detail in the body (asserted against the response text, not just the parsed field).

## The one test edit

`test_unhandled_value_error_handling` could never have passed. `add_exception_handler(Exception, ...)` is installed on Starlette's `ServerErrorMiddleware`, which builds the response and then re-raises so the server still logs the fault — so the response is unreachable through a default `TestClient`. Its sibling in `test_error_responses.py` already used `raise_server_exceptions=False` for exactly this; this now does the same, with a comment saying why.

## Docs

`docs/api_error_envelope.md` — the field table, where `code` comes from, the deprecation, what never appears in an error body and why, and the handler table. There was no written spec for this before, which is part of how a rename could half-land.

## Verification

Full backend suite, before and after, comparing the failure sets:

```
before: 96 failing    after: 79 failing
regressions: (none)
fixed:       17
```

The 17 are all of `test_error_responses.py`, `test_global_error_handler.py` and `test_request_validation.py`. The remaining 79 are pre-existing failures in unrelated areas (websockets, RBAC test fixtures, stale org paths) and are untouched by this PR.
