### PR TITLE
fix(frontend): stop answering API failures with invented data

### DIFF
--- a/docs/frontend_data_fallbacks.md
+++ b/docs/frontend_data_fallbacks.md
@@ -1,0 +1,67 @@
+# Fallbacks and empty states in the frontend
+
+One rule:
+
+> **Never render invented content as if it were the user's data.**
+
+A failed request and an empty result are different things, and neither of them
+is content. Three code paths broke this and shipped (#1249): invented
+collaboration metrics, an invented team timeline, and a hardcoded maintenance
+banner shown to every user who had no announcements.
+
+## The three cases
+
+| Situation | What to render |
+|---|---|
+| Request failed | an error state, with a retry if the component has one |
+| Request succeeded, result is empty | an empty state |
+| Backend not configured (`isBackendConfigured()` is false) | the seeded mock data — this is local mock mode and is deliberate |
+
+The third is a development convenience and only applies when
+`VITE_API_BASE_URL` is unset. It must never be reached because a *configured*
+backend failed.
+
+## Why an empty result is the easiest one to get wrong
+
+```js
+return res && res.length > 0 ? res : MOCK_ANNOUNCEMENTS;
+```
+
+That reads as defensive. It is not: `[]` is a correct, successful answer
+meaning "there is nothing to announce", and treating it as a failure showed
+every user a maintenance notice that did not exist. Dated `new Date()`, so it
+was always tonight.
+
+`if (res && res.project_id)` had the same shape — anything falsy fell through
+to the mock, so "quiet project" and "backend is down" produced the same very
+busy screen.
+
+## Why this hid other bugs
+
+`withFallback` in `services/index.ts` logged only under `import.meta.env.DEV`.
+In production a swallowed failure produced no signal from either side: no error
+on the page, nothing in the console, and a screenful of plausible content.
+
+Eleven backend routers were 404ing on the legacy `/api` surface (#1246) and
+nobody noticed, partly for this reason. The warning is unconditional now.
+
+## Writing a fallback
+
+Only ever fall back to something **empty**: `[]`, `null`, a zeroed summary. The
+caller cannot tell a fallback from a real answer, so anything with content in
+it becomes indistinguishable from data the user actually has.
+
+If a component needs to distinguish "nothing" from "we do not know", it needs
+the error, not a fallback — let the call throw.
+
+## The components are usually ready for this
+
+Worth checking before writing new UI. `ProjectCollaborationMetrics` already had
+a loading skeleton, an error panel and a Retry button; `TeamActivityTimeline`
+already had an error panel and a "No activity events found" state. Both were
+complete and unreachable, because the API module caught everything before it
+got there.
+
+Shared pieces: `components/ui/empty-state.tsx`,
+`components/shared/EmptyState.tsx`, `components/shared/EmptySearchState.tsx`,
+`components/errors/SectionErrorBoundary.tsx`.

--- a/frontend/src/api/__tests__/projectCollaborationMetrics.test.ts
+++ b/frontend/src/api/__tests__/projectCollaborationMetrics.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getProjectCollaborationMetrics } from "../modules/projectCollaborationMetrics";
+import { api } from "../client";
+
+const PROJECT_ID = 42;
+
+const REAL_RESPONSE = {
+  project_id: PROJECT_ID,
+  active_members: 2,
+  total_team_size: 3,
+  avg_response_time_hours: 9.5,
+  messages_exchanged: 4,
+  tasks_completed: 1,
+  applications_received: 0,
+  collaboration_score: 31,
+  daily_activity: [],
+};
+
+describe("getProjectCollaborationMetrics", () => {
+  beforeEach(() => {
+    vi.spyOn(api, "get").mockResolvedValue(REAL_RESPONSE as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("targets the project-scoped metrics endpoint", async () => {
+    await getProjectCollaborationMetrics(PROJECT_ID);
+
+    expect(api.get).toHaveBeenCalledWith(`/projects/${PROJECT_ID}/collaboration-metrics`);
+  });
+
+  it("returns what the backend sent", async () => {
+    await expect(getProjectCollaborationMetrics(PROJECT_ID)).resolves.toEqual(REAL_RESPONSE);
+  });
+
+  // The regression. This used to catch everything and return a fixed object,
+  // so a 401, a 500 or an unreachable backend all rendered as a healthy
+  // project with a collaboration score of 92.
+  it("propagates a failure instead of inventing metrics", async () => {
+    vi.spyOn(api, "get").mockRejectedValue(new Error("Request failed with status 500"));
+
+    await expect(getProjectCollaborationMetrics(PROJECT_ID)).rejects.toThrow(
+      "Request failed with status 500",
+    );
+  });
+
+  it("does not substitute a fallback for an unauthorised response", async () => {
+    vi.spyOn(api, "get").mockRejectedValue(new Error("401"));
+
+    await expect(getProjectCollaborationMetrics(PROJECT_ID)).rejects.toThrow();
+  });
+
+  // A real project can legitimately have a score of zero, or no team, or no
+  // messages. The old guard was `if (res && res.project_id)`, which fell
+  // through to the mock for anything falsy -- so "quiet project" and "backend
+  // is down" produced the same very busy screen.
+  it("returns a genuinely empty project as empty", async () => {
+    const empty = {
+      ...REAL_RESPONSE,
+      active_members: 0,
+      total_team_size: 0,
+      messages_exchanged: 0,
+      tasks_completed: 0,
+      collaboration_score: 0,
+      daily_activity: [],
+    };
+    vi.spyOn(api, "get").mockResolvedValue(empty as never);
+
+    const result = await getProjectCollaborationMetrics(PROJECT_ID);
+
+    expect(result.collaboration_score).toBe(0);
+    expect(result.daily_activity).toEqual([]);
+  });
+
+  it("never returns the numbers the old fallback used", async () => {
+    const result = await getProjectCollaborationMetrics(PROJECT_ID);
+
+    // 92/342/2.4 were the hardcoded values. Named explicitly so that
+    // reintroducing the fallback fails here rather than looking plausible.
+    expect(result.collaboration_score).not.toBe(92);
+    expect(result.messages_exchanged).not.toBe(342);
+    expect(result.avg_response_time_hours).not.toBe(2.4);
+  });
+});

--- a/frontend/src/api/__tests__/teamActivity.test.ts
+++ b/frontend/src/api/__tests__/teamActivity.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getTeamActivityTimeline } from "../modules/teamActivity";
+import { api } from "../client";
+
+const PROJECT_ID = 7;
+
+const EMPTY_PAGE = {
+  project_id: PROJECT_ID,
+  items: [],
+  total: 0,
+  page: 1,
+  limit: 10,
+  has_more: false,
+};
+
+describe("getTeamActivityTimeline", () => {
+  beforeEach(() => {
+    vi.spyOn(api, "get").mockResolvedValue(EMPTY_PAGE as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("requests the project's timeline with pagination", async () => {
+    await getTeamActivityTimeline(PROJECT_ID, 2, 5);
+
+    expect(api.get).toHaveBeenCalledWith(
+      `/projects/${PROJECT_ID}/activity-timeline?page=2&limit=5`,
+    );
+  });
+
+  it("appends the activity type filter when given one", async () => {
+    await getTeamActivityTimeline(PROJECT_ID, 1, 10, "member_joined");
+
+    expect(api.get).toHaveBeenCalledWith(expect.stringContaining("&activity_type=member_joined"));
+  });
+
+  it("omits the filter entirely when not given one", async () => {
+    await getTeamActivityTimeline(PROJECT_ID);
+
+    expect(api.get).toHaveBeenCalledWith(expect.not.stringContaining("activity_type"));
+  });
+
+  it("encodes the filter so a value with a space cannot break the query string", async () => {
+    await getTeamActivityTimeline(PROJECT_ID, 1, 10, "role updated&page=99");
+
+    const url = vi.mocked(api.get).mock.calls[0][0] as string;
+    expect(url).toContain("activity_type=role%20updated%26page%3D99");
+    expect(url).toContain("page=1");
+  });
+
+  // The regression. Any failure used to return five invented activities
+  // attributed to people who do not exist, with timestamps derived from
+  // Date.now() so they always looked recent.
+  it("propagates a failure instead of inventing a timeline", async () => {
+    vi.spyOn(api, "get").mockRejectedValue(new Error("Network error"));
+
+    await expect(getTeamActivityTimeline(PROJECT_ID)).rejects.toThrow("Network error");
+  });
+
+  it("returns an empty timeline as empty", async () => {
+    const result = await getTeamActivityTimeline(PROJECT_ID);
+
+    expect(result.items).toEqual([]);
+    expect(result.has_more).toBe(false);
+  });
+
+  it("returns the real items when there are some", async () => {
+    vi.spyOn(api, "get").mockResolvedValue({
+      ...EMPTY_PAGE,
+      items: [
+        {
+          id: "real-1",
+          project_id: PROJECT_ID,
+          activity_type: "member_joined",
+          title: "Priya joined the team",
+          actor_name: "Priya Raman",
+          created_at: "2026-08-20T09:00:00Z",
+        },
+      ],
+      total: 1,
+    } as never);
+
+    const result = await getTeamActivityTimeline(PROJECT_ID);
+
+    expect(result.items.map((i) => i.actor_name)).toEqual(["Priya Raman"]);
+    // The invented cast from the old fallback.
+    expect(result.items.map((i) => i.actor_name)).not.toContain("Sarah Connor");
+  });
+});

--- a/frontend/src/api/modules/projectCollaborationMetrics.ts
+++ b/frontend/src/api/modules/projectCollaborationMetrics.ts
@@ -1,4 +1,4 @@
-import { api } from '../client';
+import { api } from "../client";
 
 export interface DailyActivityPoint {
   date: string;
@@ -19,38 +19,18 @@ export interface ProjectCollaborationMetricsResponse {
   daily_activity: DailyActivityPoint[];
 }
 
+/**
+ * Collaboration metrics for one project.
+ *
+ * Errors propagate. This used to catch everything and return a fixed object --
+ * a collaboration score of 92, 342 messages exchanged and a seven-day chart
+ * hardcoded to the week of 2026-08-04 -- so a 401, a 500 or an unreachable
+ * backend rendered as somebody's real-looking project metrics (#1249).
+ *
+ * `ProjectCollaborationMetrics` already had a loading skeleton, an error panel
+ * and a Retry button. The catch here is what made them unreachable.
+ */
 export const getProjectCollaborationMetrics = async (
-  projectId: number
-): Promise<ProjectCollaborationMetricsResponse> => {
-  try {
-    const res = await api.get<ProjectCollaborationMetricsResponse>(
-      `/projects/${projectId}/collaboration-metrics`
-    );
-    if (res && res.project_id) {
-      return res;
-    }
-  } catch (e) {
-    console.warn('Backend API unavailable, using fallback mock metrics:', e);
-  }
-
-  // Fallback Mock Data
-  return {
-    project_id: projectId,
-    active_members: 8,
-    total_team_size: 12,
-    avg_response_time_hours: 2.4,
-    messages_exchanged: 342,
-    tasks_completed: 29,
-    applications_received: 14,
-    collaboration_score: 92,
-    daily_activity: [
-      { date: '2026-08-04', activity_count: 12, messages: 45, tasks_completed: 4 },
-      { date: '2026-08-05', activity_count: 18, messages: 62, tasks_completed: 6 },
-      { date: '2026-08-06', activity_count: 15, messages: 50, tasks_completed: 3 },
-      { date: '2026-08-07', activity_count: 22, messages: 80, tasks_completed: 7 },
-      { date: '2026-08-08', activity_count: 14, messages: 40, tasks_completed: 2 },
-      { date: '2026-08-09', activity_count: 8, messages: 25, tasks_completed: 1 },
-      { date: '2026-08-10', activity_count: 25, messages: 95, tasks_completed: 6 },
-    ],
-  };
-};
+  projectId: number,
+): Promise<ProjectCollaborationMetricsResponse> =>
+  api.get<ProjectCollaborationMetricsResponse>(`/projects/${projectId}/collaboration-metrics`);

--- a/frontend/src/api/modules/teamActivity.ts
+++ b/frontend/src/api/modules/teamActivity.ts
@@ -17,7 +17,7 @@ export interface TeamActivityItem {
   description?: string;
   actor_name: string;
   actor_avatar?: string;
-  metadata_info?: Record<string, any>;
+  metadata_info?: Record<string, unknown>;
   created_at: string;
 }
 
@@ -30,90 +30,29 @@ export interface TeamActivityTimelineResponse {
   has_more: boolean;
 }
 
+/**
+ * Activity timeline for one project's team.
+ *
+ * Errors propagate. This used to answer any failure with a five-item timeline
+ * of invented people -- "Sarah Connor joined the team", "Uploaded
+ * architecture_v2.pdf" -- with avatars and `created_at` computed from
+ * `Date.now()`, so the timestamps were always plausibly recent. It even
+ * honoured the `activity_type` filter, so filtering the fake timeline worked
+ * and made it look more real (#1249).
+ *
+ * `TeamActivityTimeline` already renders an error panel and a "No activity
+ * events found" empty state.
+ */
 export const getTeamActivityTimeline = async (
   projectId: number,
   page: number = 1,
   limit: number = 10,
   activityType?: string,
 ): Promise<TeamActivityTimelineResponse> => {
-  try {
-    let url = `/projects/${projectId}/activity-timeline?page=${page}&limit=${limit}`;
-    if (activityType) {
-      url += `&activity_type=${activityType}`;
-    }
-    const res = await api.get<TeamActivityTimelineResponse>(url);
-    if (res && res.items) return res;
-  } catch (e) {
-    console.warn("Backend API unavailable, using fallback mock activity timeline:", e);
+  let url = `/projects/${projectId}/activity-timeline?page=${page}&limit=${limit}`;
+  if (activityType) {
+    url += `&activity_type=${encodeURIComponent(activityType)}`;
   }
 
-  const raw_items: TeamActivityItem[] = [
-    {
-      id: "1",
-      project_id: projectId,
-      activity_type: "member_joined",
-      title: "Sarah Connor joined the team",
-      description: "Sarah joined as Frontend Engineer",
-      actor_name: "Sarah Connor",
-      actor_avatar: "https://api.dicebear.com/7.x/avataaars/svg?seed=Sarah",
-      metadata_info: { role: "Frontend Engineer" },
-      created_at: new Date(Date.now() - 2 * 3600 * 1000).toISOString(),
-    },
-    {
-      id: "2",
-      project_id: projectId,
-      activity_type: "milestone_completed",
-      title: "Completed Milestone: MVP Auth & Database Schema",
-      description: "All 12 sub-tasks for Sprint 1 have been marked completed.",
-      actor_name: "Alex Mercer",
-      actor_avatar: "https://api.dicebear.com/7.x/avataaars/svg?seed=Alex",
-      metadata_info: { milestone_id: 101, progress: "100%" },
-      created_at: new Date(Date.now() - 5 * 3600 * 1000).toISOString(),
-    },
-    {
-      id: "3",
-      project_id: projectId,
-      activity_type: "file_uploaded",
-      title: "Uploaded architecture_v2.pdf",
-      description: "System architecture diagram and cloud specs uploaded to team workspace.",
-      actor_name: "Elena Rostova",
-      actor_avatar: "https://api.dicebear.com/7.x/avataaars/svg?seed=Elena",
-      metadata_info: { file_name: "architecture_v2.pdf", size_kb: 2048 },
-      created_at: new Date(Date.now() - 24 * 3600 * 1000).toISOString(),
-    },
-    {
-      id: "4",
-      project_id: projectId,
-      activity_type: "new_discussion",
-      title: "Started discussion: Real-time WebSocket Protocol Design",
-      description: "Opened discussion thread regarding socket event schemas.",
-      actor_name: "Marcus Vance",
-      actor_avatar: "https://api.dicebear.com/7.x/avataaars/svg?seed=Marcus",
-      metadata_info: { comments_count: 8 },
-      created_at: new Date(Date.now() - 48 * 3600 * 1000).toISOString(),
-    },
-    {
-      id: "5",
-      project_id: projectId,
-      activity_type: "role_updated",
-      title: "Updated Alex Mercer role to Project Lead",
-      description: "Permissions elevated to Project Admin",
-      actor_name: "Project Owner",
-      actor_avatar: "https://api.dicebear.com/7.x/avataaars/svg?seed=Owner",
-      metadata_info: { new_role: "Project Lead" },
-      created_at: new Date(Date.now() - 72 * 3600 * 1000).toISOString(),
-    },
-  ];
-
-  const filtered = activityType
-    ? raw_items.filter((item) => item.activity_type === activityType)
-    : raw_items;
-  return {
-    project_id: projectId,
-    items: filtered,
-    total: filtered.length,
-    page,
-    limit,
-    has_more: false,
-  };
+  return api.get<TeamActivityTimelineResponse>(url);
 };

--- a/frontend/src/components/__tests__/AnnouncementBanner.test.tsx
+++ b/frontend/src/components/__tests__/AnnouncementBanner.test.tsx
@@ -1,0 +1,128 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AnnouncementBanner, type Announcement } from "../shared/AnnouncementBanner";
+import { api } from "../../api/client";
+
+const REAL_ANNOUNCEMENT: Announcement = {
+  id: "ann-real",
+  title: "Read receipts are live",
+  content: "Message read receipts have shipped for all conversations.",
+  severity: "info",
+  target_audience: "all",
+  start_date: "2026-08-20T00:00:00Z",
+  is_active: true,
+};
+
+function renderBanner() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AnnouncementBanner />
+    </QueryClientProvider>,
+  );
+}
+
+describe("AnnouncementBanner", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders the announcements the backend returned", async () => {
+    vi.spyOn(api, "get").mockResolvedValue([REAL_ANNOUNCEMENT] as never);
+
+    renderBanner();
+
+    expect(await screen.findByText(/Read receipts are live/)).toBeInTheDocument();
+  });
+
+  // The regression, and the worst of the three: this did not need a failure.
+  // An empty list is a valid answer meaning "nothing to announce", and it was
+  // treated as one, so every user with no announcements was shown a hardcoded
+  // "Scheduled Maintenance tonight from 2:00 AM to 3:00 AM UTC" -- dated
+  // new Date(), so always tonight, on every page, forever.
+  it("renders nothing when there are no announcements", async () => {
+    vi.spyOn(api, "get").mockResolvedValue([] as never);
+
+    const { container } = renderBanner();
+
+    await waitFor(() => expect(api.get).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText(/Scheduled Maintenance/i)).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when the request fails", async () => {
+    vi.spyOn(api, "get").mockRejectedValue(new Error("500"));
+
+    const { container } = renderBanner();
+
+    await waitFor(() => expect(api.get).toHaveBeenCalled());
+    expect(screen.queryByText(/Scheduled Maintenance/i)).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  // The mock was also the useQuery default value, so it painted before any
+  // request resolved -- a user saw the fake banner on first load even when the
+  // backend was about to answer with nothing.
+  it("renders nothing while the request is still in flight", () => {
+    vi.spyOn(api, "get").mockReturnValue(new Promise(() => {}) as never);
+
+    const { container } = renderBanner();
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("hides an announcement once it is dismissed", async () => {
+    vi.spyOn(api, "get").mockResolvedValue([REAL_ANNOUNCEMENT] as never);
+
+    renderBanner();
+    await screen.findByText(/Read receipts are live/);
+
+    await userEvent.click(screen.getByRole("button", { name: /dismiss banner/i }));
+
+    await waitFor(() =>
+      expect(screen.queryByText(/Read receipts are live/)).not.toBeInTheDocument(),
+    );
+  });
+
+  it("keeps a dismissal across a remount", async () => {
+    vi.spyOn(api, "get").mockResolvedValue([REAL_ANNOUNCEMENT] as never);
+
+    const first = renderBanner();
+    await screen.findByText(/Read receipts are live/);
+    await userEvent.click(screen.getByRole("button", { name: /dismiss banner/i }));
+    first.unmount();
+
+    const { container } = renderBanner();
+
+    await waitFor(() => expect(api.get).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("still shows a different announcement after one is dismissed", async () => {
+    vi.spyOn(api, "get").mockResolvedValue([REAL_ANNOUNCEMENT] as never);
+
+    const first = renderBanner();
+    await screen.findByText(/Read receipts are live/);
+    await userEvent.click(screen.getByRole("button", { name: /dismiss banner/i }));
+    first.unmount();
+
+    vi.spyOn(api, "get").mockResolvedValue([
+      { ...REAL_ANNOUNCEMENT, id: "ann-other", title: "Planned downtime" },
+    ] as never);
+
+    renderBanner();
+
+    expect(await screen.findByText(/Planned downtime/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/shared/AnnouncementBanner.tsx
+++ b/frontend/src/components/shared/AnnouncementBanner.tsx
@@ -17,18 +17,6 @@ export interface Announcement {
 
 const DISMISSED_STORAGE_KEY = "devlink_dismissed_announcements";
 
-const MOCK_ANNOUNCEMENTS: Announcement[] = [
-  {
-    id: "ann-1",
-    title: "Scheduled Maintenance",
-    content: "DevLink platform will undergo brief maintenance tonight from 2:00 AM to 3:00 AM UTC.",
-    severity: "warning",
-    target_audience: "all",
-    start_date: new Date().toISOString(),
-    is_active: true,
-  },
-];
-
 export function AnnouncementBanner() {
   const [dismissedIds, setDismissedIds] = useState<string[]>(() => {
     try {
@@ -39,17 +27,28 @@ export function AnnouncementBanner() {
     }
   });
 
-  const { data: announcements = MOCK_ANNOUNCEMENTS } = useQuery<Announcement[]>({
+  // An empty list is a valid answer meaning "nothing to announce", and a
+  // failure means we do not know. Both render nothing.
+  //
+  // This used to substitute a hardcoded "Scheduled Maintenance tonight from
+  // 2:00 AM to 3:00 AM UTC" for either case -- dated `new Date()`, so it was
+  // always tonight, on every page, for every user, forever. It was also the
+  // `useQuery` default, so it rendered during the first load before any
+  // request resolved (#1249).
+  //
+  // A fake maintenance notice is the piece of invented content users are most
+  // likely to act on.
+  const { data: announcements = [] } = useQuery<Announcement[]>({
     queryKey: ["global-announcements-active"],
     queryFn: async (): Promise<Announcement[]> => {
-      try {
-        const res = await api.get<Announcement[]>("/api/announcements/active");
-        return res && res.length > 0 ? res : MOCK_ANNOUNCEMENTS;
-      } catch {
-        return MOCK_ANNOUNCEMENTS;
-      }
+      const res = await api.get<Announcement[]>("/api/announcements/active");
+      return res ?? [];
     },
     refetchInterval: 60000,
+    // The banner is decoration on top of whatever page the user is on. A
+    // failure should cost them nothing, so it stays quiet and retries on the
+    // interval above rather than surfacing an error over their content.
+    retry: 1,
   });
 
   const activeAnnouncements = announcements.filter((item) => !dismissedIds.includes(item.id));

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -40,14 +40,24 @@ import type { Hackathon, Flare, Message } from "@/mocks/seed";
 const delay = 120;
 const mock = <T>(v: T): Promise<T> => new Promise((r) => setTimeout(() => r(v), delay));
 
-// Wrap a real API call so a network/backend failure silently degrades to the
-// provided fallback. Keeps every page usable if the backend is unreachable.
+// Wrap a real API call so a network/backend failure degrades to the provided
+// fallback. Keeps every page usable if the backend is unreachable.
+//
+// Only ever pass an *empty* fallback -- `[]`, `null`, a zeroed summary. The
+// caller cannot tell a fallback from a real answer, so anything with content
+// in it becomes indistinguishable from data the user actually has (#1249).
+//
+// The warning is unconditional. It used to be `import.meta.env.DEV` only,
+// which meant that in production a swallowed failure produced no signal from
+// either side: no error state on the page and nothing in the console. That is
+// a large part of why eleven routers could 404 on the legacy /api surface
+// (#1246) without anybody noticing.
 async function withFallback<T>(call: () => Promise<T>, fallback: T): Promise<T> {
   if (!isBackendConfigured()) return mock(fallback);
   try {
     return await call();
   } catch (err) {
-    if (import.meta.env.DEV) console.warn("[services] API call failed, using fallback:", err);
+    console.warn("[services] API call failed, using fallback:", err);
     return fallback;
   }
 }
@@ -682,8 +692,7 @@ export const collectionsService = {
       try {
         return await collectionsApi.list();
       } catch (err) {
-        if (import.meta.env.DEV)
-          console.warn("[services] collections API failed, using fallback:", err);
+        console.warn("[services] collections API failed, using fallback:", err);
       }
     }
 
@@ -702,8 +711,7 @@ export const collectionsService = {
       try {
         return await collectionsApi.get(id);
       } catch (err) {
-        if (import.meta.env.DEV)
-          console.warn("[services] collections API failed, using fallback:", err);
+        console.warn("[services] collections API failed, using fallback:", err);
       }
     }
 
@@ -733,8 +741,7 @@ export const collectionsService = {
       try {
         return await collectionsApi.create(name);
       } catch (err) {
-        if (import.meta.env.DEV)
-          console.warn("[services] collections API failed, using fallback:", err);
+        console.warn("[services] collections API failed, using fallback:", err);
       }
     }
 
@@ -764,8 +771,7 @@ export const collectionsService = {
       try {
         return await collectionsApi.rename(id, name);
       } catch (err) {
-        if (import.meta.env.DEV)
-          console.warn("[services] collections API failed, using fallback:", err);
+        console.warn("[services] collections API failed, using fallback:", err);
       }
     }
 
@@ -798,8 +804,7 @@ export const collectionsService = {
         await collectionsApi.delete(id);
         return;
       } catch (err) {
-        if (import.meta.env.DEV)
-          console.warn("[services] collections API failed, using fallback:", err);
+        console.warn("[services] collections API failed, using fallback:", err);
       }
     }
 
@@ -824,8 +829,7 @@ export const collectionsService = {
       try {
         return await collectionsApi.addBookmark(collectionId, bookmarkId);
       } catch (err) {
-        if (import.meta.env.DEV)
-          console.warn("[services] collections API failed, using fallback:", err);
+        console.warn("[services] collections API failed, using fallback:", err);
       }
     }
 
@@ -859,8 +863,7 @@ export const collectionsService = {
         await collectionsApi.removeBookmark(collectionId, bookmarkId);
         return;
       } catch (err) {
-        if (import.meta.env.DEV)
-          console.warn("[services] collections API failed, using fallback:", err);
+        console.warn("[services] collections API failed, using fallback:", err);
       }
     }
 
@@ -883,8 +886,7 @@ export const collectionsService = {
       try {
         return await collectionsApi.getBookmarkCollections(bookmarkId);
       } catch (err) {
-        if (import.meta.env.DEV)
-          console.warn("[services] collections API failed, using fallback:", err);
+        console.warn("[services] collections API failed, using fallback:", err);
       }
     }
 


### PR DESCRIPTION
Fixes #1249.

## What was rendering

**`projectCollaborationMetrics.ts`** caught everything and returned a fixed
object: collaboration score 92, 342 messages exchanged, 8 of 12 members active,
and a seven-day chart hardcoded to the week of `2026-08-04`. A 401, a 500 or an
unreachable backend all produced a healthy-looking project.

**`teamActivity.ts`** returned five invented activities — "Sarah Connor joined
the team", "Uploaded architecture_v2.pdf", "Updated Alex Mercer role to Project
Lead" — with dicebear avatars and `created_at` computed from `Date.now()`, so
the timestamps were always plausibly recent. It also honoured the
`activity_type` filter, so filtering the fake timeline worked and made it look
more real.

**`AnnouncementBanner.tsx`** is the one that did not need a failure:

```js
return res && res.length > 0 ? res : MOCK_ANNOUNCEMENTS;
```

`[]` is a correct, successful answer meaning "nothing to announce". Treated as
a failure, so every user with no announcements saw

> **Scheduled Maintenance** — DevLink platform will undergo brief maintenance
> tonight from 2:00 AM to 3:00 AM UTC.

dated `new Date()`, so always tonight, on every dashboard page, forever. It was
also the `useQuery` default value, so it painted during the first load before
any request resolved. Of the three, a fake maintenance notice is the one users
are most likely to act on.

## The error states already existed

This is the part that changed how I wrote the fix.

`ProjectCollaborationMetrics.tsx` has a loading skeleton, an error panel with
an `AlertCircle`, the message, and a **Retry button wired to `fetchMetrics`**.
`TeamActivityTimeline.tsx` has an error panel and a "No activity events found"
empty state. Both components call the API inside a `try`/`catch` and set an
`error` state that could never be non-null, because the module below them
caught first.

So there is no new UI here. The fix is deleting three catches and letting the
components do what they were already written to do:

```diff
-  try {
-    const res = await api.get(...);
-    if (res && res.project_id) return res;
-  } catch (e) {
-    console.warn('Backend API unavailable, using fallback mock metrics:', e);
-  }
-  return { active_members: 8, collaboration_score: 92, ... };
+  api.get<ProjectCollaborationMetricsResponse>(
+    `/projects/${projectId}/collaboration-metrics`,
+  );
```

For the banner, an empty list and a failure both render nothing, which is what
`if (activeAnnouncements.length === 0) return null` already did.

## `withFallback` logs in production now

```diff
-    if (import.meta.env.DEV) console.warn("[services] API call failed, using fallback:", err);
+    console.warn("[services] API call failed, using fallback:", err);
```

Nine places, counting the eight in `collectionsService`.

In production the swallow was completely silent: no error state on the page,
nothing in the console, and a screenful of plausible content. That is why a
broken endpoint produced no signal from either side — and it is a large part of
why eleven backend routers could 404 on the legacy `/api` surface (#1246)
without anyone noticing.

## Something I found while in here

`withFallback` has 35 call sites. The issue said most fall back to `[]` or
`null`, which is a defensible empty state — that is still true, but **five fall
back to seeded content**:

```
services/index.ts:129  projectsApi.list      -> seed.projects
services/index.ts:148  buildersApi.list      -> seed.builders
services/index.ts:151  buildersApi.trending  -> seed.builders.slice(3, 6)
services/index.ts:322  messagesApi.conversations -> seed.conversations
services/index.ts:499  notificationsApi.list -> seed.notifications
```

`withFallback` uses the same value for both branches — mock mode *and* an error
with a real backend configured — so a configured backend that fails shows
seeded projects, builders, conversations and notifications as if they were the
user's.

I have not fixed it here. Splitting the two branches means either a signature
change across all 35 call sites or letting errors propagate to pages that have
no error handling, and both are a product decision rather than a bug fix.
Recording it with line numbers so it does not have to be found again.

`routes/_app.graph.tsx` looked like a fourth case and is not: its `MOCK_DATA`
is only used when `!isBackendConfigured()`, which is documented mock mode. A
real failure already propagates to `useQuery`. Left alone.

## Tests

20 tests across three files.

**`projectCollaborationMetrics.test.ts`** — errors propagate; a genuinely quiet
project (score 0, no members, no activity) comes back as itself rather than
falling through the old `if (res && res.project_id)` guard; and one test
asserts the response is not `92` / `342` / `2.4` by name, so reintroducing the
fallback fails loudly rather than looking plausible.

**`teamActivity.test.ts`** — errors propagate; an empty timeline stays empty;
real items come back with their real names and not `Sarah Connor`. Also covers
URL construction, including `encodeURIComponent` on the filter — the old code
interpolated it raw, so a value containing `&` could inject query parameters.
That is a small fix that came with the rewrite and is asserted rather than
assumed.

**`AnnouncementBanner.test.tsx`** — nothing renders on empty, nothing renders
on failure, and **nothing renders while the request is in flight** (the mock
was the `useQuery` default, so it painted before any answer arrived). Plus the
positive cases: real announcements render, dismissal hides one, dismissal
survives a remount, and a *different* announcement still shows after an earlier
one was dismissed — a banner change that silently swallows real announcements
would be a worse bug than the one being fixed.

## Verification

Against the unfixed source, 8 of the 20 fail:

```
× propagates a failure instead of inventing metrics
× does not substitute a fallback for an unauthorised response
× propagates a failure instead of inventing a timeline
× encodes the filter so a value with a space cannot break the query string
× renders nothing when there are no announcements
× renders nothing when the request fails
× renders nothing while the request is still in flight
× keeps a dismissal across a remount
8 failed | 12 passed
```

Full frontend suite: **50 files, 721 tests, all passing.**

`npx tsc --noEmit` reports the same 10 pre-existing errors as `main` and no new
ones. Those are the stale `routeTree.gen.ts` and are fixed by #1253, not here.

Prettier is clean on every file this touches. `services/index.ts` reports
pre-existing formatting drift at lines 143 and 205–238; my edits are at 43–60
and 695–889 and I have not reformatted the rest of the file.

## Docs

`docs/frontend_data_fallbacks.md` writes down the three cases — failed, empty,
and backend-not-configured — the "only ever fall back to something empty" rule,
and a note to check whether the component already has the error and empty
states before writing new ones, because in all three of these it did.
