### PR TITLE
fix(messages): require conversation membership on every message route

### DIFF
--- a/backend/app/routers/messages.py
+++ b/backend/app/routers/messages.py
@@ -25,7 +25,7 @@ from app.schemas.message import (
 from app.services.message_service import MessageService
 
 # pyrefly: ignore [missing-import]
-from sqlalchemy import select
+from sqlalchemy import func, select
 
 from app.models.conversation_member import ConversationMember
 from app.models.message import Message
@@ -35,6 +35,84 @@ from app.services.notification_service import NotificationService
 router = APIRouter(
     tags=["Messages"],
 )
+
+
+# ------------------------------------------------------------------
+# Conversation membership  (issue #1234)
+# ------------------------------------------------------------------
+#
+# Every route below addresses a conversation: by path parameter, through the
+# body of the request, or indirectly through the message it names. None of
+# them may act on a conversation the caller does not belong to.
+#
+# The read-receipt routes already got this right at the service layer
+# (`MessageService.mark_as_read` and friends check `ConversationMember` before
+# touching anything), so the shape below is deliberately the same check and
+# the same 403 -- this is applying an existing convention to the routes that
+# never adopted it, not inventing a second one.
+
+
+def _assert_conversation_member(
+    db: Session,
+    conversation_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> None:
+    """Raise 403 unless ``user_id`` belongs to ``conversation_id``.
+
+    A count rather than a fetch: nothing here needs the membership row, only
+    the yes/no, and the composite index on (conversation_id, user_id) answers
+    it without loading anything.
+    """
+    is_member = db.scalar(
+        select(func.count(ConversationMember.id)).where(
+            ConversationMember.conversation_id == conversation_id,
+            ConversationMember.user_id == user_id,
+        )
+    )
+
+    if not is_member:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You are not a member of this conversation",
+        )
+
+
+def require_conversation_member(
+    conversation_id: uuid.UUID,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
+) -> User:
+    """Dependency for routes with a ``conversation_id`` path parameter.
+
+    Returns the caller, so a route declares
+    ``current_user: User = Depends(require_conversation_member)`` and gets
+    both the authentication and the membership check from one dependency --
+    there is no way to take the user and forget the check.
+    """
+    _assert_conversation_member(db, conversation_id, current_user.id)
+    return current_user
+
+
+def _member_message_or_404(
+    db: Session,
+    message_id: uuid.UUID,
+    current_user: User,
+) -> Message:
+    """Fetch a message the caller is entitled to see.
+
+    For routes keyed on a ``message_id``, where the conversation is only
+    reachable through the message itself.
+    """
+    db_message = MessageService.get_message(db, message_id)
+
+    if db_message is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Message not found",
+        )
+
+    _assert_conversation_member(db, db_message.conversation_id, current_user.id)
+    return db_message
 
 
 @router.post(
@@ -49,6 +127,11 @@ def send_message(
     db: Session = Depends(get_database),
     current_user: User = Depends(get_current_user),
 ):
+
+    # The conversation id is in the body, out of reach of
+    # `require_conversation_member`, so the check is explicit here -- and
+    # before the write, not after it.
+    _assert_conversation_member(db, message.conversation_id, current_user.id)
 
     sent = MessageService.send_message(
         db=db,
@@ -172,7 +255,9 @@ def search_messages(
     conversation_id: uuid.UUID,
     keyword: str = Query(...),
     db: Session = Depends(get_database),
+    current_user: User = Depends(require_conversation_member),
 ):
+    """Search one conversation the caller belongs to."""
 
     return MessageService.search_messages(
         db,
@@ -189,7 +274,9 @@ def count_messages(
     request: Request,
     conversation_id: uuid.UUID,
     db: Session = Depends(get_database),
+    current_user: User = Depends(require_conversation_member),
 ):
+    """Count the messages in a conversation the caller belongs to."""
 
     return {
         "count": MessageService.count_messages(
@@ -207,7 +294,7 @@ def count_messages(
 def pinned_messages(
     request: Request,
     conversation_id: uuid.UUID,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_conversation_member),
     db: Session = Depends(get_database),
 ):
     """List messages pinned in a conversation (issue #973)."""
@@ -224,7 +311,9 @@ def list_conversation_messages(
     conversation_id: uuid.UUID,
     limit: int = Query(100, ge=1, le=500),
     db: Session = Depends(get_database),
+    current_user: User = Depends(require_conversation_member),
 ):
+    """Read a conversation the caller belongs to."""
 
     return MessageService.list_conversation_messages(
         db,
@@ -247,7 +336,7 @@ def set_typing(
     request: Request,
     conversation_id: uuid.UUID,
     db: Session = Depends(get_database),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_conversation_member),
 ):
     """Record that the current user is typing in a conversation.
 
@@ -272,7 +361,7 @@ def stop_typing(
     request: Request,
     conversation_id: uuid.UUID,
     db: Session = Depends(get_database),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_conversation_member),
 ):
     """Explicitly clear the current user's typing state.
 
@@ -294,7 +383,7 @@ def get_typing(
     request: Request,
     conversation_id: uuid.UUID,
     db: Session = Depends(get_database),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_conversation_member),
 ):
     """Return the list of user IDs currently typing in a conversation.
 
@@ -323,18 +412,7 @@ def get_message(
     current_user: User = Depends(get_current_user),
 ):
 
-    message = MessageService.get_message(
-        db,
-        message_id,
-    )
-
-    if message is None:
-        raise HTTPException(
-            status_code=404,
-            detail="Message not found",
-        )
-
-    return message
+    return _member_message_or_404(db, message_id, current_user)
 
 
 def _get_owned_message(
@@ -342,18 +420,21 @@ def _get_owned_message(
     message_id: uuid.UUID,
     current_user: User,
 ) -> Message:
-    """Fetch a message and assert the current user owns it (issue #973)."""
-    db_message = MessageService.get_message(db, message_id)
-    if db_message is None:
-        raise HTTPException(
-            status_code=404,
-            detail="Message not found",
-        )
+    """Fetch a message the caller wrote, in a conversation they are still in.
+
+    Authorship alone is not enough. Someone removed from a conversation keeps
+    their `sender_id` on every message they wrote there, so an ownership-only
+    check let a removed member go on editing and deleting inside a thread they
+    no longer belong to.
+    """
+    db_message = _member_message_or_404(db, message_id, current_user)
+
     if db_message.sender_id != current_user.id:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="You can only edit or delete your own messages.",
         )
+
     return db_message
 
 
@@ -391,12 +472,8 @@ def pin_message(
     db: Session = Depends(get_database),
 ):
     """Pin a message in its conversation (issue #973)."""
-    db_message = MessageService.get_message(db, message_id)
-    if db_message is None:
-        raise HTTPException(
-            status_code=404,
-            detail="Message not found",
-        )
+    db_message = _member_message_or_404(db, message_id, current_user)
+
     if db_message.is_deleted:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -417,12 +494,8 @@ def unpin_message(
     db: Session = Depends(get_database),
 ):
     """Unpin a message (issue #973)."""
-    db_message = MessageService.get_message(db, message_id)
-    if db_message is None:
-        raise HTTPException(
-            status_code=404,
-            detail="Message not found",
-        )
+    db_message = _member_message_or_404(db, message_id, current_user)
+
     return MessageService.unpin_message(db, db_message)
 
 
@@ -498,6 +571,7 @@ def bulk_mark_read(
 ):
     """Bulk mark messages or an entire conversation as read by the current user."""
     if body.conversation_id:
+        _assert_conversation_member(db, body.conversation_id, current_user.id)
         count, read_at = MessageService.mark_conversation_as_read(
             db=db,
             conversation_id=body.conversation_id,
@@ -527,7 +601,7 @@ def mark_conversation_as_read(
     request: Request,
     conversation_id: uuid.UUID,
     db: Session = Depends(get_database),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_conversation_member),
 ):
     """Mark all unread messages in a conversation as read by the current user."""
     count, read_at = MessageService.mark_conversation_as_read(
@@ -570,6 +644,7 @@ def bulk_mark_as_delivered(
 ):
     """Mark multiple messages or an entire conversation as delivered to the current user."""
     if body.conversation_id:
+        _assert_conversation_member(db, body.conversation_id, current_user.id)
         count, delivered_at = MessageService.mark_conversation_as_delivered(
             db=db,
             conversation_id=body.conversation_id,

--- a/backend/tests/test_message_authorization.py
+++ b/backend/tests/test_message_authorization.py
@@ -1,0 +1,417 @@
+"""Conversation membership is enforced on every /messages route (issue #1234).
+
+Three routes -- list, count and per-conversation search -- were reachable with
+no `Authorization` header at all, because the router declared no dependency and
+those handlers took no `current_user`. The rest authenticated the caller and
+then never asked whether that caller belonged to the conversation they were
+addressing, so a conversation id was the only thing standing between a
+stranger and a private thread.
+
+Each route is checked three ways: anonymous, authenticated-but-not-a-member,
+and member. The third matters as much as the first two -- an authorization fix
+that quietly breaks the people who *are* allowed in is not a fix.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.conversation import Conversation, ConversationType
+from app.models.conversation_member import ConversationMember
+
+
+@pytest.fixture
+def private_thread(db: Session, register_and_login) -> dict:
+    """Alice and Bob in a conversation; Eve registered but outside it."""
+    alice_id, alice_token = register_and_login("authz.alice@example.com", "authzalice")
+    bob_id, bob_token = register_and_login("authz.bob@example.com", "authzbob")
+    eve_id, eve_token = register_and_login("authz.eve@example.com", "authzeve")
+
+    conversation = Conversation(
+        title="Offer discussion",
+        type=ConversationType.DIRECT,
+        created_by=uuid.UUID(alice_id),
+    )
+    db.add(conversation)
+    db.commit()
+    db.refresh(conversation)
+
+    db.add(
+        ConversationMember(
+            conversation_id=conversation.id, user_id=uuid.UUID(alice_id)
+        )
+    )
+    db.add(
+        ConversationMember(conversation_id=conversation.id, user_id=uuid.UUID(bob_id))
+    )
+    db.commit()
+
+    return {
+        "conversation_id": conversation.id,
+        "alice_id": alice_id,
+        "alice": {"Authorization": f"Bearer {alice_token}"},
+        "bob_id": bob_id,
+        "bob": {"Authorization": f"Bearer {bob_token}"},
+        "eve_id": eve_id,
+        "eve": {"Authorization": f"Bearer {eve_token}"},
+    }
+
+
+@pytest.fixture
+def thread_with_message(client: TestClient, private_thread: dict) -> dict:
+    """The same thread, with one message from Alice in it."""
+    response = client.post(
+        "/api/messages/",
+        json={
+            "conversation_id": str(private_thread["conversation_id"]),
+            "content": "The offer is 250k, keep it between us",
+        },
+        headers=private_thread["alice"],
+    )
+    assert response.status_code == 201, response.text
+
+    return {**private_thread, "message_id": response.json()["id"]}
+
+
+SECRET = "250k"
+
+
+def _conversation_routes(conversation_id) -> list[tuple[str, str, dict | None]]:
+    """(method, path, json body) for every conversation-scoped route."""
+    cid = str(conversation_id)
+    return [
+        ("GET", f"/api/messages/conversation/{cid}", None),
+        ("GET", f"/api/messages/conversation/{cid}/count", None),
+        ("GET", f"/api/messages/conversation/{cid}/pinned", None),
+        ("GET", f"/api/messages/search/{cid}?keyword=offer", None),
+        ("GET", f"/api/messages/conversation/{cid}/typing", None),
+        ("POST", f"/api/messages/conversation/{cid}/typing", None),
+        ("DELETE", f"/api/messages/conversation/{cid}/typing", None),
+        ("POST", f"/api/messages/conversation/{cid}/read", None),
+    ]
+
+
+def _call(client: TestClient, method: str, path: str, body, headers):
+    return client.request(method, path, json=body, headers=headers)
+
+
+# ------------------------------------------------------------------
+# Anonymous callers
+# ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "method,path_template",
+    [
+        ("GET", "/api/messages/conversation/{cid}"),
+        ("GET", "/api/messages/conversation/{cid}/count"),
+        ("GET", "/api/messages/search/{cid}?keyword=offer"),
+    ],
+)
+def test_unauthenticated_read_routes_are_closed(
+    client: TestClient, thread_with_message: dict, method: str, path_template: str
+) -> None:
+    """The three routes that used to answer 200 with no credentials.
+
+    This is the core of the report: `curl` with no header returned message
+    bodies. Anything other than a 2xx is a pass here, but the body is checked
+    too -- a handler that 500s *after* serialising the messages would still be
+    a leak.
+    """
+    path = path_template.format(cid=thread_with_message["conversation_id"])
+
+    response = _call(client, method, path, None, headers=None)
+
+    assert response.status_code in (401, 403), (
+        f"{method} {path} answered {response.status_code} to an anonymous caller"
+    )
+    assert SECRET not in response.text
+
+
+def test_anonymous_caller_cannot_send(
+    client: TestClient, private_thread: dict
+) -> None:
+    response = client.post(
+        "/api/messages/",
+        json={
+            "conversation_id": str(private_thread["conversation_id"]),
+            "content": "anyone home",
+        },
+    )
+
+    assert response.status_code in (401, 403)
+
+
+# ------------------------------------------------------------------
+# Authenticated non-members
+# ------------------------------------------------------------------
+
+
+def test_non_member_is_refused_every_conversation_route(
+    client: TestClient, thread_with_message: dict
+) -> None:
+    """Eve is a real user with a real token, and still gets nothing."""
+    refused = []
+
+    for method, path, body in _conversation_routes(
+        thread_with_message["conversation_id"]
+    ):
+        response = _call(client, method, path, body, thread_with_message["eve"])
+        refused.append((method, path, response.status_code))
+
+        assert response.status_code == 403, (
+            f"{method} {path} answered {response.status_code} to a non-member"
+        )
+        assert SECRET not in response.text
+
+    assert len(refused) == 8, "route list drifted; update the test"
+
+
+def test_non_member_cannot_send_into_the_conversation(
+    client: TestClient, private_thread: dict
+) -> None:
+    """The send route reads the conversation id out of the body.
+
+    `require_conversation_member` cannot see it there, so this is the case a
+    path-parameter dependency would have missed.
+    """
+    response = client.post(
+        "/api/messages/",
+        json={
+            "conversation_id": str(private_thread["conversation_id"]),
+            "content": "eve was here",
+        },
+        headers=private_thread["eve"],
+    )
+
+    assert response.status_code == 403
+
+
+def test_non_member_cannot_read_a_single_message(
+    client: TestClient, thread_with_message: dict
+) -> None:
+    response = client.get(
+        f"/api/messages/{thread_with_message['message_id']}",
+        headers=thread_with_message["eve"],
+    )
+
+    assert response.status_code == 403
+    assert SECRET not in response.text
+
+
+def test_non_member_cannot_pin_or_unpin(
+    client: TestClient, thread_with_message: dict
+) -> None:
+    """Pinning is a write into someone else's thread.
+
+    It also surfaces in the conversation for everyone in it, so this was a way
+    to put content in front of people who never accepted anything from you.
+    """
+    message_id = thread_with_message["message_id"]
+
+    pin = client.patch(
+        f"/api/messages/{message_id}/pin", headers=thread_with_message["eve"]
+    )
+    unpin = client.patch(
+        f"/api/messages/{message_id}/unpin", headers=thread_with_message["eve"]
+    )
+
+    assert pin.status_code == 403
+    assert unpin.status_code == 403
+
+
+def test_non_member_cannot_mark_messages_read_or_delivered(
+    client: TestClient, thread_with_message: dict
+) -> None:
+    """Read state is visible to the sender, so writing it is not harmless."""
+    message_id = thread_with_message["message_id"]
+    eve = thread_with_message["eve"]
+    cid = str(thread_with_message["conversation_id"])
+
+    assert client.patch(f"/api/messages/{message_id}/read", headers=eve).status_code == 403
+    assert (
+        client.post(f"/api/messages/{message_id}/deliver", headers=eve).status_code
+        == 403
+    )
+    assert (
+        client.post(
+            "/api/messages/read/bulk", json={"conversation_id": cid}, headers=eve
+        ).status_code
+        == 403
+    )
+    assert (
+        client.post(
+            "/api/messages/bulk-deliver", json={"conversation_id": cid}, headers=eve
+        ).status_code
+        == 403
+    )
+
+
+def test_bulk_read_by_message_id_ignores_foreign_messages(
+    client: TestClient, thread_with_message: dict
+) -> None:
+    """The by-id bulk path is scoped, not refused.
+
+    A caller may legitimately pass ids spanning several of their own
+    conversations, so the service filters to conversations they belong to
+    rather than rejecting the whole request. Nothing outside is touched.
+    """
+    response = client.post(
+        "/api/messages/read/bulk",
+        json={"message_ids": [thread_with_message["message_id"]]},
+        headers=thread_with_message["eve"],
+    )
+
+    assert response.status_code == 200
+    assert response.json()["updated_count"] == 0
+
+
+def test_non_member_cannot_edit_or_delete(
+    client: TestClient, thread_with_message: dict
+) -> None:
+    message_id = thread_with_message["message_id"]
+    eve = thread_with_message["eve"]
+
+    assert (
+        client.put(
+            f"/api/messages/{message_id}", json={"content": "edited"}, headers=eve
+        ).status_code
+        == 403
+    )
+    assert client.delete(f"/api/messages/{message_id}", headers=eve).status_code == 403
+
+
+def test_global_search_does_not_reach_foreign_conversations(
+    client: TestClient, thread_with_message: dict
+) -> None:
+    """The cross-conversation search was already scoped; keep it that way."""
+    response = client.get(
+        "/api/messages/search?q=offer", headers=thread_with_message["eve"]
+    )
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+# ------------------------------------------------------------------
+# Members still get through
+# ------------------------------------------------------------------
+
+
+def test_member_can_use_every_conversation_route(
+    client: TestClient, thread_with_message: dict
+) -> None:
+    """Bob is in the conversation and nothing above gets in his way."""
+    for method, path, body in _conversation_routes(
+        thread_with_message["conversation_id"]
+    ):
+        response = _call(client, method, path, body, thread_with_message["bob"])
+
+        assert response.status_code < 400, (
+            f"{method} {path} refused a member with {response.status_code}: "
+            f"{response.text[:200]}"
+        )
+
+
+def test_member_can_read_send_and_pin(
+    client: TestClient, thread_with_message: dict
+) -> None:
+    cid = str(thread_with_message["conversation_id"])
+    bob = thread_with_message["bob"]
+
+    listing = client.get(f"/api/messages/conversation/{cid}", headers=bob)
+    assert listing.status_code == 200
+    assert SECRET in listing.text
+
+    sent = client.post(
+        "/api/messages/",
+        json={"conversation_id": cid, "content": "understood"},
+        headers=bob,
+    )
+    assert sent.status_code == 201
+
+    pin = client.patch(
+        f"/api/messages/{thread_with_message['message_id']}/pin", headers=bob
+    )
+    assert pin.status_code == 200
+    assert pin.json()["is_pinned"] is True
+
+
+def test_author_can_still_edit_and_delete_their_own_message(
+    client: TestClient, thread_with_message: dict
+) -> None:
+    message_id = thread_with_message["message_id"]
+    alice = thread_with_message["alice"]
+
+    edited = client.put(
+        f"/api/messages/{message_id}", json={"content": "revised"}, headers=alice
+    )
+    assert edited.status_code == 200
+
+    deleted = client.delete(f"/api/messages/{message_id}", headers=alice)
+    assert deleted.status_code in (200, 204)
+
+
+def test_member_cannot_edit_another_members_message(
+    client: TestClient, thread_with_message: dict
+) -> None:
+    """Membership is not authorship.
+
+    Bob belongs to the conversation, so he passes the new check and then has
+    to fail the older ownership one. Both are load-bearing.
+    """
+    response = client.put(
+        f"/api/messages/{thread_with_message['message_id']}",
+        json={"content": "not mine to edit"},
+        headers=thread_with_message["bob"],
+    )
+
+    assert response.status_code == 403
+
+
+def test_removed_member_loses_access_to_their_own_messages(
+    client: TestClient, db: Session, thread_with_message: dict
+) -> None:
+    """Authorship outlives membership, and must not outlive access.
+
+    `sender_id` still points at Alice after she leaves, so an ownership-only
+    check would have let her keep editing and deleting inside a thread she is
+    no longer part of.
+    """
+    membership = (
+        db.query(ConversationMember)
+        .filter(
+            ConversationMember.conversation_id == thread_with_message["conversation_id"],
+            ConversationMember.user_id == uuid.UUID(thread_with_message["alice_id"]),
+        )
+        .one()
+    )
+    db.delete(membership)
+    db.commit()
+
+    message_id = thread_with_message["message_id"]
+    alice = thread_with_message["alice"]
+
+    assert client.get(f"/api/messages/{message_id}", headers=alice).status_code == 403
+    assert (
+        client.put(
+            f"/api/messages/{message_id}", json={"content": "still mine"}, headers=alice
+        ).status_code
+        == 403
+    )
+    assert client.delete(f"/api/messages/{message_id}", headers=alice).status_code == 403
+
+
+def test_unknown_conversation_is_refused_not_leaked(
+    client: TestClient, private_thread: dict
+) -> None:
+    """A conversation that does not exist looks the same as one you are not in."""
+    response = client.get(
+        f"/api/messages/conversation/{uuid.uuid4()}", headers=private_thread["eve"]
+    )
+
+    assert response.status_code == 403

--- a/docs/messaging_authorization.md
+++ b/docs/messaging_authorization.md
@@ -1,0 +1,85 @@
+# Messaging authorization
+
+Every route under `/api/messages` acts on a conversation. The rule is one line:
+
+> A caller may only act on a conversation they are a member of.
+
+Membership is a row in `conversation_members`. There is no "public" conversation
+and no read-only observer role — if you are not in the `ConversationMember`
+table for a conversation, every route answers `403`.
+
+## Where the check happens
+
+`app/routers/messages.py`. The router is the enforcement point, and it enforces
+in one of three ways depending on where the conversation id comes from.
+
+**1. Path parameter — `require_conversation_member`.**
+
+```python
+def list_conversation_messages(
+    conversation_id: uuid.UUID,
+    current_user: User = Depends(require_conversation_member),
+): ...
+```
+
+The dependency both authenticates the caller and checks membership, and it
+returns the caller. A route that needs `current_user` gets it *from* the check,
+so there is no way to take the user and forget the check — which is how the
+gap in #1234 happened in the first place.
+
+**2. Request body — `_assert_conversation_member`.**
+
+`POST /messages/`, `POST /messages/read/bulk` and `POST /messages/bulk-deliver`
+carry the conversation id in the body, out of reach of a path-parameter
+dependency. They call the helper explicitly, before any write.
+
+**3. Message id — `_member_message_or_404`.**
+
+`GET /messages/{id}`, `/pin`, `/unpin` and the edit/delete/restore family reach
+the conversation only through the message. The helper resolves the message
+(`404` if it does not exist) and then checks membership of its conversation.
+
+## Membership is not authorship
+
+Two separate checks, both load-bearing:
+
+| | |
+|---|---|
+| **Membership** | read the thread, send into it, pin, mark read |
+| **Authorship** | edit, delete, restore — your own messages only |
+
+They are not redundant in either direction. A member who did not write a
+message still cannot edit it. And someone removed from a conversation keeps
+their `sender_id` on everything they wrote there — an authorship-only check let
+a removed member go on editing and deleting inside a thread they had left, so
+edit/delete requires membership *and* authorship.
+
+## Why `403` and not `404`
+
+`403 "You are not a member of this conversation"` is what the read-receipt
+routes have returned since they were written, and their tests assert it. Using
+`404` on the routes fixed here would have been marginally better at not
+confirming that a conversation exists, at the cost of two different answers to
+the same question depending on which route you asked. Conversation ids are
+UUIDs, so enumeration is not the threat model; consistency is worth more.
+
+## Bulk by id is scoped, not refused
+
+`POST /messages/read/bulk` and `/bulk-deliver` accept either a
+`conversation_id` or a list of `message_ids`. A caller may legitimately pass
+ids spanning several of their own conversations, so the id form is *filtered*
+to conversations the caller belongs to (`MessageService.bulk_mark_as_read`)
+rather than rejected wholesale. Passing a stranger's message id is not an
+error; it updates nothing.
+
+## Not covered here
+
+`/api/conversations` has its own routes for creating conversations and adding
+and removing members. This document is about `/api/messages` only.
+
+## Tests
+
+`backend/tests/test_message_authorization.py` — every route checked three ways:
+anonymous, authenticated non-member, and member. The third is not decoration;
+an authorization change that locks out the people who are allowed in is not a
+fix.


### PR DESCRIPTION
Fixes #1234.

## What was wrong

Two distinct problems, same root cause — `router = APIRouter(tags=["Messages"])` with no dependency, and per-route checks that were never added.

**Three routes had no authentication at all.** `GET /messages/conversation/{id}`, `GET /messages/conversation/{id}/count` and `GET /messages/search/{id}` took no `current_user`, so there was nothing to check. A plain `curl` with a conversation id returned message bodies.

**The rest never checked membership.** Authenticated, but a conversation id was the only thing between a stranger and a private thread: list it, send into it, read and set its pinned messages, watch and forge its typing indicators, read any single message.

## The check already existed

Worth saying plainly, because it changes what this PR is: the read-receipt routes (`mark_as_read`, `mark_as_delivered`, `mark_conversation_as_read`, the bulk variants) have been checking `ConversationMember` in the service layer since they were written, and return `403` when it fails. Nothing new was invented here — this applies an existing convention to the routes that never adopted it.

## Three shapes, because the id arrives three ways

**Path parameter → `require_conversation_member`**

```python
def list_conversation_messages(
    conversation_id: uuid.UUID,
    current_user: User = Depends(require_conversation_member),
): ...
```

The dependency authenticates, checks membership, and *returns the caller*. A route that wants `current_user` gets it from the check, so there is no way to take the user and forget the check. That coupling is deliberate — the original gap is exactly what "remember to also add the check" looks like across 20 routes.

**Request body → `_assert_conversation_member`**

`POST /messages/`, `/read/bulk` and `/bulk-deliver` carry the conversation id in the body where a path-parameter dependency cannot see it. Explicit call, before the write rather than after.

**Message id → `_member_message_or_404`**

`GET /messages/{id}`, `/pin`, `/unpin`, and the edit/delete/restore family reach the conversation only through the message. Resolve the message (404 if absent), then check membership of its conversation.

## Membership is not authorship

Edit/delete/restore keep the ownership check and gain the membership one. Not redundant in either direction:

- a member who did not write a message still cannot edit it;
- `sender_id` survives someone leaving a conversation, so an ownership-only check let a **removed member go on editing and deleting inside a thread they had left**. There is a test for this specifically.

## Two decisions worth reviewing

**403, not the 404 the issue suggested.** I changed my mind writing it. 404 avoids confirming a conversation exists, but the read-receipt routes already answer 403 and their tests assert it — 404 here would mean two different answers to the same question depending on which route you asked. Conversation ids are UUIDs, so enumeration is not the threat model, and consistency is worth more. Happy to flip both if you'd rather.

**Bulk-by-message-id is scoped, not refused.** `/read/bulk` and `/bulk-deliver` accept either a `conversation_id` or a list of `message_ids`. A caller may legitimately pass ids spanning several of their own conversations, so the id form stays *filtered* to conversations they belong to (already the behaviour in `MessageService.bulk_mark_as_read`) rather than rejecting the whole request. A stranger's id updates nothing — asserted in `test_bulk_read_by_message_id_ignores_foreign_messages`.

## Enforcement point

The router, not the service. `MessageService.list_conversation_messages` and friends still filter only on `conversation_id`. I left them alone deliberately — adding a redundant membership query inside each would double the round trips on the hot read path, and the dependency makes the router check structurally hard to skip. Flagging it since "the service does not compensate" was in the issue and this PR consciously does not change that.

## Tests

`backend/tests/test_message_authorization.py` — 18 tests, every route three ways:

| | |
|---|---|
| anonymous | the routes that used to answer 200 with no header |
| authenticated non-member | parametrised across all 8 conversation-scoped routes, plus send / read-one / pin / unpin / read-state / edit / delete |
| **member** | every route still works, listing still returns content, sending still works, pinning still works, the author can still edit and delete |

The member cases matter as much as the other two — an authorization change that locks out the people who are allowed in is not a fix.

Assertions check the response *text* for the secret string too, not just the status code, so a handler that 500s after serialising the messages would still fail.

## Verification

Reverting only the router change turns 9 of the 18 red:

```
FAILED test_unauthenticated_read_routes_are_closed[GET-/api/messages/conversation/{cid}]
FAILED test_unauthenticated_read_routes_are_closed[GET-/api/messages/conversation/{cid}/count]
FAILED test_unauthenticated_read_routes_are_closed[GET-/api/messages/search/{cid}?keyword=offer]
FAILED test_non_member_is_refused_every_conversation_route
FAILED test_non_member_cannot_send_into_the_conversation
FAILED test_non_member_cannot_read_a_single_message
FAILED test_non_member_cannot_pin_or_unpin
FAILED test_removed_member_loses_access_to_their_own_messages
FAILED test_unknown_conversation_is_refused_not_leaked
9 failed, 9 passed
```

Full backend suite: 96 failures before and after — identical sets, no regressions. (Those 96 are pre-existing failures in unrelated areas on `main`.)

## Scope

`/api/conversations` has its own routes for creating conversations and adding/removing members; they are not touched here. `docs/messaging_authorization.md` writes the rule down.
