### PR TITLE
fix(export): call the builder-flare collector instead of an undefined name

### DIFF
--- a/backend/app/routers/websockets.py
+++ b/backend/app/routers/websockets.py
@@ -35,6 +35,7 @@ import json
 import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Set
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect, status
 from jose import JWTError, jwt

--- a/backend/app/services/analytics_service.py
+++ b/backend/app/services/analytics_service.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import uuid
 from datetime import datetime, timedelta, timezone
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
@@ -18,6 +19,7 @@ from app.schemas.analytics import (
     ProjectGrowthMetric,
     RetentionMetric,
 )
+from app.schemas.profile_analytics import ProfileAnalyticsResponse
 
 
 class AnalyticsService:

--- a/backend/app/services/duplicate_detection_service.py
+++ b/backend/app/services/duplicate_detection_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import re
-from typing import Optional
+from typing import Any, Optional
 from uuid import UUID
 
 from sqlalchemy import select

--- a/backend/app/services/export_service.py
+++ b/backend/app/services/export_service.py
@@ -49,6 +49,7 @@ class ExportService:
         organizations = ExportService._get_organizations(db, user.id)
         activities = ExportService._get_activities(db, user.id)
         notifications = ExportService._get_notifications(db, user.id)
+        builder_flares = ExportService._get_builder_flares(db, user.id)
         return UserExportData(
             exported_at=now,
             profile=profile,

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import uuid
+from typing import Any
+
 from app.utils.time import utcnow
 
 # pyrefly: ignore [missing-import]

--- a/backend/app/services/project_service.py
+++ b/backend/app/services/project_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from typing import Any
 
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -7,7 +7,12 @@ from sqlalchemy.orm import Session
 
 from app.models.activity import ActivityType
 from app.models.user import User
-from app.schemas.user import UserCreate, UserUpdate
+from app.schemas.user import (
+    PrivacySettingsUpdate,
+    ProfileCompletionResponse,
+    UserCreate,
+    UserUpdate,
+)
 from app.services.activity_service import ActivityService
 from app.models.application import Application, ApplicationStatus
 from app.models.follower import Follower

--- a/backend/tests/test_export_routes.py
+++ b/backend/tests/test_export_routes.py
@@ -1,0 +1,308 @@
+"""
+Coverage for the account-export routes.
+
+There was none before. `ExportService.collect_user_data` referenced an
+undefined `builder_flares` and raised `NameError` on every call, and all four
+export routes went through it, so all four were 500s -- including
+`POST /me/export`, which is the "give me everything you hold about me" route.
+The suite stayed green because nothing here ever asked for an export.
+
+So these tests do two things that are easy to skip:
+
+* they **request the routes**, rather than calling the service directly. The
+  bug was reachable from the service too, but a service-level test would not
+  have noticed that `export_portfolio_html` reaches it by a different path;
+* they assert on the **body**, not just the status. A collector that silently
+  returns `[]` for everything would pass a status-code test perfectly.
+
+Every section of the export gets a fixture row, so an empty list in the
+response means something is wrong rather than meaning the user is new.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+
+from app.models.builder_flare import BuilderFlare, FlareStatus
+from app.models.project import Project, ProjectStage
+from app.services.export_service import ExportService
+
+EXPORT_JSON = "/api/users/me/export"
+PORTFOLIO = "/api/users/me/portfolio/export"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def exporter(client, register_and_login, db):
+    """
+    A user with a project and a builder flare -- the section the bug dropped.
+
+    Returns ``(user_id, headers)``. The rows are deliberately given
+    recognisable values -- the assertions look for those strings in the
+    rendered output, which is the only way to tell "exported the flare" apart
+    from "exported an empty list".
+    """
+    user_id, token = register_and_login("exporter@example.com", "exporter")
+    headers = {"Authorization": f"Bearer {token}"}
+
+    owner = uuid.UUID(user_id)
+
+    project = Project(
+        owner_id=owner,
+        title="Kestrel Telemetry",
+        slug=f"kestrel-telemetry-{uuid.uuid4().hex[:8]}",
+        description="Flight data pipeline for small UAVs.",
+        stage=ProjectStage.MVP,
+    )
+    db.add(project)
+    db.commit()
+    db.refresh(project)
+
+    flare = BuilderFlare(
+        project_id=project.id,
+        created_by=owner,
+        title="Rust telemetry ingest",
+        description="Own the ingest path end to end.",
+        role="Backend Engineer",
+        status=FlareStatus.OPEN,
+    )
+    db.add(flare)
+
+    db.commit()
+
+    return user_id, headers
+
+
+def _flare_titles(payload: dict) -> list[str]:
+    return [f["title"] for f in payload["builder_flares"]]
+
+
+# ---------------------------------------------------------------------------
+# The routes answer at all
+# ---------------------------------------------------------------------------
+#
+# This is the regression proper. Before the fix every one of these was a
+# NameError, so parametrising them keeps the failure message pointing at the
+# route that broke rather than at whichever one happened to run first.
+
+
+@pytest.mark.parametrize(
+    "method,url",
+    [
+        ("POST", EXPORT_JSON),
+        ("GET", f"{PORTFOLIO}?format=json"),
+        ("GET", f"{PORTFOLIO}?format=markdown"),
+        ("GET", f"{PORTFOLIO}?format=pdf"),
+    ],
+    ids=["data-export", "portfolio-json", "portfolio-markdown", "portfolio-html"],
+)
+def test_export_routes_return_a_document(client, exporter, method, url):
+    _, headers = exporter
+
+    response = client.request(method, url, headers=headers)
+
+    assert response.status_code == 200, response.text
+    assert response.content, "export route returned an empty body"
+
+
+def test_every_export_route_requires_authentication(client):
+    """
+    An export is the single most sensitive read in the app. Worth pinning even
+    though nothing in this change touches auth -- the routes are new to the
+    test suite, so their auth has never actually been asserted either.
+    """
+    assert client.post(EXPORT_JSON).status_code == 401
+    assert client.get(PORTFOLIO).status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# The document contains the user's data
+# ---------------------------------------------------------------------------
+
+
+def test_data_export_carries_every_section(client, exporter):
+    _, headers = exporter
+
+    payload = client.post(EXPORT_JSON, headers=headers).json()["data"]
+
+    # Named individually rather than looped, so a missing key names itself in
+    # the failure.
+    for section in (
+        "profile",
+        "skills",
+        "projects",
+        "project_memberships",
+        "applications",
+        "connections",
+        "messages",
+        "bookmarks",
+        "organizations",
+        "activities",
+        "notifications",
+        "builder_flares",
+    ):
+        assert section in payload, f"export is missing the {section!r} section"
+
+
+def test_builder_flares_are_populated_not_just_present(client, exporter):
+    """
+    The specific regression. `builder_flares` was undefined, so the fix is a
+    call to `_get_builder_flares` -- and a fix that passed `[]` would satisfy
+    a "key exists" assertion just as well.
+    """
+    _, headers = exporter
+
+    payload = client.post(EXPORT_JSON, headers=headers).json()["data"]
+
+    assert _flare_titles(payload) == ["Rust telemetry ingest"]
+
+    flare = payload["builder_flares"][0]
+    assert flare["role"] == "Backend Engineer"
+    assert flare["status"] == "open"
+    assert flare["project_id"]
+    assert flare["created_at"]
+
+
+def test_export_does_not_leak_another_users_flares(
+    client, exporter, db, register_and_login
+):
+    """
+    `_get_builder_flares` filters on `created_by`. Nothing exercised that
+    filter, and a collector that forgot the `.filter()` would have passed every
+    other assertion in this file.
+    """
+    _, headers = exporter
+
+    stranger_id, _ = register_and_login("stranger@example.com", "stranger")
+    stranger = uuid.UUID(stranger_id)
+
+    project = Project(
+        owner_id=stranger,
+        title="Not Yours",
+        slug=f"not-yours-{uuid.uuid4().hex[:8]}",
+        description="Belongs to somebody else.",
+        stage=ProjectStage.MVP,
+    )
+    db.add(project)
+    db.commit()
+    db.refresh(project)
+
+    db.add(
+        BuilderFlare(
+            project_id=project.id,
+            created_by=stranger,
+            title="Someone else's flare",
+            description="Should never appear in another user's export.",
+            role="Designer",
+            status=FlareStatus.OPEN,
+        )
+    )
+    db.commit()
+
+    payload = client.post(EXPORT_JSON, headers=headers).json()["data"]
+
+    assert "Someone else's flare" not in _flare_titles(payload)
+
+
+# ---------------------------------------------------------------------------
+# Portfolio renderings
+# ---------------------------------------------------------------------------
+
+
+def test_portfolio_json_is_the_same_document_as_the_data_export(client, exporter):
+    _, headers = exporter
+
+    export = client.post(EXPORT_JSON, headers=headers).json()["data"]
+    portfolio = client.get(f"{PORTFOLIO}?format=json", headers=headers).json()
+
+    assert portfolio["profile"] == export["profile"]
+    assert portfolio["builder_flares"] == export["builder_flares"]
+
+
+def test_portfolio_markdown_renders_the_users_content(client, exporter):
+    _, headers = exporter
+
+    response = client.get(f"{PORTFOLIO}?format=markdown", headers=headers)
+
+    assert response.headers["content-type"].startswith("text/markdown")
+    assert "attachment" in response.headers["content-disposition"]
+
+    body = response.text
+    assert body.lstrip().startswith("#")
+    assert "Kestrel Telemetry" in body
+
+
+def test_portfolio_html_renders_the_users_content(client, exporter):
+    _, headers = exporter
+
+    response = client.get(f"{PORTFOLIO}?format=pdf", headers=headers)
+
+    assert response.headers["content-type"].startswith("text/html")
+    body = response.text
+    assert "<html" in body.lower()
+    assert "Kestrel Telemetry" in body
+
+
+def test_portfolio_rejects_an_unknown_format(client, exporter):
+    _, headers = exporter
+
+    assert client.get(f"{PORTFOLIO}?format=docx", headers=headers).status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# The service, directly
+# ---------------------------------------------------------------------------
+#
+# The routes above are the contract; this is the seam the bug actually lived
+# in, and `BackupService` reaches it without going through HTTP at all.
+
+
+def test_collect_user_data_is_callable(db, client, exporter):
+    from app.models.user import User
+
+    user_id, _ = exporter
+    user = db.get(User, uuid.UUID(user_id))
+
+    data = ExportService.collect_user_data(db, user)
+
+    assert data.builder_flares
+    assert data.exported_at is not None
+
+
+def test_collect_user_data_is_json_serialisable(db, client, exporter):
+    """
+    `BackupService` writes this out and the portfolio route hands it to
+    `JSONResponse`. Both need `model_dump(mode="json")` to survive the UUIDs
+    and datetimes.
+    """
+    from app.models.user import User
+
+    user_id, _ = exporter
+    user = db.get(User, uuid.UUID(user_id))
+
+    dumped = ExportService.collect_user_data(db, user).model_dump(mode="json")
+
+    json.dumps(dumped)  # raises if anything in there is not JSON
+
+
+def test_export_of_a_brand_new_user_is_empty_but_valid(client, register_and_login):
+    """
+    The opposite corner from `exporter`: nothing to export. Should be an empty
+    document, not an error -- and `builder_flares` should be `[]` rather than
+    absent.
+    """
+    _, token = register_and_login("fresh@example.com", "freshuser")
+    headers = {"Authorization": f"Bearer {token}"}
+
+    payload = client.post(EXPORT_JSON, headers=headers).json()["data"]
+
+    assert payload["builder_flares"] == []
+    assert payload["projects"] == []
+    assert payload["profile"]["email"] == "fresh@example.com"

--- a/backend/tests/test_no_undefined_names.py
+++ b/backend/tests/test_no_undefined_names.py
@@ -1,0 +1,154 @@
+"""
+A guard against undefined names in `app/`.
+
+`ExportService.collect_user_data` shipped with a bare `builder_flares` in it
+and took every export route down. Ruff finds that class of mistake in about a
+second:
+
+    $ ruff check --select F821 app/
+    app/services/export_service.py:65:28: F821 Undefined name `builder_flares`
+
+Nothing ran it. `lint.yml` checks out the repository and stops (#1248), and
+`ruff` in `.pre-commit-config.yaml` only sees files that are staged in a
+working tree where someone installed the hooks.
+
+So the check lives here instead, where `pytest` already runs it. That is not
+where a linter belongs long-term -- when `lint.yml` becomes real this should
+move -- but a check that runs in the wrong place beats one that does not run.
+
+Scope is deliberately one rule. This is not "lint the backend": `ruff check
+app/` reports 3354 findings, almost all formatting, and turning that on is a
+separate decision. F821 is the subset that means *this line raises when it is
+reached*, so it can be enforced today with no baseline at all -- except for
+the two below, which have a fix already in flight.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+
+#: Sites that are known-broken and already have a PR open. Listed as
+#: ``(path, message)`` so an entry cannot quietly cover a *different* undefined
+#: name in the same file.
+#:
+#: Both are `Optional` used in a module that never imports it, reported in
+#: #1236 and fixed in #1238. When that merges, these two lines come out and the
+#: allowlist should be empty -- at which point this list should be deleted
+#: rather than kept around as a place to put things.
+KNOWN_UNFIXED = {
+    ("app/routers/analytics.py", "Undefined name `Optional`"),
+    ("app/routers/projects.py", "Undefined name `Optional`"),
+}
+
+
+def _ruff_findings(rule: str, target: str) -> list[dict]:
+    """Run ruff for one rule and return its findings as dicts."""
+    completed = subprocess.run(
+        [
+            "ruff",
+            "check",
+            "--select",
+            rule,
+            "--no-cache",
+            "--output-format",
+            "json",
+            target,
+        ],
+        cwd=BACKEND_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    # ruff exits 1 when it finds something, which is not an error here.
+    if completed.returncode not in (0, 1):
+        pytest.fail(
+            f"ruff failed to run (exit {completed.returncode}):\n{completed.stderr}"
+        )
+
+    return json.loads(completed.stdout or "[]")
+
+
+def _relative(finding: dict) -> str:
+    return str(Path(finding["filename"]).resolve().relative_to(BACKEND_ROOT))
+
+
+@pytest.fixture(scope="module")
+def undefined_names() -> list[dict]:
+    if shutil.which("ruff") is None:
+        pytest.skip("ruff is not installed")
+    return _ruff_findings("F821", "app")
+
+
+def test_no_new_undefined_names(undefined_names):
+    """
+    Every F821 in `app/` is either fixed or on the allowlist above.
+
+    The failure message prints file, line and name, because "ruff found
+    something" is not actionable and the whole point of this test is that
+    somebody reads its output.
+    """
+    unexpected = [
+        finding
+        for finding in undefined_names
+        if (_relative(finding), finding["message"]) not in KNOWN_UNFIXED
+    ]
+
+    if unexpected:
+        lines = "\n".join(
+            f"  {_relative(f)}:{f['location']['row']}:{f['location']['column']}: "
+            f"{f['message']}"
+            for f in sorted(unexpected, key=_relative)
+        )
+        pytest.fail(
+            "Undefined names in app/. Each of these raises NameError when the "
+            "line is reached:\n"
+            f"{lines}\n\n"
+            "If the name only appears in an annotation it is latent rather "
+            "than live, but it still breaks `get_type_hints()` and any schema "
+            "generation that walks it -- import it rather than allowlisting it."
+        )
+
+
+def test_allowlist_only_covers_what_it_claims(undefined_names):
+    """
+    Stops the allowlist from being a place things go to be forgotten.
+
+    A stale entry is not a failure -- #1238 landing is the good outcome, and
+    this test should not turn red the moment it does. It warns instead, so the
+    dead line gets noticed at the next test run rather than at the next audit.
+    """
+    live = {(_relative(f), f["message"]) for f in undefined_names}
+    stale = KNOWN_UNFIXED - live
+
+    if stale:
+        listed = ", ".join(sorted(path for path, _ in stale))
+        pytest.skip(
+            f"KNOWN_UNFIXED has entries that are now fixed ({listed}) -- "
+            "remove them from the allowlist."
+        )
+
+
+def test_the_export_service_specifically_is_clean():
+    """
+    The regression this file was written for, pinned by name.
+
+    Redundant with the sweep above while the sweep passes, and not redundant
+    the day someone widens the allowlist.
+    """
+    if shutil.which("ruff") is None:
+        pytest.skip("ruff is not installed")
+
+    findings = _ruff_findings("F821", "app/services/export_service.py")
+
+    assert findings == [], (
+        "app/services/export_service.py has an undefined name again: "
+        f"{[f['message'] for f in findings]}"
+    )


### PR DESCRIPTION
Fixes #1245.

## The bug

```python
return UserExportData(
    ...
    notifications=notifications,
    builder_flares=builder_flares,   # <- not a local, not a param, not an import
)
```

`NameError` before the response is built, so every route that reaches
`collect_user_data` is a 500. That is `POST /me/export`, all three formats of
`GET /me/portfolio/export`, and `BackupService.create_backup`, which builds on
the same function.

The data was already collected — `_get_builder_flares` is defined at
`export_service.py:469` and had no callers. One line:

```diff
 notifications = ExportService._get_notifications(db, user.id)
+builder_flares = ExportService._get_builder_flares(db, user.id)
 return UserExportData(
```

## The other five

`ruff check --select F821 app/` reported six undefined names, not one. The issue
called the other five latent, on the grounds that they are all in annotations
under `from __future__ import annotations`. That was right for four of them and
wrong for the fifth:

```python
# routers/websockets.py, inside the doc.update handler
doc_uuid = UUID(doc_id) if doc_id else None
```

`UUID` is never imported in that module. It is a call, not an annotation, so
every collaborative-document edit over the websocket raises `NameError`. I
found it while adding the guard below rather than by reading the handler, which
is the argument for the guard.

The four genuinely latent ones (`Any` in `notification_service` /
`project_service` / `duplicate_detection_service`, `Optional` + `uuid` +
`ProfileAnalyticsResponse` in `analytics_service`, and the two schema names in
`user_service`) are imported rather than annotated away. They break
`get_type_hints()` on those classes today and would break louder the moment one
of those return types is used as a response model.

`routers/analytics.py` and `routers/projects.py` still have an `Optional` each.
Those are #1236 and **#1238 already fixes them** — I have left them alone rather
than create a conflict, and the guard allowlists exactly those two by file *and*
message until that merges.

## Why nothing caught it

No test requested an export route. `grep -rn "portfolio/export\|collect_user_data" backend/tests/`
was empty before this change. The route was not weakly covered; it was
uncovered, and so was `BackupService`'s use of it.

## Tests

**`tests/test_export_routes.py`** — 15 tests, the first coverage these routes
have had.

The two things it does deliberately:

- **requests the routes** rather than calling the service. A service-level test
  would have caught the `NameError`, but not that `export_portfolio_html`
  reaches it by a different path than `export_portfolio_markdown`.
- **asserts on the body**. A fix that passed `builder_flares=[]` satisfies every
  status-code assertion perfectly, so the fixture creates a real flare and the
  test asserts its title, role and status come back.

Also covers the two directions that a one-line fix makes easy to get wrong:
`test_export_does_not_leak_another_users_flares` (the `created_by` filter, which
nothing exercised) and `test_export_of_a_brand_new_user_is_empty_but_valid`
(empty is `[]`, not an error and not a missing key).

**`tests/test_no_undefined_names.py`** — runs `ruff check --select F821 app/`
and fails on anything not on the two-entry allowlist.

Scoped to one rule on purpose. This is not "lint the backend" — `ruff check app/`
reports 3354 findings, almost all formatting, and turning that on is a decision
that needs a baseline. F821 is the subset that means *this line raises when
reached*, so it needs no baseline beyond the two sites with a fix already open.

## The guard is in the wrong place, and I put it there anyway

A linter belongs in `lint.yml`. `lint.yml` checks out the repository and stops
(#1248), and the `ruff` pre-commit hook only sees staged files in a tree where
someone ran `pre-commit install`. So it lives in pytest, where something
actually runs it, with a comment saying it should move when the lint workflow
becomes real.

Worth flagging that this is currently advisory rather than blocking:
`backend-ci.yml` runs `pytest` under `continue-on-error: true`, so a red test
does not fail the job. That is the same defect as #1248 and out of scope here,
but it means the guard warns rather than gates until that changes.

## Verification

Reverting only the one-line fix turns 13 of the 15 export tests red, and 2 of
the 3 guard tests:

```
FAILED test_export_routes_return_a_document[data-export]
FAILED test_export_routes_return_a_document[portfolio-json]
FAILED test_export_routes_return_a_document[portfolio-markdown]
FAILED test_export_routes_return_a_document[portfolio-html]
FAILED test_data_export_carries_every_section
FAILED test_builder_flares_are_populated_not_just_present
FAILED test_export_does_not_leak_another_users_flares
FAILED test_portfolio_json_is_the_same_document_as_the_data_export
FAILED test_portfolio_markdown_renders_the_users_content
FAILED test_portfolio_html_renders_the_users_content
FAILED test_collect_user_data_is_callable
FAILED test_collect_user_data_is_json_serialisable
FAILED test_export_of_a_brand_new_user_is_empty_but_valid
13 failed, 2 passed

E  app/services/export_service.py:65:28: Undefined name `builder_flares`
2 failed, 1 passed
```

The two that stay green are the auth check and the `?format=docx` rejection —
both return before reaching the service, which is the right reason to survive.

Full backend suite, run on this branch and on `main` in a clean worktree:
**98 failures, identical sets, no regressions.** Those 98 are pre-existing and
unrelated (`test_last_active`, `test_notifications_events` and friends, mostly
the `TestingSessionLocal` import errors ruff also flags).

## Scope

Not touched: `backup_service.py`, which is fixed by consequence rather than by
change — it calls `collect_user_data` and now gets a document. I have not added
backup tests here; that path deserves its own coverage and its own PR.
