### PR TITLE
fix(notifications): honour every stored preference, not four of seventeen

### DIFF
--- a/backend/app/services/notifications/dispatcher.py
+++ b/backend/app/services/notifications/dispatcher.py
@@ -14,6 +14,10 @@ from app.services.notifications.channels.base import NotificationChannel
 from app.services.notifications.channels.database_channel import DatabaseChannel
 from app.services.notifications.channels.email_channel import EmailChannel
 from app.services.notifications.channels.websocket_channel import WebSocketChannel
+from app.services.notifications.preferences import (
+    should_deliver,
+    should_deliver_by_email,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -40,30 +44,42 @@ class NotificationDispatcher:
         return prefs
 
     def _should_send_channel(
-        self, channel_name: str, prefs: NotificationPreference
+        self,
+        channel_name: str,
+        prefs: NotificationPreference,
+        n_type: NotificationType,
     ) -> bool:
+        """
+        Whether this channel carries this notification.
+
+        Two gates for email, not one. `email_enabled` is the master switch; the
+        per-category `email_<category>` columns are the ones the settings page
+        actually shows, and nothing read them before -- so "email me about
+        mentions but not messages" was on or off for everything.
+        """
         if channel_name == "database" and not prefs.database_enabled:
-            return False
-        if channel_name == "email" and not prefs.email_enabled:
             return False
         if channel_name == "websocket" and not prefs.websocket_enabled:
             return False
+        if channel_name == "email":
+            if not prefs.email_enabled:
+                return False
+            if not should_deliver_by_email(n_type, prefs):
+                return False
         return True
 
     def _should_send_type(
         self, n_type: NotificationType, prefs: NotificationPreference
     ) -> bool:
-        if n_type in (NotificationType.PROJECT_UPDATE, NotificationType.PROJECT_INVITE):
-            return prefs.project_updates or prefs.invitations
-        if n_type == NotificationType.ROLE_CHANGE:
-            return prefs.role_changes
-        if n_type in (
-            NotificationType.SYSTEM,
-            NotificationType.WELCOME,
-            NotificationType.PASSWORD_RESET,
-        ):
-            return prefs.system_alerts
-        return True
+        """
+        Whether the user wants this category at all.
+
+        The mapping lives in `preferences.py` rather than in an `if` chain
+        here: the chain's problem was that anything it did not name fell
+        through to `True`, so nine of the fifteen types were undeniable and
+        nothing made that visible.
+        """
+        return should_deliver(n_type, prefs)
 
     def dispatch(
         self,
@@ -93,7 +109,7 @@ class NotificationDispatcher:
 
         results = []
         for channel_name in channels:
-            if not self._should_send_channel(channel_name, prefs):
+            if not self._should_send_channel(channel_name, prefs, notification_type):
                 continue
 
             channel = self.channels.get(channel_name)

--- a/backend/app/services/notifications/preferences.py
+++ b/backend/app/services/notifications/preferences.py
@@ -1,0 +1,178 @@
+"""
+Which stored preference gates which notification.
+
+`notification_preferences` has seventeen columns. The dispatcher used to read
+four of them with an `if` chain, and everything the chain did not name fell
+through to `return True` -- so nine of the fifteen notification types were
+undeniable, and turning off "email me about messages" did nothing at all
+(#1247).
+
+The `if` chain was not the problem so much as its default. A type that nobody
+remembered to add was silently delivered, and there was no place where the
+omission was visible. This module is that place: every `NotificationType` has
+a row in `CATEGORY_BY_TYPE`, and a type without one raises in the tests rather
+than quietly defaulting to "send it".
+
+Three buckets, because "gated by a preference" is not the only honest answer:
+
+* **gated** -- the type belongs to a category the user can switch off;
+* **always delivered** -- password resets and security alerts, which are not
+  marketing and should not be suppressible by a checkbox;
+* **ungated** -- there is no column for it. Currently just ``FOLLOW``. Adding
+  one means a migration and a settings row, so it is recorded here as a known
+  gap instead of being mapped to whichever category looks closest.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.models.notification import NotificationType
+
+
+@dataclass(frozen=True)
+class Category:
+    """
+    One row of the notification settings page.
+
+    ``enabled_field`` is the master switch for the category and
+    ``email_field`` is its per-channel one. ``legacy_fields`` are older columns
+    that mean the same thing and are still set on rows written before #586 --
+    see :func:`category_enabled` for how they combine.
+    """
+
+    name: str
+    enabled_field: str
+    email_field: str | None = None
+    legacy_fields: tuple[str, ...] = ()
+
+
+MESSAGES = Category("messages", "messages", "email_messages")
+MENTIONS = Category("mentions", "mentions", "email_mentions")
+TEAM_INVITATIONS = Category(
+    "team_invitations",
+    "team_invitations",
+    "email_team_invitations",
+    legacy_fields=("invitations",),
+)
+PROJECT_UPDATES = Category(
+    "project_updates", "project_updates", "email_project_updates"
+)
+SYSTEM_ANNOUNCEMENTS = Category(
+    "system_announcements",
+    "system_announcements",
+    "email_system_announcements",
+    legacy_fields=("system_alerts",),
+)
+ROLE_CHANGES = Category("role_changes", "role_changes")
+
+#: Every notification type that a preference can switch off.
+#:
+#: The enum has fifteen members and the model has six categories, so some of
+#: these are judgement calls rather than obvious pairings -- application
+#: outcomes and builder flares are filed under project activity, and the AI
+#: notifications under system announcements. Named explicitly so they can be
+#: argued with.
+CATEGORY_BY_TYPE: dict[NotificationType, Category] = {
+    NotificationType.MESSAGE: MESSAGES,
+    NotificationType.MENTION: MENTIONS,
+    NotificationType.PROJECT_INVITE: TEAM_INVITATIONS,
+    NotificationType.PROJECT_UPDATE: PROJECT_UPDATES,
+    NotificationType.APPLICATION: PROJECT_UPDATES,
+    NotificationType.APPLICATION_ACCEPTED: PROJECT_UPDATES,
+    NotificationType.APPLICATION_REJECTED: PROJECT_UPDATES,
+    NotificationType.BUILDER_FLARE: PROJECT_UPDATES,
+    NotificationType.ROLE_CHANGE: ROLE_CHANGES,
+    NotificationType.SYSTEM: SYSTEM_ANNOUNCEMENTS,
+    NotificationType.WELCOME: SYSTEM_ANNOUNCEMENTS,
+    NotificationType.AI: SYSTEM_ANNOUNCEMENTS,
+}
+
+#: Delivered whatever the preferences say.
+#:
+#: `PASSWORD_RESET` used to sit under `system_alerts`, which meant a user who
+#: switched off system alerts stopped being told their password had been reset.
+#: That is the notification you least want suppressed, and the same goes for
+#: `SECURITY_ALERT`.
+ALWAYS_DELIVERED: frozenset[NotificationType] = frozenset(
+    {
+        NotificationType.PASSWORD_RESET,
+        NotificationType.SECURITY_ALERT,
+    }
+)
+
+#: Types with no matching column. A known gap, not a decision.
+#:
+#: `FOLLOW` has no preference anywhere in the model, so there is nothing to
+#: read. Mapping it to a neighbouring category would mean somebody's "project
+#: updates" switch silently also controls follows. It stays ungated, and this
+#: set is what makes that visible.
+UNGATED: frozenset[NotificationType] = frozenset({NotificationType.FOLLOW})
+
+
+def _flag(prefs, field: str, default: bool = True) -> bool:
+    """Read a boolean column, tolerating a preference row that predates it."""
+    value = getattr(prefs, field, None)
+    return default if value is None else bool(value)
+
+
+def category_for(notification_type: NotificationType) -> Category | None:
+    """The category gating this type, or ``None`` if it is not gated."""
+    return CATEGORY_BY_TYPE.get(notification_type)
+
+
+def category_enabled(category: Category, prefs) -> bool:
+    """
+    Whether the user wants this category at all.
+
+    A category is on only if its own field **and** every legacy alias are on.
+
+    That is an ``and``, deliberately, and it is the opposite of what the old
+    code did -- it joined `project_updates` and `invitations` with ``or``, so
+    neither switch did anything on its own and the pair was off only when both
+    were. Two rows in Settings that only worked as one.
+
+    Every column defaults to ``True``, so a row written before #586 that opted
+    out via `invitations` still has `team_invitations=True`. Honouring the
+    legacy opt-out therefore means treating any ``False`` as a no.
+    """
+    if not _flag(prefs, category.enabled_field):
+        return False
+    return all(_flag(prefs, field) for field in category.legacy_fields)
+
+
+def should_deliver(notification_type: NotificationType, prefs) -> bool:
+    """Whether this notification should be delivered on any channel."""
+    if notification_type in ALWAYS_DELIVERED or notification_type in UNGATED:
+        return True
+
+    category = category_for(notification_type)
+    if category is None:
+        # Fail open. A type nobody mapped is a bug, and dropping a user's
+        # notifications is a worse way to find out about it than delivering
+        # one too many -- `test_every_notification_type_is_accounted_for`
+        # turns it red in CI instead.
+        return True
+
+    return category_enabled(category, prefs)
+
+
+def should_deliver_by_email(notification_type: NotificationType, prefs) -> bool:
+    """
+    Whether the *email* channel should carry this notification.
+
+    Assumes :func:`should_deliver` has already passed; this is the second,
+    per-channel gate that the dispatcher never had. `email_enabled` is the
+    master switch and stays with the dispatcher's channel check -- what is new
+    here is the per-category one underneath it.
+    """
+    if notification_type in ALWAYS_DELIVERED:
+        return True
+
+    category = category_for(notification_type)
+    if category is None or category.email_field is None:
+        # `role_changes` genuinely has no email column; it follows the global
+        # email switch alone.
+        return True
+
+    return _flag(prefs, category.email_field)

--- a/backend/tests/test_notification_preference_enforcement.py
+++ b/backend/tests/test_notification_preference_enforcement.py
@@ -1,0 +1,440 @@
+"""
+The stored notification preferences are actually enforced.
+
+Companion to `test_notification_preferences.py`, which covers the other half:
+that the API stores what it is given and returns it. Those four tests pass on
+`main` and always did -- which is exactly why this gap was invisible. Every
+preference was written correctly, read back correctly, and rendered correctly.
+Nothing asked whether the dispatcher consults them.
+
+`notification_preferences` has seventeen columns. The dispatcher read four of
+them, and everything its `if` chain did not name fell through to `return True`
+(#1247). A user could switch a category off, reload the settings page, see it
+off, and keep receiving the notifications.
+
+Every test here asserts **both directions**. That is the whole discipline of
+this file: an authorization-style change that only checks "off means silence"
+passes just as well when the answer is silence for everybody, and turning off
+notifications for people who want them is a worse bug than the one being
+fixed.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.models.notification import (
+    Notification,
+    NotificationPreference,
+    NotificationType,
+)
+from app.models.user import User
+from app.services.notifications import dispatcher
+from app.services.notifications.preferences import (
+    ALWAYS_DELIVERED,
+    CATEGORY_BY_TYPE,
+    UNGATED,
+)
+
+ALL_TYPES = list(NotificationType)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def make_recipient(db):
+    """A user plus a preference row, with the given flags applied."""
+    counter = {"n": 0}
+
+    def _make(**flags):
+        counter["n"] += 1
+        n = counter["n"]
+        user = User(
+            id=uuid.uuid4(),
+            email=f"pref{n}@example.com",
+            username=f"prefuser{n}",
+            first_name="Pref",
+            last_name="User",
+            password_hash="x_hashed",
+        )
+        db.add(user)
+        db.commit()
+
+        prefs = NotificationPreference(user_id=user.id)
+        for field, value in flags.items():
+            assert hasattr(prefs, field), f"no such preference column: {field}"
+            setattr(prefs, field, value)
+        db.add(prefs)
+        db.commit()
+
+        return user
+
+    return _make
+
+
+@pytest.fixture()
+def emails_sent(monkeypatch):
+    """Records every address the email channel tries to send to."""
+    sent: list[str] = []
+
+    def _capture(to_email, title, message, action_url=None):
+        sent.append(to_email)
+        return True
+
+    monkeypatch.setattr(
+        "app.services.email_service.EmailService.send_notification_email",
+        staticmethod(_capture),
+    )
+    return sent
+
+
+def _dispatch(db, user, n_type, channels=None):
+    return dispatcher.dispatch(
+        db=db,
+        recipient_id=user.id,
+        sender_id=None,
+        notification_type=n_type,
+        title="A title",
+        message="A message",
+        channels=channels,
+    )
+
+
+def _stored(db, user) -> int:
+    return db.query(Notification).filter(Notification.recipient_id == user.id).count()
+
+
+# ---------------------------------------------------------------------------
+# The table covers the enum
+# ---------------------------------------------------------------------------
+
+
+def test_every_notification_type_is_accounted_for():
+    """
+    The test that keeps the fix from decaying back into the bug.
+
+    `should_deliver` fails open for an unmapped type, on the grounds that
+    dropping somebody's notifications is a bad way to discover a missing entry.
+    That safety valve is only acceptable if something else is loud about it,
+    and this is that something.
+    """
+    accounted = set(CATEGORY_BY_TYPE) | ALWAYS_DELIVERED | UNGATED
+    missing = set(ALL_TYPES) - accounted
+
+    assert missing == set(), (
+        f"NotificationType members with no entry in preferences.py: "
+        f"{sorted(t.value for t in missing)}. Add them to CATEGORY_BY_TYPE, or "
+        "to ALWAYS_DELIVERED / UNGATED with a comment saying why they are not "
+        "gated."
+    )
+
+
+def test_the_three_buckets_do_not_overlap():
+    assert not (set(CATEGORY_BY_TYPE) & ALWAYS_DELIVERED)
+    assert not (set(CATEGORY_BY_TYPE) & UNGATED)
+    assert not (ALWAYS_DELIVERED & UNGATED)
+
+
+# ---------------------------------------------------------------------------
+# Off means off
+# ---------------------------------------------------------------------------
+
+
+GATED_CASES = sorted(
+    ((n_type, category) for n_type, category in CATEGORY_BY_TYPE.items()),
+    key=lambda pair: pair[0].value,
+)
+GATED_IDS = [f"{t.value}-{c.name}" for t, c in GATED_CASES]
+
+
+@pytest.mark.parametrize("n_type,category", GATED_CASES, ids=GATED_IDS)
+def test_disabling_the_category_stops_the_notification(
+    db, make_recipient, n_type, category
+):
+    user = make_recipient(**{category.enabled_field: False})
+
+    _dispatch(db, user, n_type)
+
+    assert _stored(db, user) == 0, (
+        f"{category.enabled_field}=False did not stop {n_type.value}"
+    )
+
+
+@pytest.mark.parametrize("n_type,category", GATED_CASES, ids=GATED_IDS)
+def test_leaving_the_category_on_still_delivers(db, make_recipient, n_type, category):
+    """
+    The half that is easy to forget. Six of the twelve cases above pass
+    trivially if the dispatcher stops delivering anything at all.
+    """
+    user = make_recipient()
+
+    _dispatch(db, user, n_type)
+
+    assert _stored(db, user) == 1, f"{n_type.value} was not delivered by default"
+
+
+# ---------------------------------------------------------------------------
+# The two toggles that were joined with `or`
+# ---------------------------------------------------------------------------
+
+
+def test_project_updates_and_invitations_are_independent(db, make_recipient):
+    """
+    The original read `prefs.project_updates or prefs.invitations` for both
+    PROJECT_UPDATE and PROJECT_INVITE, so neither switch did anything alone and
+    the pair was off only when both were.
+    """
+    no_updates = make_recipient(project_updates=False)
+    _dispatch(db, no_updates, NotificationType.PROJECT_UPDATE)
+    assert _stored(db, no_updates) == 0
+
+    # ...and the same user still gets invitations.
+    _dispatch(db, no_updates, NotificationType.PROJECT_INVITE)
+    assert _stored(db, no_updates) == 1
+
+    no_invites = make_recipient(team_invitations=False)
+    _dispatch(db, no_invites, NotificationType.PROJECT_INVITE)
+    assert _stored(db, no_invites) == 0
+
+    _dispatch(db, no_invites, NotificationType.PROJECT_UPDATE)
+    assert _stored(db, no_invites) == 1
+
+
+# ---------------------------------------------------------------------------
+# Per-category email
+# ---------------------------------------------------------------------------
+
+
+EMAIL_CASES = [
+    (n_type, category)
+    for n_type, category in GATED_CASES
+    if category.email_field is not None
+]
+EMAIL_IDS = [f"{t.value}-{c.email_field}" for t, c in EMAIL_CASES]
+
+
+@pytest.mark.parametrize("n_type,category", EMAIL_CASES, ids=EMAIL_IDS)
+def test_disabling_category_email_stops_the_email_only(
+    db, make_recipient, emails_sent, n_type, category
+):
+    """
+    The five `email_*` columns were never read by anything. This is the
+    behaviour the settings page has been offering and not delivering.
+    """
+    user = make_recipient(**{category.email_field: False})
+
+    _dispatch(db, user, n_type)
+
+    assert emails_sent == [], f"{category.email_field}=False still sent an email"
+    assert _stored(db, user) == 1, "the in-app notification should be unaffected"
+
+
+@pytest.mark.parametrize("n_type,category", EMAIL_CASES, ids=EMAIL_IDS)
+def test_category_email_on_by_default_sends(
+    db, make_recipient, emails_sent, n_type, category
+):
+    user = make_recipient()
+
+    _dispatch(db, user, n_type)
+
+    assert emails_sent == [user.email]
+
+
+def test_the_global_email_switch_still_wins(db, make_recipient, emails_sent):
+    """
+    `email_enabled` is the master switch and sits above the per-category ones.
+    """
+    user = make_recipient(email_enabled=False, email_messages=True)
+
+    _dispatch(db, user, NotificationType.MESSAGE)
+
+    assert emails_sent == []
+    assert _stored(db, user) == 1
+
+
+def test_disabling_the_category_stops_the_email_too(db, make_recipient, emails_sent):
+    """
+    Turning off the category, not just its email row, should not leave email
+    running -- the per-channel gate is underneath the category gate, not
+    beside it.
+    """
+    user = make_recipient(messages=False, email_messages=True)
+
+    _dispatch(db, user, NotificationType.MESSAGE)
+
+    assert emails_sent == []
+    assert _stored(db, user) == 0
+
+
+def test_role_changes_have_no_email_column_and_follow_the_global_switch(
+    db, make_recipient, emails_sent
+):
+    """
+    `role_changes` is the one gated category with no `email_role_changes`.
+    Rather than invent one, it follows `email_enabled` alone -- asserted so the
+    asymmetry is deliberate rather than an oversight.
+    """
+    user = make_recipient()
+    _dispatch(db, user, NotificationType.ROLE_CHANGE)
+    assert emails_sent == [user.email]
+
+    silent = make_recipient(email_enabled=False)
+    _dispatch(db, silent, NotificationType.ROLE_CHANGE)
+    assert emails_sent == [user.email]  # unchanged
+
+
+# ---------------------------------------------------------------------------
+# Legacy column names
+# ---------------------------------------------------------------------------
+
+
+def test_the_legacy_invitations_column_still_opts_out(db, make_recipient):
+    """
+    #586 renamed `invitations` to `team_invitations` and left both columns on
+    the model. Every column defaults to True, so a row written before the
+    rename that opted out via `invitations` has `team_invitations=True` -- and
+    reading only the new name would silently re-enable it.
+    """
+    user = make_recipient(invitations=False)  # team_invitations left at default
+
+    _dispatch(db, user, NotificationType.PROJECT_INVITE)
+
+    assert _stored(db, user) == 0
+
+
+def test_the_legacy_system_alerts_column_still_opts_out(db, make_recipient):
+    user = make_recipient(system_alerts=False)
+
+    _dispatch(db, user, NotificationType.SYSTEM)
+
+    assert _stored(db, user) == 0
+
+
+def test_a_legacy_opt_in_does_not_override_a_new_opt_out(db, make_recipient):
+    """
+    The combination is `and`, not "prefer the newer column". Both mean the same
+    thing, so either saying no is a no.
+    """
+    user = make_recipient(team_invitations=False, invitations=True)
+
+    _dispatch(db, user, NotificationType.PROJECT_INVITE)
+
+    assert _stored(db, user) == 0
+
+
+# ---------------------------------------------------------------------------
+# The notifications a preference must not silence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "n_type", sorted(ALWAYS_DELIVERED, key=lambda t: t.value), ids=lambda t: t.value
+)
+def test_security_notifications_survive_every_preference(db, make_recipient, n_type):
+    """
+    `PASSWORD_RESET` used to sit under `system_alerts`, so a user who switched
+    off system alerts stopped being told their password had been reset. That is
+    a behaviour change in this PR and it is deliberate.
+    """
+    user = make_recipient(
+        messages=False,
+        mentions=False,
+        team_invitations=False,
+        project_updates=False,
+        system_announcements=False,
+        system_alerts=False,
+        invitations=False,
+        role_changes=False,
+    )
+
+    _dispatch(db, user, n_type)
+
+    assert _stored(db, user) == 1, f"{n_type.value} was suppressed by a preference"
+
+
+def test_security_notifications_still_respect_the_channel_switches(
+    db, make_recipient, emails_sent
+):
+    """
+    Always-delivered is about *categories*, not channels. A user who has turned
+    email off entirely should still not get email -- they will see it in-app.
+    """
+    user = make_recipient(email_enabled=False)
+
+    _dispatch(db, user, NotificationType.SECURITY_ALERT)
+
+    assert emails_sent == []
+    assert _stored(db, user) == 1
+
+
+@pytest.mark.parametrize(
+    "n_type", sorted(UNGATED, key=lambda t: t.value), ids=lambda t: t.value
+)
+def test_ungated_types_are_delivered_and_that_is_a_known_gap(
+    db, make_recipient, n_type
+):
+    """
+    There is no preference column for FOLLOW, so it is delivered. Pinning it
+    means the day someone adds one, this test fails and points at the place to
+    wire it up -- rather than the column being added and silently ignored,
+    which is how this issue started.
+    """
+    user = make_recipient(messages=False, project_updates=False)
+
+    _dispatch(db, user, n_type)
+
+    assert _stored(db, user) == 1
+
+
+# ---------------------------------------------------------------------------
+# Channels
+# ---------------------------------------------------------------------------
+
+
+def test_the_database_channel_switch_is_respected(db, make_recipient):
+    user = make_recipient(database_enabled=False)
+
+    _dispatch(db, user, NotificationType.MESSAGE)
+
+    assert _stored(db, user) == 0
+
+
+def test_an_explicit_channel_list_still_honours_preferences(
+    db, make_recipient, emails_sent
+):
+    """
+    Callers can name channels explicitly. That should narrow what is sent, not
+    bypass the user's settings.
+    """
+    user = make_recipient(email_messages=False)
+
+    _dispatch(db, user, NotificationType.MESSAGE, channels=["email"])
+
+    assert emails_sent == []
+    assert _stored(db, user) == 0
+
+
+def test_a_user_with_no_preference_row_gets_defaults(db, make_recipient):
+    """
+    `_get_user_preferences` creates a row on first dispatch. Everything defaults
+    to on, so a brand new user receives notifications.
+    """
+    user = User(
+        id=uuid.uuid4(),
+        email="nodefaults@example.com",
+        username="nodefaults",
+        first_name="No",
+        last_name="Prefs",
+        password_hash="x_hashed",
+    )
+    db.add(user)
+    db.commit()
+
+    _dispatch(db, user, NotificationType.MESSAGE)
+
+    assert _stored(db, user) == 1

--- a/docs/notification_preferences_center.md
+++ b/docs/notification_preferences_center.md
@@ -78,12 +78,74 @@ Features:
 
 ---
 
-## 4. Running Unit Tests
+## 4. How preferences are enforced
 
-Execute backend unit tests:
+Storing a preference and honouring it are separate things, and for a long time
+only the first half was true (#1247). The mapping from notification type to
+category now lives in one place, `app/services/notifications/preferences.py`,
+rather than in an `if` chain inside the dispatcher.
+
+### Gated categories
+
+| Notification type | Category | Email column |
+|---|---|---|
+| `message` | `messages` | `email_messages` |
+| `mention` | `mentions` | `email_mentions` |
+| `project_invite` | `team_invitations` | `email_team_invitations` |
+| `project_update` | `project_updates` | `email_project_updates` |
+| `application`, `application_accepted`, `application_rejected` | `project_updates` | `email_project_updates` |
+| `builder_flare` | `project_updates` | `email_project_updates` |
+| `system`, `welcome`, `ai` | `system_announcements` | `email_system_announcements` |
+| `role_change` | `role_changes` | *(none — follows `email_enabled` alone)* |
+
+Two gates, in order: the category switch decides whether the notification is
+sent at all, and `email_<category>` decides whether email is one of the
+channels that carries it. `email_enabled` sits above both as the master switch.
+
+### Not gated
+
+- `password_reset` and `security_alert` are **always delivered**. A user who
+  switches off system announcements should still be told their password was
+  reset. Channel switches still apply — turning email off means they see it
+  in-app, not that they see it twice.
+- `follow` has **no preference column anywhere in the model**, so there is
+  nothing to read and it is always delivered. This is a known gap rather than a
+  decision; adding a column means a migration and a settings row.
+
+### Legacy column names
+
+`invitations` and `system_alerts` predate the #586 rename to `team_invitations`
+and `system_announcements`. Both old and new columns still exist and both
+default to `true`, so a row written before the rename that opted out via
+`invitations` has `team_invitations = true`.
+
+A category is therefore enabled only if its own column **and** every legacy
+alias are enabled — any `false` is a no. Reading only the newer column would
+silently re-enable notifications that a user had already opted out of.
+
+### Adding a notification type
+
+Add it to `CATEGORY_BY_TYPE`, or to `ALWAYS_DELIVERED` / `UNGATED` with a
+comment saying why. `test_every_notification_type_is_accounted_for` fails on
+any `NotificationType` member that appears in none of the three.
+
+`should_deliver()` deliberately fails *open* for an unmapped type — dropping
+someone's notifications is a worse way to discover a missing entry than sending
+one too many — so that test is the thing standing between a forgotten entry and
+a silently ungated category.
+
+---
+
+## 5. Running Unit Tests
+
 ```bash
 cd backend
-./venv/bin/pytest tests/test_notification_preferences.py -v
+./venv/bin/pytest tests/test_notification_preferences.py \
+                  tests/test_notification_preference_enforcement.py -v
 ```
 
-Expected output: **4 passed**.
+`test_notification_preferences.py` covers storage and serialisation;
+`test_notification_preference_enforcement.py` covers whether the dispatcher
+acts on what was stored. Every case in the second file asserts both directions
+— off means silence, on means delivery — because a change that only checks the
+first passes just as well when the answer is silence for everybody.


### PR DESCRIPTION
Fixes #1247.

## The bug

`_should_send_type`, in full, before:

```python
if n_type in (NotificationType.PROJECT_UPDATE, NotificationType.PROJECT_INVITE):
    return prefs.project_updates or prefs.invitations
if n_type == NotificationType.ROLE_CHANGE:
    return prefs.role_changes
if n_type in (NotificationType.SYSTEM, NotificationType.WELCOME,
              NotificationType.PASSWORD_RESET):
    return prefs.system_alerts
return True
```

Seventeen columns in the model, four read here. Six for six on the issue's
reproduction:

```
messages=False              -> MESSAGE          delivered
mentions=False              -> MENTION          delivered
team_invitations=False      -> PROJECT_INVITE   delivered
project_updates=False       -> PROJECT_UPDATE   delivered
system_announcements=False  -> SYSTEM           delivered
email_messages=False        -> MESSAGE (email)  delivered
```

Three distinct faults, which is why it is three distinct pieces of work:

1. **`return True`.** Nine of the fifteen types were not named by the chain, so
   they were undeniable. Nothing anywhere made that visible.
2. **The five `email_*` columns were dead.** `_should_send_channel` only knew
   the global `email_enabled`, so the per-category email column of the settings
   matrix had no code path that could honour it.
3. **`or`.** `project_updates` and `invitations` are separate rows in Settings.
   Joined with `or`, neither did anything on its own and the pair was off only
   when both were.

## The fix

The `if` chain was not really the problem; its **default** was. A type nobody
remembered to add was silently delivered, and there was no file you could open
to see the omission.

So the mapping moves to `app/services/notifications/preferences.py`, where
every `NotificationType` has a row. The dispatcher keeps the same two questions
it always asked, and now delegates both:

```python
def _should_send_type(self, n_type, prefs):
    return should_deliver(n_type, prefs)
```

with the channel check gaining a second gate underneath the master switch:

```python
if channel_name == "email":
    if not prefs.email_enabled:
        return False
    if not should_deliver_by_email(n_type, prefs):
        return False
```

Three buckets, because "gated by a preference" is not the only honest answer
for fifteen types across six categories:

**Gated** — the twelve that map onto a category. Some of those mappings are
judgement calls and are named as such in the module: application outcomes and
builder flares are filed under project activity, and `AI` under system
announcements. Argue with them in review; that is what having them in one
readable table is for.

**Always delivered** — `PASSWORD_RESET` and `SECURITY_ALERT`. This is a
**behaviour change** and it is deliberate: `PASSWORD_RESET` used to sit under
`system_alerts`, so a user who switched off system announcements stopped being
told their password had been reset. Channel switches still apply — someone who
has turned email off entirely still gets it in-app rather than by email, and
there is a test for exactly that.

**Ungated** — `FOLLOW`. There is no preference column for it anywhere in the
model. Mapping it to whichever category looks closest would mean somebody's
"project updates" switch silently also controls follows. It stays ungated,
recorded in a set named `UNGATED`, so it reads as a known gap rather than an
oversight. Adding a column means a migration and a settings row; worth its own
issue.

## `and`, not "prefer the newer column"

`invitations` and `system_alerts` predate the #586 rename. Both old and new
columns still exist on every row and **both default to `True`**, so a row
written before the rename that opted out via `invitations` has
`team_invitations = True`.

Reading only the new column would silently re-enable notifications somebody had
already declined. So a category is on only if its own field and every legacy
alias are on — any `False` is a no. `test_a_legacy_opt_in_does_not_override_a_new_opt_out`
pins the other direction too.

## `should_deliver` fails open, on purpose

An unmapped type is delivered rather than dropped. Dropping someone's
notifications is a worse way to find out about a missing table entry than
sending one too many.

That is only defensible because something else is loud about it.
`test_every_notification_type_is_accounted_for` fails on any enum member that
appears in none of the three buckets, and names it. Strict in CI, safe in
production.

## Tests

`backend/tests/test_notification_preference_enforcement.py` — 62 tests.

Every category case is asserted **both ways**:

```python
def test_disabling_the_category_stops_the_notification(...)
def test_leaving_the_category_on_still_delivers(...)
```

Six of the twelve "off means silence" cases pass perfectly if the dispatcher
stops delivering anything at all. A preferences change that locks out the
people who want notifications is a worse bug than the one being fixed, so the
second half is not optional.

Also covered: the `or` fix as an explicit independence test, the five per-category
email columns (asserting the *email* stops and the in-app notification does
not), the global switch still winning, `role_changes` having no email column
and following `email_enabled` alone, both legacy aliases, the always-delivered
pair surviving every category switch while still respecting channel switches,
and an explicit `channels=[...]` list narrowing delivery rather than bypassing
preferences.

## A note on the existing test file

I nearly wrote this into `tests/test_notification_preferences.py` before
noticing it already exists. Its four tests cover storage and serialisation —
preferences are written, read back and validated correctly — and they pass on
`main` and always did.

That is the whole reason this was invisible. Everything about the preferences
worked except the part that consults them, and the test file's name suggested
the area was covered. The new file is
`test_notification_preference_enforcement.py` and says so in its docstring;
the original is untouched.

## Verification

Against the unfixed dispatcher, 28 of the 62 fail — the eleven category cases,
the independence test, the fifteen email cases, and the legacy-alias pair:

```
FAILED test_disabling_the_category_stops_the_notification[message-messages]
FAILED test_disabling_the_category_stops_the_notification[mention-mentions]
FAILED test_disabling_the_category_stops_the_notification[project_invite-team_invitations]
... 8 more categories ...
FAILED test_project_updates_and_invitations_are_independent
FAILED test_disabling_category_email_stops_the_email_only[message-email_messages]
... 14 more email cases ...
28 failed, 34 passed
```

The 34 that pass without the fix are the "on still delivers" half, which is
exactly right — `return True` delivers everything, including the things it
should.

Full backend suite, this branch and `main` in a clean worktree: **98 failures,
identical sets, no regressions.**

## Docs

`docs/notification_preferences_center.md` gains the type-to-category table, the
two not-gated buckets and why, the legacy-alias rule, and what to do when
adding a notification type.
