### PR TITLE
ci(frontend): run the tests, and fail when a suite stops being run

### DIFF
--- a/.github/scripts/check_workflows.py
+++ b/.github/scripts/check_workflows.py
@@ -31,14 +31,30 @@ missing context is not a failing one, every pull request then waits forever on
 a check that will never arrive. That is a repository-wide outage caused by a
 one-word edit, so it is worth a test.
 
+`SUITES` is the same idea one level up. A workflow can run a real step and
+still leave the repository's actual tests on the floor: `frontend-ci.yml`
+installed, built, and compared the route tree -- three substantive steps, a
+green tick, and 726 vitest tests that no workflow had ever executed (#1316).
+Two ways for a suite to stop mattering, and this checks both:
+
+* nothing invokes it, which is what happened to the frontend suite;
+* something invokes it under `continue-on-error: true`, which is what still
+  happens to `pytest` -- the job reports success whatever the tests say.
+
+`KNOWN_UNGATED` is the second case with a name attached, the same way
+`KNOWN_HOLLOW` is for workflows. An entry there is a debt, not an exemption,
+and the script says so when one is paid off.
+
 Deliberately not clever. It does not try to judge whether a step is a *good*
 check, only whether one exists and still answers to the name `main` expects.
 """
 
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
+from typing import Iterator, NamedTuple
 
 import yaml
 
@@ -98,6 +114,73 @@ SCAFFOLDING = {
 }
 
 
+class Suite(NamedTuple):
+    """
+    A test suite the repository ships, and how to spot it being run.
+
+    A `NamedTuple` rather than a dataclass so this module can be exec'd
+    straight from its path -- which is how `tests/test_check_workflows.py`
+    loads it, and how anyone poking at it from a REPL will. `@dataclass`
+    resolves its annotations through `sys.modules[cls.__module__]`, which is
+    `None` for a module loaded that way, and raises during class creation.
+    """
+
+    #: What to call it in an error message.
+    description: str
+    #: Where the suite lives, so the message points somewhere useful.
+    home: str
+    #: Matched against each command in the `run:` of every step.
+    pattern: re.Pattern
+
+
+#: Suites that must be invoked by some workflow, and must gate when they are.
+#:
+#: Deliberately a short hand-maintained list rather than anything that goes
+#: looking. The failure this catches is a suite quietly falling out of CI, and
+#: a discovery mechanism that can also miss a suite would inherit the same
+#: blind spot.
+#:
+#: Patterns are anchored to the start of a *command*, not matched anywhere in
+#: the `run:` block, because the difference matters:
+#:
+#:     pip install black ruff mypy pytest     <- names it, does not run it
+#:     pytest                                 <- runs it
+#:
+#: `npm run test` is matched without a trailing `:`, so `npm run test:e2e` --
+#: a different suite, needing browsers and a server -- does not satisfy this.
+SUITES = {
+    "frontend": Suite(
+        description="frontend unit tests (vitest)",
+        home="frontend/package.json -> scripts.test",
+        pattern=re.compile(
+            r"^(?:npx\s+)?(?:npm\s+run\s+test(?![\w:.-])|vitest(?![\w.-]))"
+        ),
+    ),
+    "backend": Suite(
+        description="backend tests (pytest)",
+        home="backend/tests/ and backend/app/tests/",
+        pattern=re.compile(r"^(?:[\w./-]*python[\w.]*\s+-m\s+)?pytest(?![\w.-])"),
+    ),
+}
+
+#: Suites that run but do not gate, and why that is not fixed here.
+#:
+#: `backend-ci.yml` has carried `continue-on-error: true` on its `pytest` step
+#: since the workflow was written, so the `backend` context is green whatever
+#: the tests say. Taking the flag off is the right end state and is not a
+#: one-line change: it turns the existing failures on `main` into a blocked
+#: repository, which has to be dealt with first and separately.
+#:
+#: An entry here is a debt with a name attached. The script fails when a suite
+#: listed here starts gating, so paying one off cannot leave the note behind.
+KNOWN_UNGATED = {
+    "backend": (
+        "`pytest` runs in backend-ci.yml under `continue-on-error: true`; "
+        "removing that needs the failing tests on `main` dealt with first"
+    ),
+}
+
+
 def is_scaffolding(step: dict) -> bool:
     """Whether this step only prepares the runner."""
     if "run" in step:
@@ -124,6 +207,97 @@ def substantive_steps(job: dict) -> int:
     )
 
 
+#: Shell operators that end one command and begin the next, plus the newlines
+#: of a `run: |` block. Splitting on these is what lets the suite patterns
+#: anchor to `^` and still see the second half of `cd backend && pytest`.
+_COMMAND_SEPARATOR = re.compile(r"[\n;]|&&|\|\||(?<!\|)\|(?!\|)")
+
+#: A leading `FOO=bar ` assignment is part of the invocation, not a different
+#: command. `CI=true npm run test` is running the suite.
+_ENV_PREFIX = re.compile(r"^(?:\w+=\S*\s+)*")
+
+
+def commands_in(run: str) -> Iterator[str]:
+    """Split a `run:` block into the individual commands it executes."""
+    for fragment in _COMMAND_SEPARATOR.split(run):
+        command = _ENV_PREFIX.sub("", fragment.strip())
+        if command:
+            yield command
+
+
+def iter_run_steps(document: dict) -> Iterator[tuple[str, bool]]:
+    """
+    Yield ``(command, gates)`` for every `run:` step in a workflow document.
+
+    ``gates`` is False when the step or its job carries
+    ``continue-on-error: true``, which makes the job report success regardless
+    of what the step returned. Both levels matter: the flag is legal on either
+    and means the same thing for our purposes.
+    """
+    jobs = document.get("jobs")
+    if not isinstance(jobs, dict):
+        return
+
+    for job in jobs.values():
+        if not isinstance(job, dict):
+            continue
+
+        job_gates = job.get("continue-on-error") is not True
+
+        steps = job.get("steps")
+        if not isinstance(steps, list):
+            continue
+
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            command = step.get("run")
+            if isinstance(command, str):
+                yield command, job_gates and step.get("continue-on-error") is not True
+
+
+def suite_problems(invocations: dict[str, list[bool]]) -> list[str]:
+    """
+    Turn what was found into the complaints worth making.
+
+    ``invocations`` maps a suite name to one entry per step that runs it, each
+    saying whether that step gates. A suite is satisfied by *any* gating
+    invocation -- running it twice, once under `continue-on-error`, is fine.
+    """
+    problems: list[str] = []
+
+    for name, suite in SUITES.items():
+        found = invocations.get(name, [])
+
+        if not found:
+            problems.append(
+                f"nothing in {WORKFLOWS} runs the {suite.description}. The "
+                f"suite exists ({suite.home}) and no pull request has ever "
+                "been told what it thinks. A test nobody runs is worse than a "
+                "test nobody wrote: it reads as coverage on the pull request "
+                "page while asserting nothing."
+            )
+            continue
+
+        gates = any(found)
+
+        if not gates and name not in KNOWN_UNGATED:
+            problems.append(
+                f"the {suite.description} runs, but every invocation is under "
+                "`continue-on-error: true`, so the job reports success "
+                "whatever the tests say. Drop the flag, or add an entry to "
+                "KNOWN_UNGATED saying why not."
+            )
+        elif gates and name in KNOWN_UNGATED:
+            problems.append(
+                f"the {suite.description} now gates, so its KNOWN_UNGATED "
+                "entry is stale. Remove it -- a tracked debt that has been "
+                "paid off is the one kind of entry that must not linger."
+            )
+
+    return problems
+
+
 def main() -> int:
     if not WORKFLOWS.is_dir():
         print(f"::error::{WORKFLOWS} does not exist")
@@ -131,6 +305,7 @@ def main() -> int:
 
     problems: list[str] = []
     contexts: set[str] = set()
+    invocations: dict[str, list[bool]] = {}
     checked = 0
 
     for path in sorted(WORKFLOWS.glob("*.y*ml")):
@@ -162,6 +337,14 @@ def main() -> int:
             if isinstance(job, dict):
                 contexts.add(job.get("name") or name)
 
+        # Scanned before the KNOWN_HOLLOW skip below: a workflow excused from
+        # the hollow check is still a place a suite could be run from.
+        for run, gates in iter_run_steps(document):
+            for command in commands_in(run):
+                for suite_name, suite in SUITES.items():
+                    if suite.pattern.match(command):
+                        invocations.setdefault(suite_name, []).append(gates)
+
         if path.name in KNOWN_HOLLOW:
             continue
 
@@ -179,6 +362,8 @@ def main() -> int:
                 "asserting anything is worse than no workflow -- give it a "
                 "real step, or delete the file."
             )
+
+    problems.extend(suite_problems(invocations))
 
     missing = REQUIRED_CONTEXTS - contexts
     if missing:
@@ -200,8 +385,14 @@ def main() -> int:
     known = ", ".join(sorted(KNOWN_HOLLOW))
     print(f"{checked} workflows checked; each runs at least one real step.")
     print(f"All {len(REQUIRED_CONTEXTS)} required status checks are produced.")
+    print(f"All {len(SUITES)} test suites are run by a workflow.")
     if KNOWN_HOLLOW:
         print(f"Still hollow, tracked in KNOWN_HOLLOW: {known}")
+    if KNOWN_UNGATED:
+        print(
+            f"Runs but does not gate, tracked in KNOWN_UNGATED: "
+            f"{', '.join(sorted(KNOWN_UNGATED))}"
+        )
     return 0
 
 

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -31,6 +31,21 @@ jobs:
       - name: Build
         run: npm run build 2>&1
 
+      # Building a component and running it are different questions. `vite
+      # build` bundled `_app.settings.tsx` happily while the module threw
+      # `ReferenceError` the moment React called it, and the test written to
+      # cover that page was red for four days under a green `frontend` tick,
+      # because nothing here ran it (#1316).
+      #
+      # After the build on purpose: a failing test is more useful to read than
+      # a failing test that might just be a bad bundle, and the install is
+      # already warm either way.
+      #
+      # e2e is excluded here, as in `npm run test` -- Playwright needs browsers
+      # and a server, which is a separate job when somebody wants it.
+      - name: Test
+        run: npm run test
+
       # src/routeTree.gen.ts is generated from the filenames in src/routes/ and
       # committed. That only works if something fails when the two disagree,
       # and nothing did -- `showcase.tsx` and `verify-email.tsx` were live

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -5,6 +5,7 @@ export type { CollabEvent as WsEvent } from "./ws";
 
 export { authApi } from "./modules/auth";
 export { usersApi } from "./modules/users";
+export type { CurrentUserProfile } from "./modules/users";
 export { projectsApi } from "./modules/projects";
 export { buildersApi } from "./modules/builders";
 export { postsApi } from "./modules/posts";

--- a/frontend/src/api/modules/users.ts
+++ b/frontend/src/api/modules/users.ts
@@ -1,13 +1,50 @@
 import { api } from "../client";
 
+/**
+ * The authenticated user as `/api/users/me` returns it.
+ *
+ * Deliberately wider than `AuthUser` in `modules/auth`: that one describes the
+ * summary embedded in a login response, this one is the full profile row the
+ * settings page edits. `handle` is the legacy spelling of `username` and is
+ * still present on older rows.
+ *
+ * `version` is the optimistic-concurrency token. Send it back on a write and
+ * the server answers 409 if the profile changed underneath you; drop it and
+ * the last write silently wins.
+ */
+export interface CurrentUserProfile {
+  id: string;
+  first_name?: string;
+  last_name?: string;
+  username?: string;
+  handle?: string;
+  email?: string;
+  bio?: string;
+  headline?: string;
+  location?: string;
+  website?: string;
+  avatar?: string;
+  profile_image?: string;
+  version?: number;
+}
+
 export const usersApi = {
+  /**
+   * The caller's own profile.
+   *
+   * `auth-context.tsx` reached for this endpoint with a hand-rolled
+   * `api.get("/api/users/me")` because there was nothing here to call, and the
+   * settings page called a `usersService.getMe` that did not exist (#1315).
+   */
+  me: () => api.get<CurrentUserProfile>("/api/users/me"),
   list: (query?: { page?: number; limit?: number; q?: string }) =>
     api.get<unknown[]>("/api/users", { query }),
   get: (id: string) => api.get<unknown>(`/api/users/${id}`),
   update: (id: string, body: Record<string, unknown>) => api.put<unknown>(`/api/users/${id}`, body),
   updateMe: (body: Record<string, unknown>) => api.put<unknown>("/api/users/me", body),
   getPrivacySettings: () => api.get<any>("/api/users/me/privacy"),
-  updatePrivacySettings: (body: Record<string, any>) => api.put<unknown>("/api/users/me/privacy", body),
+  updatePrivacySettings: (body: Record<string, any>) =>
+    api.put<unknown>("/api/users/me/privacy", body),
   remove: (id: string) => api.delete<void>(`/api/users/${id}`),
   search: (q: string) => api.get<unknown[]>("/api/users/search", { query: { q } }),
   recommendations: () => api.get<unknown[]>("/api/users/recommendations"),

--- a/frontend/src/components/__tests__/settings-profile.test.tsx
+++ b/frontend/src/components/__tests__/settings-profile.test.tsx
@@ -1,0 +1,179 @@
+// Regression cover for #1315, at the page level.
+//
+// Three faults, all in the profile tab of `/settings`:
+//
+//   1. `useRef` was called without being imported, so the component threw
+//      `ReferenceError` on its first render and the route was an error
+//      boundary. Every test in this file would fail on that alone.
+//   2. `usersService.getMe` did not exist, so the mount effect threw and the
+//      form never populated.
+//   3. `usersService.updateMe` swallowed failures and returned `{}`, so a save
+//      that did not happen was reported as "Profile saved successfully" and
+//      the version token was reset to 1 -- which made the *next* save stale too.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+const PROFILE = {
+  id: "usr_1",
+  first_name: "Ada",
+  last_name: "Lovelace",
+  username: "ada",
+  email: "ada@example.com",
+  headline: "Analytical Engines",
+  location: "London",
+  website: "https://example.com",
+  bio: "Notes on the engine",
+  version: 4,
+};
+
+const getMe = vi.fn();
+const updateMe = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (opts: any) => ({ options: opts }),
+  Link: ({ children, to, ...props }: any) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+  useRouterState: () => "/settings",
+}));
+
+vi.mock("@/services", () => ({
+  usersService: {
+    getMe: (...args: unknown[]) => getMe(...args),
+    updateMe: (...args: unknown[]) => updateMe(...args),
+    getPrivacySettings: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock("@/api", () => ({
+  authApi: { me: vi.fn().mockResolvedValue({}) },
+  exportApi: { exportData: vi.fn().mockResolvedValue({ data: {} }) },
+}));
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccess(...args),
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}));
+
+import { SettingsPage } from "@/routes/_app.settings";
+
+/** Type into the bio field, which is the simplest way to make the form dirty. */
+function editBio(value: string) {
+  const bio = screen.getByPlaceholderText(/short summary about your developer background/i);
+  fireEvent.change(bio, { target: { value } });
+  return bio;
+}
+
+function submit() {
+  fireEvent.click(screen.getByRole("button", { name: /save profile/i }));
+}
+
+describe("Settings profile tab (#1315)", () => {
+  beforeEach(() => {
+    getMe.mockReset().mockResolvedValue(PROFILE);
+    updateMe.mockReset().mockResolvedValue({ ...PROFILE, bio: "edited", version: 5 });
+    toastSuccess.mockReset();
+    toastError.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders without throwing", () => {
+    // The `useRef` regression: this threw `ReferenceError: useRef is not
+    // defined` before anything painted.
+    expect(() => render(<SettingsPage />)).not.toThrow();
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Settings");
+  });
+
+  it("loads the profile through usersService.getMe and fills the form", async () => {
+    render(<SettingsPage />);
+
+    await waitFor(() => expect(getMe).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(screen.getByDisplayValue("Notes on the engine")).toBeInTheDocument(),
+    );
+    expect(screen.getByDisplayValue("ada@example.com")).toBeInTheDocument();
+  });
+
+  it("says so when the profile cannot be loaded", async () => {
+    getMe.mockResolvedValue(null);
+
+    render(<SettingsPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/could not load your profile/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("sends the loaded version with the save", async () => {
+    render(<SettingsPage />);
+    await waitFor(() =>
+      expect(screen.getByDisplayValue("Notes on the engine")).toBeInTheDocument(),
+    );
+
+    editBio("edited");
+    submit();
+
+    await waitFor(() => expect(updateMe).toHaveBeenCalledTimes(1));
+    expect(updateMe.mock.calls[0][0]).toMatchObject({ bio: "edited", version: 4 });
+  });
+
+  it("reports a failed save as a failure", async () => {
+    updateMe.mockRejectedValue(new Error("Network is down"));
+
+    render(<SettingsPage />);
+    await waitFor(() =>
+      expect(screen.getByDisplayValue("Notes on the engine")).toBeInTheDocument(),
+    );
+
+    editBio("edited");
+    submit();
+
+    await waitFor(() => expect(screen.getByText("Network is down")).toBeInTheDocument());
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalled();
+  });
+
+  it("routes a 409 to the conflict state rather than reporting a save", async () => {
+    updateMe.mockRejectedValue(Object.assign(new Error("Conflict"), { status: 409 }));
+
+    render(<SettingsPage />);
+    await waitFor(() =>
+      expect(screen.getByDisplayValue("Notes on the engine")).toBeInTheDocument(),
+    );
+
+    editBio("edited");
+    submit();
+
+    await waitFor(() => expect(screen.getByText(/profile updated elsewhere/i)).toBeInTheDocument());
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("keeps the version the server returned after a successful save", async () => {
+    // The old code read `version` off a `{}` fallback, so it reset to 1 and
+    // every later save was sent with a stale token.
+    render(<SettingsPage />);
+    await waitFor(() =>
+      expect(screen.getByDisplayValue("Notes on the engine")).toBeInTheDocument(),
+    );
+
+    editBio("edited");
+    submit();
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
+
+    editBio("edited twice");
+    submit();
+
+    await waitFor(() => expect(updateMe).toHaveBeenCalledTimes(2));
+    expect(updateMe.mock.calls[1][0]).toMatchObject({ version: 5 });
+  });
+});

--- a/frontend/src/routes/_app.settings.tsx
+++ b/frontend/src/routes/_app.settings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/shared/primitives";
@@ -101,6 +101,10 @@ export function SettingsPage() {
   const [saveStatus, setSaveStatus] = useState<"saved" | "unsaved" | "saving" | "error" | "conflict">("saved");
   const [errorMessage, setErrorMessage] = useState("");
   const [loadingProfile, setLoadingProfile] = useState(true);
+  // Distinct from `errorMessage`, which belongs to the save path. A profile
+  // that could not be read leaves the form blank, and a blank form that says
+  // nothing reads as "you have no name set" rather than "we could not ask".
+  const [loadError, setLoadError] = useState("");
 
   // Appearance States
   const [selectedTheme, setSelectedTheme] = useState<"light" | "dark" | "system">("system");
@@ -142,9 +146,9 @@ export function SettingsPage() {
             last_name: user.last_name || "",
             username: user.username || user.handle || "",
             email: user.email || "",
-            headline: (user as any).headline || "Full-Stack Developer & Open Source Contributor",
-            location: (user as any).location || "San Francisco, CA",
-            website: (user as any).website || "https://devlink.io",
+            headline: user.headline || "Full-Stack Developer & Open Source Contributor",
+            location: user.location || "San Francisco, CA",
+            website: user.website || "https://devlink.io",
             bio: user.bio || "",
             version: user.version || 1,
           };
@@ -152,9 +156,12 @@ export function SettingsPage() {
           setOriginalProfileData(loadedData);
           setFullNameInput(`${loadedData.first_name} ${loadedData.last_name}`.trim());
           setSaveStatus("saved");
+        } else {
+          setLoadError("Could not load your profile. Your details are not shown.");
         }
       } catch (err) {
         console.error("Failed to load user profile:", err);
+        setLoadError("Could not load your profile. Your details are not shown.");
       } finally {
         setLoadingProfile(false);
       }
@@ -563,6 +570,10 @@ export function SettingsPage() {
                         placeholder="Short summary about your developer background..."
                       />
                     </div>
+
+                    {loadError && (
+                      <p className="text-xs font-medium text-destructive">{loadError}</p>
+                    )}
 
                     {errorMessage && (
                       <p className="text-xs font-medium text-destructive">{errorMessage}</p>

--- a/frontend/src/services/__tests__/usersService.test.ts
+++ b/frontend/src/services/__tests__/usersService.test.ts
@@ -1,0 +1,104 @@
+// Regression cover for #1315.
+//
+// The settings page is the only caller of `usersService.getMe`, and it was
+// calling a method that did not exist. `updateMe` did exist and was worse: it
+// was wrapped in `withFallback`, so every failure -- including the 409 that
+// optimistic concurrency exists to produce -- came back as a truthy `{}` and
+// was reported to the user as a successful save.
+//
+// These tests pin both halves at the service boundary, which is where the
+// decision lives. The page-level consequence is covered in
+// `components/__tests__/settings-profile.test.tsx`.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const PROFILE = {
+  id: "usr_1",
+  first_name: "Ada",
+  last_name: "Lovelace",
+  username: "ada",
+  email: "ada@example.com",
+  bio: "Analytical engines",
+  version: 4,
+};
+
+// `withFallback` short-circuits to mock data when VITE_API_BASE_URL is empty,
+// which would make every assertion below vacuous. Point it at something.
+vi.mock("@/api", async () => {
+  const actual = await vi.importActual<typeof import("@/api")>("@/api");
+  return {
+    ...actual,
+    isBackendConfigured: () => true,
+    usersApi: {
+      ...actual.usersApi,
+      me: vi.fn(),
+      updateMe: vi.fn(),
+      updatePrivacySettings: vi.fn(),
+      getPrivacySettings: vi.fn(),
+    },
+  };
+});
+
+import { usersApi } from "@/api";
+import { usersService } from "@/services";
+
+describe("usersService.getMe", () => {
+  beforeEach(() => {
+    vi.mocked(usersApi.me).mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("exists, and reads the caller's own profile", async () => {
+    vi.mocked(usersApi.me).mockResolvedValue(PROFILE);
+
+    await expect(usersService.getMe()).resolves.toEqual(PROFILE);
+    expect(usersApi.me).toHaveBeenCalledTimes(1);
+  });
+
+  it("answers null when the profile cannot be read, not an invented user", async () => {
+    // A fabricated profile here would be rendered into the form fields as the
+    // user's own data, and then written back over the real row on the next
+    // save. `null` is the only shape the page can tell apart from an answer.
+    vi.mocked(usersApi.me).mockRejectedValue(new Error("network"));
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(usersService.getMe()).resolves.toBeNull();
+  });
+});
+
+describe("usersService.updateMe", () => {
+  beforeEach(() => {
+    vi.mocked(usersApi.updateMe).mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("passes the body straight through, version included", async () => {
+    vi.mocked(usersApi.updateMe).mockResolvedValue({ ...PROFILE, version: 5 });
+
+    const result = await usersService.updateMe({ bio: "new", version: 4 });
+
+    expect(usersApi.updateMe).toHaveBeenCalledWith({ bio: "new", version: 4 });
+    expect(result).toEqual({ ...PROFILE, version: 5 });
+  });
+
+  it("rejects when the save fails instead of answering with an empty object", async () => {
+    const failure = new Error("500");
+    vi.mocked(usersApi.updateMe).mockRejectedValue(failure);
+
+    await expect(usersService.updateMe({ bio: "new" })).rejects.toBe(failure);
+  });
+
+  it("lets a 409 reach the caller so the conflict is not reported as a save", async () => {
+    // The whole point of sending `version`. Swallowing this was the bug.
+    const conflict = Object.assign(new Error("Conflict"), { status: 409 });
+    vi.mocked(usersApi.updateMe).mockRejectedValue(conflict);
+
+    await expect(usersService.updateMe({ version: 1 })).rejects.toMatchObject({ status: 409 });
+  });
+});

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -34,6 +34,7 @@ import type {
   IssueCreateInput,
   IssueUpdateInput,
   TechStackResponse,
+  CurrentUserProfile,
 } from "@/api";
 import type { Hackathon, Flare, Message } from "@/mocks/seed";
 
@@ -60,6 +61,23 @@ async function withFallback<T>(call: () => Promise<T>, fallback: T): Promise<T> 
     console.warn("[services] API call failed, using fallback:", err);
     return fallback;
   }
+}
+
+// A mutation has no fallback.
+//
+// `withFallback` exists so a *read* can degrade to an empty shape the page can
+// still render. There is no equivalent for a write: the only two honest
+// answers are "the server applied it" and "it failed", and manufacturing the
+// first is worse than any error state. `usersService.updateMe` used to be
+// `withFallback(..., {})`, which meant the settings page's 409 handling could
+// never run -- every failed save, conflict included, came back as a truthy
+// `{}` and was reported to the user as "Profile saved successfully" (#1315).
+//
+// Mock mode still needs an answer, so it gets one; a configured backend gets
+// the real call, errors and all.
+async function write<T>(call: () => Promise<T>, mockResult: T): Promise<T> {
+  if (!isBackendConfigured()) return mock(mockResult);
+  return call();
 }
 
 const apiBaseUrl = (import.meta.env.VITE_API_BASE_URL ?? "").replace(/\/$/, "");
@@ -140,8 +158,7 @@ export const projectsService = {
   updateDraft: (id: string, body: any) =>
     withFallback(() => projectsApi.updateDraft(id, body as any), {} as any),
 
-  clone: (id: string, body?: any) =>
-    projectsApi.clone(id, body),
+  clone: (id: string, body?: any) => projectsApi.clone(id, body),
 };
 
 export const buildersService = {
@@ -201,28 +218,32 @@ export const dashboardService = {
 };
 
 export const usersService = {
+  /**
+   * The caller's own profile, or `null` when it cannot be read.
+   *
+   * `null` rather than a fabricated user: the settings page renders whatever
+   * comes back into its form fields, so an invented profile would be shown as
+   * the user's own data and then saved back over the real row.
+   */
+  getMe: () => withFallback<CurrentUserProfile | null>(() => usersApi.me(), null),
   getPrivacySettings: () =>
-    withFallback(
-      () => usersApi.getPrivacySettings(),
-      {
-        email: "private",
-        github: "public",
-        resume: "public",
-        social_links: "public",
-        availability: "public",
-        activity: "public",
-      }
-    ),
+    withFallback(() => usersApi.getPrivacySettings(), {
+      email: "private",
+      github: "public",
+      resume: "public",
+      social_links: "public",
+      availability: "public",
+      activity: "public",
+    }),
   updatePrivacySettings: (body: Record<string, any>) =>
-    withFallback(
-      () => usersApi.updatePrivacySettings(body),
-      {}
-    ),
-  updateMe: (body: Record<string, any>) =>
-    withFallback(
-      () => usersApi.updateMe(body),
-      {}
-    ),
+    write(() => usersApi.updatePrivacySettings(body), body),
+  /**
+   * Write the caller's profile. Rejects on failure -- see `write` above.
+   *
+   * In particular a 409 from the optimistic-concurrency check reaches the
+   * caller, which is the whole reason `version` is sent.
+   */
+  updateMe: (body: Record<string, any>) => write<unknown>(() => usersApi.updateMe(body), body),
 };
 
 export const activitiesService = {

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -34,3 +34,27 @@ Object.defineProperty(window, "sessionStorage", {
   value: sessionStorageMock,
   writable: true,
 });
+
+// jsdom does not implement ResizeObserver, and several Radix primitives we use
+// (`Switch`, `Select`, `Popover`, anything built on `useSize`) construct one in
+// a layout effect. Without this, any test that waits for a component tree
+// containing one of them dies with `ReferenceError: ResizeObserver is not
+// defined` *after* the assertions have already passed -- an uncaught exception
+// attributed to whichever test happened to be running at the time, which is a
+// miserable thing to debug.
+//
+// A no-op is the right shape: nothing here is asserting on measured sizes, and
+// the components only need the constructor not to throw.
+class ResizeObserverStub implements ResizeObserver {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+if (!("ResizeObserver" in globalThis)) {
+  Object.defineProperty(globalThis, "ResizeObserver", {
+    value: ResizeObserverStub,
+    writable: true,
+    configurable: true,
+  });
+}

--- a/tests/test_check_workflows.py
+++ b/tests/test_check_workflows.py
@@ -308,3 +308,195 @@ def test_no_workflow_file_is_empty():
     ]
 
     assert empty == [], f"empty workflow files: {empty}"
+
+
+# ---------------------------------------------------------------------------
+# Test suites (#1316)
+# ---------------------------------------------------------------------------
+#
+# A workflow can run three real steps and still leave the repository's tests on
+# the floor. `frontend-ci.yml` installed, built and compared the route tree --
+# hollow-check-clean, green tick, and 726 vitest tests it had never run. These
+# cover the judgements that catch that.
+
+
+def _splits_to(run: str) -> list[str]:
+    return list(check_workflows.commands_in(run))
+
+
+@pytest.mark.parametrize(
+    ("run", "expected"),
+    [
+        ("npm run test", ["npm run test"]),
+        ("cd backend && pytest", ["cd backend", "pytest"]),
+        ("npm ci\nnpm run build\nnpm run test", ["npm ci", "npm run build", "npm run test"]),
+        ("black --check . ; pytest", ["black --check .", "pytest"]),
+        ("pytest || echo failed", ["pytest", "echo failed"]),
+        ("CI=true npm run test", ["npm run test"]),
+        ("  \n  npm run test  \n  ", ["npm run test"]),
+    ],
+)
+def test_run_blocks_split_into_commands(run, expected):
+    assert _splits_to(run) == expected
+
+
+def test_a_pipe_separates_commands_but_an_or_is_not_two_pipes():
+    assert _splits_to("cat x | grep y") == ["cat x", "grep y"]
+    assert _splits_to("pytest || true") == ["pytest", "true"]
+
+
+def _runs_suite(name: str, run: str) -> bool:
+    """Whether this `run:` block runs the named suite, the way `main` asks."""
+    suite = check_workflows.SUITES[name]
+    return any(
+        suite.pattern.match(command) for command in check_workflows.commands_in(run)
+    )
+
+
+@pytest.mark.parametrize(
+    "run",
+    [
+        "npm run test",
+        "npx vitest run",
+        "vitest run --exclude e2e",
+        "CI=1 npm run test",
+        "npm ci\nnpm run build\nnpm run test",
+    ],
+)
+def test_frontend_suite_is_recognised(run):
+    assert _runs_suite("frontend", run) is True
+
+
+@pytest.mark.parametrize(
+    "run",
+    [
+        # A different suite: Playwright needs browsers and a server.
+        "npm run test:e2e",
+        # Naming the package is not running it.
+        "npm install vitest",
+        "npm ci",
+        "npm run build",
+    ],
+)
+def test_frontend_suite_is_not_recognised_in(run):
+    assert _runs_suite("frontend", run) is False
+
+
+@pytest.mark.parametrize(
+    "run",
+    [
+        "pytest",
+        "pytest -q",
+        "python -m pytest",
+        "python3.12 -m pytest tests/",
+        "cd backend && pytest",
+    ],
+)
+def test_backend_suite_is_recognised(run):
+    assert _runs_suite("backend", run) is True
+
+
+@pytest.mark.parametrize(
+    "run",
+    [
+        # The line that made the first draft of this check pass for the wrong
+        # reason: `backend-ci.yml` installs pytest in a step that gates, and
+        # runs it in a step that does not. Reading the install as a run made
+        # the backend suite look gated and hid the `continue-on-error`.
+        "pip install black ruff mypy pytest",
+        "pip install -r requirements.txt",
+        "pytest-cov --version",
+    ],
+)
+def test_backend_suite_is_not_recognised_in(run):
+    assert _runs_suite("backend", run) is False
+
+
+def _document(steps, job_extra=None):
+    job = {"runs-on": "ubuntu-latest", "steps": steps}
+    job.update(job_extra or {})
+    return {"jobs": {"job": job}}
+
+
+def test_a_plain_step_gates():
+    document = _document([{"run": "npm run test"}])
+    assert list(check_workflows.iter_run_steps(document)) == [("npm run test", True)]
+
+
+def test_continue_on_error_on_the_step_means_it_does_not_gate():
+    document = _document([{"run": "pytest", "continue-on-error": True}])
+    assert list(check_workflows.iter_run_steps(document)) == [("pytest", False)]
+
+
+def test_continue_on_error_on_the_job_means_its_steps_do_not_gate():
+    document = _document([{"run": "pytest"}], {"continue-on-error": True})
+    assert list(check_workflows.iter_run_steps(document)) == [("pytest", False)]
+
+
+def test_steps_without_a_run_are_ignored():
+    document = _document([{"uses": "actions/checkout@v4"}, {"run": "pytest"}])
+    assert list(check_workflows.iter_run_steps(document)) == [("pytest", True)]
+
+
+def test_a_suite_nobody_runs_is_a_problem():
+    problems = check_workflows.suite_problems({"backend": [False]})
+
+    assert len(problems) == 1
+    assert "frontend unit tests" in problems[0]
+
+
+def test_a_suite_that_only_runs_under_continue_on_error_is_a_problem():
+    problems = check_workflows.suite_problems({"frontend": [False], "backend": [False]})
+
+    assert len(problems) == 1
+    assert "continue-on-error" in problems[0]
+    assert "frontend unit tests" in problems[0]
+
+
+def test_one_gating_invocation_is_enough():
+    """Running a suite twice, once advisory, is not a fault."""
+    assert (
+        check_workflows.suite_problems({"frontend": [False, True], "backend": [False]})
+        == []
+    )
+
+
+def test_a_known_ungated_suite_that_starts_gating_must_lose_its_entry():
+    """
+    The one direction that has to be an error rather than a skip: a debt that
+    has been paid off and still has a note saying it has not is a lie the next
+    reader will believe.
+    """
+    problems = check_workflows.suite_problems({"frontend": [True], "backend": [True]})
+
+    assert len(problems) == 1
+    assert "stale" in problems[0]
+
+
+def test_the_repositorys_own_workflows_satisfy_the_suite_check():
+    """The check that actually matters, run here so a failure names itself."""
+    workflows = REPO_ROOT / ".github" / "workflows"
+    invocations: dict[str, list[bool]] = {}
+
+    for path in sorted(workflows.glob("*.y*ml")):
+        document = yaml.safe_load(path.read_text())
+        if not isinstance(document, dict):
+            continue
+        for run, gates in check_workflows.iter_run_steps(document):
+            for command in check_workflows.commands_in(run):
+                for name, suite in check_workflows.SUITES.items():
+                    if suite.pattern.match(command):
+                        invocations.setdefault(name, []).append(gates)
+
+    assert check_workflows.suite_problems(invocations) == []
+
+
+def test_each_known_ungated_entry_names_a_real_suite():
+    unknown = set(check_workflows.KNOWN_UNGATED) - set(check_workflows.SUITES)
+
+    assert unknown == set(), f"KNOWN_UNGATED names suites that do not exist: {unknown}"
+
+
+def test_each_known_ungated_entry_says_why():
+    for name, reason in check_workflows.KNOWN_UNGATED.items():
+        assert reason.strip(), f"{name} is allowlisted with no reason given"


### PR DESCRIPTION
Fixes #1316.

> **Stacked on #1320.** This branch carries that commit so its own `frontend`
> check can be green — turning the suite on while `settings-tabs.test.tsx` is
> red would just be a red tick for a different reason. Merge #1320 first and
> this diff collapses to the workflow, the script and its tests. Review the
> second commit.

## The bug

```console
$ grep -rn "vitest\|npm run test\|npm test\|playwright" .github/workflows/
$ echo $?
1
```

53 test files. 726 tests. No workflow has ever run one of them.

`frontend-ci.yml` installs, builds, and checks the committed route tree against
the generated one. All three are worth having and none of them executes a test.
`vite build` will bundle a component that throws the moment React calls it —
which is exactly what happened: `settings-tabs.test.tsx` was written to cover
the settings page, has been red since #1230, and the `frontend` context was
green for that merge and every merge since.

## The fix, part one

A `Test` step in `frontend-ci.yml`, after the build. `e2e` stays excluded, as it
is in `npm run test` — Playwright needs browsers and a server, which is a
separate job for whoever wants it.

## The fix, part two

`check_workflows.py` already refuses a workflow whose jobs are all scaffolding
(#1248). `frontend-ci.yml` sailed through it: install, build and route-tree
comparison are three substantive steps. The check answers *"does this workflow
do something"*, and the thing that went wrong here is narrower — a suite exists,
is wired into `package.json`, and nothing invokes it.

So `SUITES`, listing the suites the repository ships and how to spot one being
run. Two ways to fail it:

- **nothing runs it.** What happened to the frontend suite.
- **it runs, but never gates.** What still happens to `pytest`: `backend-ci.yml`
  has carried `continue-on-error: true` on that step since the workflow was
  written, so the `backend` context is green whatever the tests say.

The second one is real and I am not fixing it here. Dropping the flag turns the
existing failures on `main` into a blocked repository, which has to be dealt
with first and separately. It goes in `KNOWN_UNGATED` with a reason, next to
`KNOWN_HOLLOW` and for the same reason — a debt with a name attached rather than
a silence. The script fails if a suite listed there starts gating, so paying one
off cannot leave the note behind lying about it.

### Two details that are not obvious

**Patterns match the start of a command, not anywhere in the `run:` block.** The
first draft searched the whole block, and this line —

```yaml
run: pip install black ruff mypy pytest
```

— is in a step that *does* gate. So the backend suite looked gated, the
`continue-on-error` two steps down was invisible, and the check passed for
exactly the wrong reason. `commands_in()` splits a block on newlines, `&&`,
`||`, `;` and `|` so `cd backend && pytest` is still seen, and the patterns
anchor to `^`. `npm run test` is matched without a trailing `:` so
`npm run test:e2e` — a different suite — does not satisfy it.

**`Suite` is a `NamedTuple`, not a `@dataclass`.** `tests/test_check_workflows.py`
loads the script with `spec_from_file_location`, which leaves
`sys.modules[__module__]` as `None`; `@dataclass` resolves its annotations
through exactly that and raises during class creation. A `NamedTuple` does not
care, and keeping the module exec-able from its path is worth more than the
`@dataclass` sugar.

## Tests

24 new cases in `tests/test_check_workflows.py`: command splitting (including
that `|` separates but `||` is not two of them), what each suite pattern does
and does not recognise — with `pip install ... pytest` in there by name —
`continue-on-error` at step and job level, one gating invocation being enough,
and a `KNOWN_UNGATED` entry that has gone stale being an error rather than a
skip. Plus the check run against the repository's own workflows, so a failure
names the suite rather than just exiting 1.

```console
$ python .github/scripts/check_workflows.py
14 workflows checked; each runs at least one real step.
All 7 required status checks are produced.
All 2 test suites are run by a workflow.
Still hollow, tracked in KNOWN_HOLLOW: lint.yml, security.yml
Runs but does not gate, tracked in KNOWN_UNGATED: backend

$ python -m pytest tests/test_check_workflows.py -q
68 passed
```

And with the new Test step deleted again, which is the case that matters:

```console
$ python .github/scripts/check_workflows.py
::error::One or more workflows do not check anything.
  - nothing in .github/workflows runs the frontend unit tests (vitest). The suite
    exists (frontend/package.json -> scripts.test) and no pull request has ever
    been told what it thinks. ...
```
