### PR TITLE
fix(routing): stop mounting routers under a prefix they already declare

### DIFF
--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -93,9 +93,6 @@ api_v1_router.include_router(
     builder_flares.router, prefix="/flare", tags=["Builder's Flare"]
 )
 api_v1_router.include_router(messages.router, prefix="/messages", tags=["Messages"])
-api_v1_router.include_router(
-    organizations.router, prefix="/organizations", tags=["Organizations"]
-)
 api_v1_router.include_router(org_audit_logs.router)
 api_v1_router.include_router(webhooks.router)
 api_v1_router.include_router(
@@ -112,13 +109,11 @@ api_v1_router.include_router(
     profile_summary.router, prefix="/profile-summary", tags=["Profile Summary"]
 )
 api_v1_router.include_router(
-    profile_suggestions.router,
-    prefix="/profile-suggestions",
-    tags=["Profile Suggestions"],
+    profile_suggestions.router, tags=["Profile Suggestions"]
 )
 api_v1_router.include_router(
     profile_suggestions.router,
-    prefix="/users/me/profile-suggestions",
+    prefix="/users/me",
     tags=["Profile Suggestions"],
 )
 api_v1_router.include_router(
@@ -136,7 +131,7 @@ api_v1_router.include_router(
 )
 api_v1_router.include_router(repositories.router)
 api_v1_router.include_router(project_releases.router)
-api_v1_router.include_router(organizations.router)
+api_v1_router.include_router(organizations.router, tags=["Organizations"])
 api_v1_router.include_router(applications.router)
 api_v1_router.include_router(skills.router)
 api_v1_router.include_router(testimonials.router)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -530,9 +530,6 @@ from app.routers import project_milestones
 app.include_router(
     project_milestones.router, prefix="/api", tags=["Project Milestones"]
 )
-app.include_router(
-    project_milestones.router, prefix="/api", tags=["Project Milestones"]
-)
 from app.routers import project_time_logs
 
 app.include_router(
@@ -558,25 +555,20 @@ app.include_router(
 )
 
 app.include_router(followers.router, prefix="/api/followers", tags=["Followers"])
-app.include_router(bookmarks.router, prefix="/api/bookmarks", tags=["Bookmarks"])
+app.include_router(bookmarks.router, prefix="/api", tags=["Bookmarks"])
 app.include_router(
     bookmark_collections.router,
-    prefix="/api/bookmark-collections",
+    prefix="/api",
     tags=["Bookmark Collections"],
 )
 app.include_router(activities.router, prefix="/api/activities", tags=["Activities"])
 from app.routers import activity_heatmap
 
 app.include_router(activity_heatmap.router, prefix="/api", tags=["Activity Heatmap"])
-app.include_router(
-    conversations.router, prefix="/api/conversations", tags=["Conversations"]
-)
+app.include_router(conversations.router, prefix="/api", tags=["Conversations"])
 from app.routers import moderation
 
 app.include_router(moderation.router, prefix="/api", tags=["Moderation"])
-app.include_router(
-    conversations.router, prefix="/api/conversations", tags=["Conversations"]
-)
 from app.routers import audit
 
 app.include_router(audit.router, prefix="/api", tags=["Audit"])
@@ -596,12 +588,12 @@ from app.routers import profile_suggestions
 
 app.include_router(
     profile_suggestions.router,
-    prefix="/api/profile-suggestions",
+    prefix="/api",
     tags=["Profile Suggestions"],
 )
 app.include_router(
     profile_suggestions.router,
-    prefix="/api/users/me/profile-suggestions",
+    prefix="/api/users/me",
     tags=["Profile Suggestions"],
 )
 from app.routers import profile_views
@@ -621,12 +613,8 @@ app.include_router(
     prefix="/api/contributor-matching",
     tags=["Contributor Matching"],
 )
-app.include_router(
-    repositories.router, prefix="/api/repositories", tags=["Repositories"]
-)
-app.include_router(
-    organizations.router, prefix="/api/organizations", tags=["Organizations"]
-)
+app.include_router(repositories.router, prefix="/api", tags=["Repositories"])
+app.include_router(organizations.router, prefix="/api", tags=["Organizations"])
 
 from app.routers import workspace_api_tokens
 
@@ -637,25 +625,21 @@ app.include_router(
 app.include_router(
     applications.router, prefix="/api/applications", tags=["Applications"]
 )
-app.include_router(skills.router, prefix="/api/skills", tags=["Skills"])
+app.include_router(skills.router, prefix="/api", tags=["Skills"])
 # users.router already included above
-app.include_router(websockets.router, prefix="/api/ws", tags=["WebSockets"])
+app.include_router(websockets.router, prefix="/api", tags=["WebSockets"])
 app.include_router(graph.router, prefix="/api", tags=["Graph"])
 from app.routers import webhooks
 
 app.include_router(webhooks.router, prefix="/api", tags=["Webhooks"])
-app.include_router(
-    recommendations.router, prefix="/api/recommendations", tags=["Recommendations"]
-)
+app.include_router(recommendations.router, prefix="/api", tags=["Recommendations"])
 app.include_router(
     repository_quality.router, prefix="/api", tags=["Repository Quality"]
 )
-app.include_router(health.router, prefix="/api/health", tags=["Health"])
+app.include_router(health.router, prefix="/api", tags=["Health"])
 app.include_router(maintenance.router, prefix="/api", tags=["Maintenance"])
 app.include_router(search.router, prefix="/api/search", tags=["Search"])
-app.include_router(
-    saved_searches.router, prefix="/api/saved-searches", tags=["Saved Searches"]
-)
+app.include_router(saved_searches.router, prefix="/api", tags=["Saved Searches"])
 app.include_router(hackathons.router, prefix="/api/hackathons", tags=["Hackathons"])
 app.include_router(
     notification_templates.router, prefix="/api", tags=["Notification Templates"]
@@ -671,10 +655,6 @@ from app.routers import project_templates
 app.include_router(
     project_templates.router, prefix="/api", tags=["Project Templates Marketplace"]
 )
-
-from app.routers import background_jobs
-
-app.include_router(background_jobs.router, prefix="/api")
 
 from app.routers import badges
 

--- a/backend/app/routers/saved_searches.py
+++ b/backend/app/routers/saved_searches.py
@@ -18,7 +18,7 @@ from app.services.saved_search_service import (
 )
 
 router = APIRouter(
-    prefix="/api/saved-searches",
+    prefix="/saved-searches",
     tags=["Saved Searches"],
 )
 

--- a/backend/tests/test_route_paths.py
+++ b/backend/tests/test_route_paths.py
@@ -1,0 +1,320 @@
+"""
+Structural assertions about the URLs this app serves.
+
+Nothing checked route *paths* before. 4822 tests, and a router could be mounted
+at any URL at all without one of them noticing -- which is how eleven routers
+ended up served at `/api/bookmarks/bookmarks`, `/api/conversations/conversations`
+and so on, while the paths everyone writes down returned 404.
+
+The mistake is a mechanical one. A router that declares its own prefix
+
+    router = APIRouter(prefix="/bookmarks")
+
+and is then mounted under a prefix that repeats the segment
+
+    app.include_router(bookmarks.router, prefix="/api/bookmarks")
+
+gets both. There is nothing to notice at either site; you have to read the two
+together. So the check is mechanical too, rather than a list of known-good
+paths -- a list would need updating by exactly the person who just made this
+mistake.
+"""
+
+from __future__ import annotations
+
+from itertools import pairwise
+
+import pytest
+
+from app.main import app
+
+#: Paths that repeat a segment on purpose.
+#:
+#: `project_tags.get_predefined_tags` carries a second `@router.get` at
+#: `/project-tags/predefined` with `include_in_schema=False`, as a compatibility
+#: alias for callers that hardcoded the doubled form. Deliberate, hidden, and
+#: documented at the decorator -- so it is listed here rather than being swept
+#: up by a blanket "ignore hidden routes" rule, which would also hide the next
+#: accident.
+DELIBERATE_ALIASES = frozenset(
+    {
+        "/api/project-tags/project-tags/predefined",
+        "/api/v1/project-tags/project-tags/predefined",
+    }
+)
+
+#: A floor, not a target. The walker below reads FastAPI internals, and the
+#: failure mode that matters is it silently returning almost nothing after a
+#: version bump -- at which point every assertion in this file passes
+#: vacuously. Asking for a plausible count turns that into a visible failure.
+MINIMUM_EXPECTED_ROUTES = 500
+
+
+def _effective_paths(routes, prefix: str = "") -> list[str]:
+    """
+    Every path the app actually serves, fully qualified.
+
+    Not as simple as reading `route.path`. FastAPI does not flatten
+    `include_router` into `app.routes`; it leaves an `_IncludedRouter` holding
+    the mount prefix, and the child routes already carry their own router's
+    prefix in `path`. So the mount prefix is added and the child's router
+    prefix is *not* -- adding both is the same doubling this file is about.
+    """
+    found: list[str] = []
+
+    for route in routes:
+        context = getattr(route, "include_context", None)
+        if context is not None:
+            inner = getattr(route, "original_router", None) or context.included_router
+            found += _effective_paths(inner.routes, prefix + (context.prefix or ""))
+            continue
+
+        path = getattr(route, "path", None)
+        if path is None:
+            continue
+
+        # A Mount (e.g. /uploads) carries child routes and no endpoint.
+        is_mount = (
+            getattr(route, "routes", None) is not None
+            and not hasattr(route, "methods")
+            and not hasattr(route, "endpoint")
+        )
+        if is_mount:
+            found += _effective_paths(route.routes, prefix + path)
+        else:
+            found.append(prefix + path)
+
+    return found
+
+
+@pytest.fixture(scope="module")
+def paths() -> list[str]:
+    return sorted(set(_effective_paths(app.routes)))
+
+
+def _repeated_segment(path: str) -> str | None:
+    """The first segment that immediately repeats itself, if any."""
+    segments = [s for s in path.split("/") if s]
+    for current, following in pairwise(segments):
+        if current == following:
+            return current
+    return None
+
+
+# ---------------------------------------------------------------------------
+# The walker itself
+# ---------------------------------------------------------------------------
+
+
+def test_the_walker_finds_a_plausible_number_of_routes(paths):
+    """
+    Guards every other test in this file.
+
+    An earlier draft of `_effective_paths` returned 7 paths because it did not
+    understand `_IncludedRouter`, and every assertion below passed. A check
+    that cannot see the thing it checks is worse than no check.
+    """
+    assert len(paths) >= MINIMUM_EXPECTED_ROUTES, (
+        f"only {len(paths)} routes found, expected at least "
+        f"{MINIMUM_EXPECTED_ROUTES}. _effective_paths() has probably stopped "
+        "understanding how FastAPI stores included routers -- fix the walker "
+        "rather than lowering this number."
+    )
+
+
+# ---------------------------------------------------------------------------
+# No doubled segments
+# ---------------------------------------------------------------------------
+
+
+def test_no_path_repeats_a_segment(paths):
+    offenders = {
+        path: _repeated_segment(path)
+        for path in paths
+        if _repeated_segment(path) and path not in DELIBERATE_ALIASES
+    }
+
+    if offenders:
+        listed = "\n".join(
+            f"  {path}   (segment {segment!r} appears twice)"
+            for path, segment in sorted(offenders.items())
+        )
+        pytest.fail(
+            "Routes with a repeated path segment:\n"
+            f"{listed}\n\n"
+            "This is almost always a router that declares its own prefix being "
+            "mounted under a prefix that repeats it. Drop the prefix= from the "
+            "include_router call and let the router's own prefix stand."
+        )
+
+
+def test_no_v1_path_contains_a_second_api_segment(paths):
+    """
+    `saved_searches` hardcoded `/api/saved-searches` as its *own* prefix, which
+    gave `/api/v1/api/saved-searches` under v1. A router's prefix is relative to
+    wherever it is mounted; it should never name the mount.
+    """
+    offenders = [
+        p for p in paths if p.startswith("/api/v1/") and "/api/" in p[len("/api/v1") :]
+    ]
+
+    assert offenders == [], (
+        "Versioned paths with a nested /api/ segment: "
+        f"{offenders}. A router's prefix must not include the mount point."
+    )
+
+
+def test_deliberate_aliases_still_exist(paths):
+    """
+    Keeps `DELIBERATE_ALIASES` from becoming a graveyard.
+
+    If the compatibility alias is removed, this entry should go too -- otherwise
+    the next genuinely doubled path at that URL passes silently.
+    """
+    stale = DELIBERATE_ALIASES - set(paths)
+    if stale:
+        pytest.skip(
+            f"DELIBERATE_ALIASES lists paths that no longer exist ({sorted(stale)}) "
+            "-- remove them."
+        )
+
+
+# ---------------------------------------------------------------------------
+# The specific paths this change restores
+# ---------------------------------------------------------------------------
+#
+# The mechanical check above is the part that keeps working. These are the
+# eleven from the issue, named so a failure says which router regressed rather
+# than "some path repeats a segment".
+
+
+AFFECTED_ROUTERS = [
+    ("bookmarks", "/api/bookmarks/"),
+    ("bookmark_collections", "/api/bookmark-collections/"),
+    ("conversations", "/api/conversations/"),
+    ("profile_suggestions", "/api/profile-suggestions/"),
+    ("repositories", "/api/repositories/"),
+    ("organizations", "/api/organizations/"),
+    ("skills", "/api/skills/"),
+    ("recommendations", "/api/recommendations/builders"),
+    ("health", "/api/health/ready"),
+    ("saved_searches", "/api/saved-searches/"),
+]
+
+
+@pytest.mark.parametrize(
+    "router,path", AFFECTED_ROUTERS, ids=[r for r, _ in AFFECTED_ROUTERS]
+)
+def test_router_is_served_at_the_undoubled_path(paths, router, path):
+    assert path in paths, f"{router} is not served at {path}"
+
+
+@pytest.mark.parametrize(
+    "router,path", AFFECTED_ROUTERS, ids=[r for r, _ in AFFECTED_ROUTERS]
+)
+def test_the_doubled_path_is_gone(paths, router, path):
+    """
+    The other half. Leaving both live would mean two URLs for one resource and
+    two sets of cache keys, logs and rate-limit buckets.
+    """
+    segment = path.strip("/").split("/")[1]
+    doubled = path.replace(f"/{segment}/", f"/{segment}/{segment}/", 1)
+    assert doubled not in paths, f"{router} is still also served at {doubled}"
+
+
+def test_websockets_are_reachable_without_the_doubled_segment(paths):
+    """
+    `/api/ws/ws/presence` is the one where nobody would have guessed the URL,
+    and a websocket that cannot be connected to fails quietly on the client.
+    """
+    assert "/api/ws/presence" in paths
+    assert "/api/ws/ws/presence" not in paths
+
+
+# ---------------------------------------------------------------------------
+# Duplicate mounts
+# ---------------------------------------------------------------------------
+
+
+def test_no_router_is_mounted_twice_at_the_same_prefix(paths):
+    """
+    `conversations` was included twice with byte-identical arguments, six lines
+    apart, and `organizations` and `profile_suggestions` were each included
+    twice under v1 -- once doubled, once not. Harmless to serve and confusing
+    to read: the second registration is dead, so editing it changes nothing.
+
+    Deduplicating `paths` cannot see this, so count the mounts directly.
+    """
+    seen: dict[tuple[int, str], int] = {}
+
+    def count(routes, prefix=""):
+        for route in routes:
+            context = getattr(route, "include_context", None)
+            if context is None:
+                continue
+            inner = getattr(route, "original_router", None) or context.included_router
+            key = (id(inner), prefix + (context.prefix or ""))
+            seen[key] = seen.get(key, 0) + 1
+            count(inner.routes, prefix + (context.prefix or ""))
+
+    count(app.routes)
+
+    duplicates = sorted(mount for (_, mount), n in seen.items() if n > 1)
+    assert duplicates == [], f"routers mounted more than once at: {duplicates}"
+
+
+# ---------------------------------------------------------------------------
+# End to end
+# ---------------------------------------------------------------------------
+
+
+def test_the_restored_paths_actually_answer(client, register_and_login):
+    """
+    Path registration is not the same as a working route. Asserting on
+    `app.routes` alone would pass if every one of these 500'd.
+    """
+    _, token = register_and_login("paths@example.com", "pathsuser")
+    headers = {"Authorization": f"Bearer {token}"}
+
+    for path in (
+        "/api/bookmarks/",
+        "/api/bookmark-collections/",
+        "/api/conversations/",
+        "/api/organizations/",
+        "/api/skills/",
+    ):
+        response = client.get(path, headers=headers)
+        assert response.status_code == 200, (
+            f"{path} -> {response.status_code} {response.text[:200]}"
+        )
+
+
+def test_the_doubled_paths_stop_serving_the_collection(client, register_and_login):
+    """
+    Not asserted as a flat 404. `/api/bookmarks/bookmarks/` now falls through to
+    `/api/bookmarks/{bookmark_id}` and answers 422 because "bookmarks" is not a
+    UUID -- which is the routing table behaving correctly. What matters is that
+    it no longer returns the collection.
+    """
+    _, token = register_and_login("gone@example.com", "goneuser")
+    headers = {"Authorization": f"Bearer {token}"}
+
+    for path in (
+        "/api/bookmarks/bookmarks/",
+        "/api/conversations/conversations/",
+        "/api/organizations/organizations/",
+        "/api/skills/skills/",
+    ):
+        status = client.get(path, headers=headers).status_code
+        assert status != 200, f"{path} still serves a collection"
+
+
+def test_health_is_reachable_at_the_documented_path(client):
+    """
+    `/api/health/ready` is what a load balancer or `kubectl` probe would be
+    pointed at. It was `/api/health/health/ready`.
+    """
+    response = client.get("/api/health/ready")
+
+    assert response.status_code in (200, 503), response.text
+    assert "services" in response.json()

--- a/docs/routing_prefixes.md
+++ b/docs/routing_prefixes.md
@@ -1,0 +1,74 @@
+# Router prefixes
+
+One rule, because getting it wrong is silent:
+
+> **A router owns its prefix. A mount owns the surface it is mounted on.**
+
+```python
+# app/routers/bookmarks.py
+router = APIRouter(prefix="/bookmarks", tags=["Bookmarks"])
+
+# app/main.py            -> /api/bookmarks/...
+app.include_router(bookmarks.router, prefix="/api", tags=["Bookmarks"])
+
+# app/api/v1/router.py   -> /api/v1/bookmarks/...
+api_v1_router.include_router(bookmarks.router)
+```
+
+The router says *what* the resource is called. The mount says *where* that
+resource is exposed — `/api` for the legacy surface, `/api/v1` for the
+versioned one. Neither repeats the other's half.
+
+## What goes wrong
+
+Both prefixes are applied, so a repeated segment produces a real, reachable,
+wrong URL rather than an error:
+
+```python
+router = APIRouter(prefix="/bookmarks")                       # says "bookmarks"
+app.include_router(bookmarks.router, prefix="/api/bookmarks") # says it again
+#                                     -> /api/bookmarks/bookmarks/...
+```
+
+FastAPI is right to allow this — nesting prefixes is how `/projects/{id}/milestones`
+is built — so nothing warns. Eleven routers were mounted this way and the
+documented paths returned 404 for as long as it took someone to check
+(#1246).
+
+Two shapes to watch for:
+
+**A mount that repeats the router's own segment.** The example above. Drop the
+segment from the mount, not from the router — the router's prefix is what makes
+the same file mountable on both surfaces.
+
+**A router prefix that names the mount.** `saved_searches` declared
+`prefix="/api/saved-searches"`, which gave `/api/saved-searches/api/saved-searches`
+on the legacy surface and `/api/v1/api/saved-searches` under v1. A router prefix
+is relative to wherever it is mounted and must never contain `/api`.
+
+## Mounting the same router twice
+
+Legitimate when the two mounts are genuinely different paths:
+
+```python
+app.include_router(profile_suggestions.router, prefix="/api")
+app.include_router(profile_suggestions.router, prefix="/api/users/me")
+```
+
+Not legitimate when they are the same. `conversations`, `project_milestones`
+and `background_jobs` were each included twice with identical arguments. The
+second registration is dead — it serves nothing new, and editing it changes
+nothing, which is the actual cost.
+
+## The check
+
+`backend/tests/test_route_paths.py` walks every route the app serves and fails
+on any path with an immediately repeated segment, any `/api/v1/` path with a
+nested `/api/`, and any router mounted twice at the same prefix.
+
+It is mechanical on purpose. A list of known-good paths would have to be
+updated by whoever just made the mistake, which is the one person guaranteed
+not to.
+
+Deliberate exceptions go in `DELIBERATE_ALIASES` with a comment saying why —
+there is currently one, a hidden compatibility alias in `project_tags`.


### PR DESCRIPTION
Fixes #1246.

## The bug

Two prefixes, both applied:

```python
# app/routers/bookmarks.py
router = APIRouter(prefix="/bookmarks")

# app/main.py
app.include_router(bookmarks.router, prefix="/api/bookmarks")
#                                    -> /api/bookmarks/bookmarks/...
```

Neither line is wrong on its own, which is why this survived eleven times. You
have to read them together, and they are in different files.

```
GET /api/bookmarks         -> 404   |  /api/bookmarks/bookmarks         -> 200
GET /api/conversations     -> 404   |  /api/conversations/conversations -> 200
GET /api/organizations     -> 404   |  /api/organizations/organizations -> 200
GET /api/skills            -> 404   |  /api/skills/skills               -> 200
```

`docs/api_versioning_and_migration.md` says unversioned `/api` routes map to
the current stable version. For these eleven they did not map to anything you
could find.

## The fix

Mounts under `/api` carry only `/api`, and each router's own prefix supplies
the segment — which is what `api/v1/router.py` already does for most of its
includes. The router file is the one that should name the resource, because it
is the file that gets mounted on two surfaces.

```diff
-app.include_router(bookmarks.router, prefix="/api/bookmarks", tags=["Bookmarks"])
+app.include_router(bookmarks.router, prefix="/api", tags=["Bookmarks"])
```

Eleven of those. Two things needed more than that:

**`saved_searches` had the mount in its own prefix.**

```diff
 router = APIRouter(
-    prefix="/api/saved-searches",
+    prefix="/saved-searches",
```

`/api` in a router's prefix is wrong on both surfaces — it gave
`/api/saved-searches/api/saved-searches` on the legacy mount and
`/api/v1/api/saved-searches` under v1. This is the one place a route moved
under `/api/v1` as well.

**Three routers were included twice.** `conversations` (`main.py`, six lines
apart, byte-identical), `project_milestones` (adjacent, byte-identical) and
`background_jobs` (`main.py`, fifteen lines apart, with the import repeated
too). Under v1, `organizations` and `profile_suggestions` were each included
twice — once doubled, once not. The dead registrations are removed.

`organizations` needed a moment's care: the doubled v1 include was the one
carrying `tags=["Organizations"]`, so the tag moves onto the bare include
that survives rather than being dropped with it.

## `/api/ws/ws/presence`

Worth pulling out. The websocket router was mounted at `/api/ws` with its own
`/ws`, so the socket endpoints were at `/api/ws/ws/presence` and
`/api/ws/ws/collab`. A websocket that cannot be connected to does not 404
visibly; the client just never gets a connection. There is a test for this one
specifically.

## Tests

`backend/tests/test_route_paths.py` — 29 tests. The first thing in this repo
that asserts anything about a route's *path*.

The core of it is mechanical rather than a list of known-good URLs:

- no path has an immediately repeated segment
- no `/api/v1/` path contains a nested `/api/`
- no router is mounted twice at the same prefix

A list would work today and would have to be updated by whoever next makes
this mistake, which is the one person guaranteed not to think of it.

On top of that, the eleven from the issue are named individually — both
directions, `test_router_is_served_at_the_undoubled_path` and
`test_the_doubled_path_is_gone` — so a failure says which router regressed
rather than "some path repeats a segment". And `test_the_restored_paths_actually_answer`
requests them over HTTP, because a route being registered is not the same as a
route that works.

## One test guards the others

`test_the_walker_finds_a_plausible_number_of_routes`.

FastAPI does not flatten `include_router` into `app.routes` — it leaves an
`_IncludedRouter` holding the mount prefix, and the child routes already carry
their own router's prefix in `path`. My first walker did not know that and
returned **7 paths**. Every assertion in the file passed.

So the walker asserts it found at least 500 routes before anything else runs.
Without it this file is one FastAPI upgrade away from being a green tick that
checks nothing, which is the failure mode I am trying to remove from this
repository, not add to it.

## Decisions worth reviewing

**The doubled paths are gone, not deprecated.** They 404 now (or 422, where
`/api/bookmarks/bookmarks/` falls through to `/api/bookmarks/{bookmark_id}` and
"bookmarks" is not a UUID — the test asserts "not 200" rather than a specific
code for that reason).

I went back and forth. The argument for a deprecation shim is that removing a
live URL is a break. The argument against, which won: these URLs are not
documented anywhere, no test requests them, and the frontend does not call them
— it calls `/bookmarks/` and `/recommendations/...` relative to
`VITE_API_BASE_URL`, which `docs/environment-setup.md` sets to `/api/v1`. So
the population of callers is plausibly empty, and keeping both live means two
URLs per resource, two sets of cache keys, two rate-limit buckets and two
things to grep for. Happy to add aliases if you would rather not assume that.

**`project_tags` keeps its doubled path.** `/project-tags/predefined` is a
second `@router.get` with `include_in_schema=False` — a deliberate hidden alias
for callers that hardcoded the old form. It is in `DELIBERATE_ALIASES` by exact
path rather than covered by a blanket "skip hidden routes" rule, which would
also hide the next accident.

## Verification

Against unfixed `app/`, 26 of the 29 tests fail:

```
FAILED test_no_path_repeats_a_segment
FAILED test_no_v1_path_contains_a_second_api_segment
FAILED test_router_is_served_at_the_undoubled_path[bookmarks]
... 8 more routers ...
FAILED test_the_doubled_path_is_gone[bookmarks]
... 8 more routers ...
FAILED test_websockets_are_reachable_without_the_doubled_segment
FAILED test_no_router_is_mounted_twice_at_the_same_prefix
FAILED test_the_restored_paths_actually_answer
FAILED test_health_is_reachable_at_the_documented_path
26 failed, 3 passed
```

The three that stay green are the walker sanity check, the alias check and one
parametrised case — all correctly independent of the fix.

Full backend suite, this branch and `main` in a clean worktree: **98 failures,
identical sets, no regressions.** Nothing was relying on a doubled path, which
is the one thing I most wanted to confirm before deleting them.

## Docs

`docs/routing_prefixes.md` writes the rule down, including the two shapes that
go wrong and the legitimate case for mounting one router twice
(`profile_suggestions` at `/api` and `/api/users/me`, which is a real pair of
paths and stays).
