### PR TITLE
fix(followers): one notification per follow, and a duplicate that stays contained

### DIFF
--- a/backend/app/routers/followers.py
+++ b/backend/app/routers/followers.py
@@ -10,11 +10,9 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from app.dependencies import get_current_user, get_database, get_optional_current_user
-from app.models.notification import NotificationType
 from app.models.user import User
 from app.schemas.follower import FollowerResponse, FollowStatusResponse
 from app.services.follower_service import FollowerService
-from app.services.notification_service import NotificationService
 
 router = APIRouter(
     tags=["Followers"],
@@ -50,26 +48,14 @@ def follow_user(
             detail="Already following this user",
         )
 
-    follow = FollowerService.follow_user(
+    # The notification is the service's job and has been all along. This used
+    # to enqueue a second one here -- same event, different title, different
+    # link -- so a follow put two rows in the recipient's list (#1317).
+    return FollowerService.follow_user(
         db,
         current_user.id,
         user_id,
     )
-
-    try:
-        NotificationService.enqueue(
-            db,
-            recipient_id=user_id,
-            sender_id=current_user.id,
-            type=NotificationType.FOLLOW,
-            title="New follower",
-            message=f"{current_user.username} started following you.",
-            action_url=f"/users/{current_user.id}",
-        )
-    except Exception as e:
-        print(f"ENQUEUE ERROR: {e}")
-
-    return follow
 
 
 @router.delete(

--- a/backend/app/services/follower_service.py
+++ b/backend/app/services/follower_service.py
@@ -8,6 +8,9 @@ from sqlalchemy import and_, select, func
 # pyrefly: ignore [missing-import]
 from sqlalchemy.orm import Session
 
+# pyrefly: ignore [missing-import]
+from sqlalchemy.exc import IntegrityError
+
 from app.models.activity import ActivityType
 from app.models.follower import Follower
 from app.models.user import User
@@ -30,6 +33,23 @@ class FollowerService:
         follower_id: uuid.UUID,
         following_id: uuid.UUID,
     ) -> Follower:
+        """
+        Follow a user, once.
+
+        Idempotent: following someone you already follow returns the existing
+        relationship and does nothing else -- no second activity entry, no
+        second notification.
+
+        The insert runs inside a SAVEPOINT because a `SELECT` first is
+        check-then-act, and two concurrent requests from the same user both
+        pass it. Losing that race raises `IntegrityError` from the unique
+        constraint, and an unhandled one puts the whole `Session` into a
+        rolled-back state -- every later statement in the request, including
+        the response serialiser and the request-logging middleware, then fails
+        with `PendingRollbackError` instead. The savepoint confines the rollback
+        to the insert, so the outer transaction survives and the request can go
+        on to answer normally.
+        """
 
         if BlockService.is_blocked(db, follower_id, following_id):
             raise HTTPException(
@@ -37,13 +57,30 @@ class FollowerService:
                 detail="Cannot follow a user who has blocked you or whom you have blocked.",
             )
 
+        existing = FollowerService.get_relationship(db, follower_id, following_id)
+        if existing is not None:
+            return existing
+
         relationship = Follower(
             follower_id=follower_id,
             following_id=following_id,
         )
 
-        db.add(relationship)
-        db.flush()
+        try:
+            with db.begin_nested():
+                db.add(relationship)
+                db.flush()
+        except IntegrityError:
+            # Somebody else inserted the same pair between the check above and
+            # this flush. Their row is as good as ours, and they have already
+            # recorded the activity and sent the notification.
+            existing = FollowerService.get_relationship(db, follower_id, following_id)
+            if existing is None:
+                # A different constraint then -- a dangling user id, say. Not
+                # ours to swallow.
+                raise
+            return existing
+
         db.refresh(relationship)
 
         following_user = db.get(User, following_id)
@@ -63,7 +100,8 @@ class FollowerService:
             color="success",
         )
 
-        # Trigger notification
+        # The only place a follow notification is sent. The router used to send
+        # a second one of its own, with a different title and a different link.
         follower = db.get(User, follower_id)
         follower_name = (
             f"{follower.first_name} {follower.last_name}" if follower else "Someone"

--- a/backend/tests/test_follow_idempotency.py
+++ b/backend/tests/test_follow_idempotency.py
@@ -1,0 +1,220 @@
+"""
+One follow, one notification, and a duplicate that does not take the request
+with it (#1317).
+
+Two faults lived in this flow. `FollowerService.follow_user` sent a
+notification and then the router sent a second one of its own -- same event,
+different title, different link, two rows in the recipient's list. And
+`follow_user` inserted unconditionally, so a duplicate raised `IntegrityError`
+from the unique constraint with nothing to catch it; the `Session` went into a
+rolled-back state and every later statement in the request failed with
+`PendingRollbackError`, including ones with nothing to do with following
+anybody.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from app.models.follower import Follower
+from app.models.user import User
+from app.services.follower_service import FollowerService
+from app.services.notification_service import NotificationService
+
+
+def _user(db, username: str) -> User:
+    user = User(
+        first_name=username.capitalize(),
+        last_name="User",
+        username=username,
+        email=f"{username}@example.com",
+        password_hash="hashed",
+        is_active=True,
+        is_verified=True,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@pytest.fixture()
+def enqueued(monkeypatch) -> list[dict]:
+    """
+    Record every notification handed to `NotificationService.enqueue`.
+
+    Counted at the enqueue rather than by reading rows back, because the fault
+    is at the enqueue -- the service sent one and the router sent another. It
+    also keeps these tests off the dispatch path, which reaches for Celery,
+    falls back to running the task inline against `SessionLocal`, and is
+    therefore sensitive to whatever the previous test in the session did to
+    that engine.
+    """
+    calls: list[dict] = []
+
+    def record(db, **kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr(NotificationService, "enqueue", staticmethod(record))
+    return calls
+
+
+def _relationships(
+    db, follower_id: uuid.UUID, following_id: uuid.UUID
+) -> list[Follower]:
+    return list(
+        db.scalars(
+            select(Follower).where(
+                Follower.follower_id == follower_id,
+                Follower.following_id == following_id,
+            )
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# One follow, one notification
+# ---------------------------------------------------------------------------
+
+
+def test_a_follow_notifies_once(db, enqueued):
+    alice = _user(db, "alice")
+    bob = _user(db, "bob")
+
+    FollowerService.follow_user(db, follower_id=alice.id, following_id=bob.id)
+
+    assert len(enqueued) == 1
+    assert enqueued[0]["recipient_id"] == bob.id
+    assert enqueued[0]["sender_id"] == alice.id
+
+
+def test_the_notification_carries_the_service_wording(db, enqueued):
+    """
+    The router's copy said "New follower" and linked to `/users/<uuid>`; the
+    service says "New Follower" and links to the profile. Two spellings of the
+    same event is how you notice there are two of them.
+    """
+    alice = _user(db, "alice")
+    bob = _user(db, "bob")
+
+    FollowerService.follow_user(db, follower_id=alice.id, following_id=bob.id)
+
+    assert enqueued[0]["title"] == "New Follower"
+    assert enqueued[0]["action_url"] == "/profile/alice"
+
+
+def test_following_over_the_api_notifies_once(client, register_and_login, enqueued):
+    """
+    The end the bug was reported from. The router used to add its own enqueue
+    on the line after the service call, so this was 2.
+    """
+    _, alice_token = register_and_login("alice@example.com", "alice")
+    bob_id, _ = register_and_login("bob@example.com", "bob")
+
+    response = client.post(
+        f"/api/followers/{bob_id}",
+        headers={"Authorization": f"Bearer {alice_token}"},
+    )
+
+    assert response.status_code == 201
+    assert len(enqueued) == 1
+    assert enqueued[0]["recipient_id"] == uuid.UUID(bob_id)
+
+
+# ---------------------------------------------------------------------------
+# Duplicates
+# ---------------------------------------------------------------------------
+
+
+def test_following_twice_creates_one_relationship(db):
+    alice = _user(db, "alice")
+    bob = _user(db, "bob")
+
+    first = FollowerService.follow_user(db, follower_id=alice.id, following_id=bob.id)
+    second = FollowerService.follow_user(db, follower_id=alice.id, following_id=bob.id)
+    db.commit()
+
+    assert first.id == second.id
+    assert len(_relationships(db, alice.id, bob.id)) == 1
+
+
+def test_following_twice_notifies_once(db, enqueued):
+    alice = _user(db, "alice")
+    bob = _user(db, "bob")
+
+    FollowerService.follow_user(db, follower_id=alice.id, following_id=bob.id)
+    FollowerService.follow_user(db, follower_id=alice.id, following_id=bob.id)
+
+    assert len(enqueued) == 1
+
+
+def test_following_twice_leaves_the_session_usable(db):
+    """
+    The `PendingRollbackError` this pins is raised by the *next* statement, not
+    the failing one -- which is why the symptom was a 500 from somewhere else
+    entirely.
+    """
+    alice = _user(db, "alice")
+    bob = _user(db, "bob")
+
+    FollowerService.follow_user(db, follower_id=alice.id, following_id=bob.id)
+    FollowerService.follow_user(db, follower_id=alice.id, following_id=bob.id)
+
+    assert FollowerService.follower_count(db, user_id=bob.id) == 1
+    assert db.get(User, alice.id) is not None
+
+
+def test_losing_the_insert_race_returns_the_winning_row(db, monkeypatch, enqueued):
+    """
+    The router's `SELECT` before the insert is check-then-act, and so is the
+    one inside `follow_user`. Two concurrent requests both pass it; one of them
+    hits the unique constraint.
+
+    Simulated by making the existence check answer "no" while the row is there,
+    which is exactly what the losing request sees.
+    """
+    alice = _user(db, "alice")
+    bob = _user(db, "bob")
+
+    winner = Follower(follower_id=alice.id, following_id=bob.id)
+    db.add(winner)
+    db.commit()
+    db.refresh(winner)
+
+    real_get_relationship = FollowerService.get_relationship
+    calls = {"n": 0}
+
+    def blind_once(session, follower_id, following_id):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return None
+        return real_get_relationship(session, follower_id, following_id)
+
+    monkeypatch.setattr(FollowerService, "get_relationship", staticmethod(blind_once))
+
+    result = FollowerService.follow_user(db, follower_id=alice.id, following_id=bob.id)
+
+    assert result.id == winner.id
+    assert len(_relationships(db, alice.id, bob.id)) == 1
+    assert enqueued == []
+    # And the session is still good afterwards, which is the whole point.
+    assert FollowerService.follower_count(db, user_id=bob.id) == 1
+
+
+def test_an_integrity_error_that_is_not_a_duplicate_still_propagates(db, monkeypatch):
+    """
+    The `except IntegrityError` is for one specific collision. A dangling
+    foreign key is a different problem and swallowing it would hide it.
+    """
+    alice = _user(db, "alice")
+
+    monkeypatch.setattr(
+        FollowerService, "get_relationship", staticmethod(lambda *a, **k: None)
+    )
+
+    with pytest.raises(IntegrityError):
+        FollowerService.follow_user(db, follower_id=alice.id, following_id=uuid.uuid4())


### PR DESCRIPTION
Fixes #1317.

## Fault 1 — two notifications, one follow

The service notified (`follower_service.py:73`), and then the router notified
again on the line after the call (`routers/followers.py:57`). Same event, twice,
differing in every field:

| | service | router |
|---|---|---|
| title | `New Follower` | `New follower` |
| message | `Ada Lovelace started following you.` | `ada started following you.` |
| `action_url` | `/profile/ada` | `/users/9f1c…` |

Two rows in the recipient's list for one follow, linking to two different pages,
ordered by whichever write landed first.

The router's copy goes. The service has owned this since it was written, uses
the display name rather than the handle, and links to the profile the follower
actually has — it is the better of the two, and more to the point there should
only be one.

Its `except Exception: print(f"ENQUEUE ERROR: {e}")` goes with it.
`NotificationService.enqueue` already catches a broker outage, falls back to
inline dispatch, and logs through `structlog`; the try/except added nothing
except a stdout write no log query would ever find.

## Fault 2 — the duplicate took the request with it

`follow_user` inserted unconditionally. The router's `SELECT` in front of it is
check-then-act, so two concurrent `POST /api/followers/{id}` from the same user
both pass it and one hits the unique constraint on
`(follower_id, following_id)`.

The `IntegrityError` itself is not the interesting part. An unhandled one leaves
the `Session` in a rolled-back state, and SQLAlchemy raises
`PendingRollbackError` on the *next* statement — so the visible failure is the
response serialiser reading a lazy attribute, or the activity write, or the
request-logging middleware's insert. A 500 from a line with nothing to do with
following anybody, and the request's audit trail gone with it.

So `follow_user` is idempotent now, and the insert runs inside a `SAVEPOINT`:

```python
existing = FollowerService.get_relationship(db, follower_id, following_id)
if existing is not None:
    return existing

try:
    with db.begin_nested():
        db.add(relationship)
        db.flush()
except IntegrityError:
    existing = FollowerService.get_relationship(db, follower_id, following_id)
    if existing is None:
        raise
    return existing
```

The `SELECT` handles the ordinary "already following" case without a round trip
through an exception. The savepoint handles the race the `SELECT` cannot: losing
it rolls back to the savepoint rather than the transaction, so the outer
transaction survives and the request answers normally. The loser returns the
winner's row and sends nothing — the winner already recorded the activity and
sent the notification.

The re-`raise` when the row still is not there matters. `IntegrityError` covers
every constraint on the table, and a dangling `following_id` is a different
problem; swallowing it would turn a bad request into a silent no-op.

The router keeps its 400 for the common case. It is a nicer answer than a
duplicate 201 and it is now only an optimisation, not the thing standing between
the API and a poisoned session.

## Tests

`backend/tests/test_follow_idempotency.py`, 8 cases: one follow enqueues one
notification, with the service's wording and link; the same over the API, which
is the end the bug was reported from and where the count was 2; following twice
creates one relationship, enqueues once, and leaves the session usable;
losing the insert race returns the winning row and sends nothing; and an
`IntegrityError` that is not a duplicate still propagates.

Counted at `NotificationService.enqueue` rather than by reading rows back. The
fault is at the enqueue, and it keeps these tests off the dispatch path — which
reaches for Celery, falls back to running the task inline against `SessionLocal`,
and is therefore sensitive to what the previous test in the session did to that
engine. Asserting on rows made them fail depending on file order, which is not a
property of the code under test.

```console
$ cd backend && python -m pytest tests/test_follow_idempotency.py -q
8 passed

$ python -m pytest app/tests/test_followers.py::test_prevent_duplicate_follow -q
1 passed          # PendingRollbackError on main
```

## Not fixed here

Two failures in files this touches, both pre-existing on `main` and both a
different question:

- `app/tests/test_followers.py::test_mutual_followers_service` asserts that
  `mutual_followers(a, b)` means "a and b follow each other". The service
  implements "people a and b both follow". The second reading is the one that is
  not already answered by `GET /followers/status/{id}`, but the endpoint is
  undocumented and unused by the frontend, so picking one is a decision, not a
  bug fix.
- `app/tests/test_notifications.py::test_follow_notification` gets past its
  first assertion now and fails on a later one, which asserts that
  `NotificationService.create_notification` deduplicates. Only
  `DatabaseChannel.send` does. That inconsistency is real and is its own change.
