### PR TITLE
fix(webhooks): sign the bytes we send, and only send them where we checked

### DIFF
--- a/backend/app/routers/webhooks.py
+++ b/backend/app/routers/webhooks.py
@@ -15,6 +15,7 @@ from app.schemas.webhook import (
     WebhookMetricsResponse,
 )
 from app.services.webhook_service import WebhookService
+from app.utils.url_safety import UnsafeURL
 
 router = APIRouter(
     prefix="/webhooks",
@@ -34,14 +35,23 @@ def dispatch_webhook(
     db: Session = Depends(get_database),
 ):
     """Dispatch a webhook to a target URL with automatic retries and dead letter queue fallback."""
-    return WebhookService.dispatch_webhook(
-        db=db,
-        event_type=params.event_type,
-        target_url=params.target_url,
-        payload=params.payload,
-        headers=params.headers,
-        max_retries=params.max_retries,
-    )
+    try:
+        return WebhookService.dispatch_webhook(
+            db=db,
+            event_type=params.event_type,
+            target_url=params.target_url,
+            payload=params.payload,
+            headers=params.headers,
+            max_retries=params.max_retries,
+        )
+    except UnsafeURL as exc:
+        # 400, not 500: the caller sent a destination we will not connect to,
+        # and the message from `url_safety` says which rule it broke without
+        # echoing back what the host resolved to.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
 
 
 @router.post(

--- a/backend/app/services/webhook_service.py
+++ b/backend/app/services/webhook_service.py
@@ -16,6 +16,12 @@ from app.models.webhook import (
     WebhookDeadLetterQueue,
     WebhookDeliveryStatus,
 )
+from app.utils.url_safety import (
+    SafeTarget,
+    UnsafeURL,
+    pin_target,
+    validate_outbound_url,
+)
 
 logger = structlog.get_logger("devlink.webhooks")
 
@@ -39,18 +45,43 @@ def calculate_backoff_delay(
 
 
 class WebhookService:
+    #: How a destination is checked before we connect to it.
+    #:
+    #: A class attribute rather than a direct call so it can be substituted:
+    #: validation resolves the hostname, and a unit test that depends on DNS is
+    #: a unit test that fails on a train.
+    validate_target = staticmethod(validate_outbound_url)
+
+    @classmethod
+    def canonical_body(cls, payload: Dict[str, Any] | str) -> bytes:
+        """
+        The bytes we sign, which are the bytes we send.
+
+        There is only one function here on purpose. The signature used to be
+        computed over ``json.dumps(payload, sort_keys=True)`` while the request
+        body came from ``httpx``'s own serialisation of the same dict -- which
+        uses ``separators=(",", ":")``, ``ensure_ascii=False`` and insertion
+        order. Three differences, any one of which is enough to make the
+        signature un-verifiable by the only sane procedure a receiver has: HMAC
+        the bytes you received and compare.
+
+        ``sort_keys`` is kept so the same payload signs identically on a retry
+        regardless of dict ordering, and the separators match what a receiver
+        gets so nothing has to reverse-engineer our serialiser.
+        """
+        if isinstance(payload, (dict, list)):
+            return json.dumps(
+                payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+            ).encode("utf-8")
+        return str(payload).encode("utf-8")
+
     @classmethod
     def generate_signature(cls, payload: Dict[str, Any] | str, secret: str) -> str:
         """
-        Generates an HMAC-SHA256 signature for webhook payload verification.
+        Generates an HMAC-SHA256 signature over the exact request body.
         """
-        if isinstance(payload, dict):
-            payload_bytes = json.dumps(payload, sort_keys=True).encode("utf-8")
-        else:
-            payload_bytes = str(payload).encode("utf-8")
-
         signature = hmac.new(
-            secret.encode("utf-8"), payload_bytes, hashlib.sha256
+            secret.encode("utf-8"), cls.canonical_body(payload), hashlib.sha256
         ).hexdigest()
         return f"sha256={signature}"
 
@@ -65,6 +96,11 @@ class WebhookService:
         secret: Optional[str] = None,
         max_retries: int = 5,
     ) -> WebhookDelivery:
+        # Checked here as well as in `_execute_delivery` so the caller gets a
+        # readable rejection instead of a stored delivery that quietly failed.
+        # The one in `_execute_delivery` is the guard; this one is the message.
+        cls.validate_target(target_url)
+
         # Include signature header if a shared secret is provided
         req_headers = headers or {}
         if secret:
@@ -93,13 +129,78 @@ class WebhookService:
 
     @classmethod
     def _send_http_request(
-        cls, url: str, payload: dict, headers: dict
+        cls, target: SafeTarget, body: bytes, headers: dict
     ) -> httpx.Response:
-        with httpx.Client(timeout=10.0) as client:
-            return client.post(url, json=payload, headers=headers)
+        """
+        POST the already-serialised body to a validated target.
+
+        Takes ``bytes`` rather than a dict because the caller has already
+        decided what the bytes are -- see :meth:`canonical_body`. Letting
+        ``httpx`` serialise here is what made the signature describe a
+        different payload than the one on the wire.
+
+        The connection is pinned to the address validation approved, the same
+        way link previews do it: handing the hostname to ``httpx`` would let it
+        resolve a second time, and a short-TTL record that answers
+        public-then-private turns the check into decoration.
+
+        Redirects are not followed. A 302 to 169.254.169.254 is the whole
+        attack, and re-validating each hop is not worth it for a webhook -- a
+        receiver that wants us somewhere else can say so in its configuration.
+        """
+        pinned = pin_target(target)
+
+        with httpx.Client(timeout=10.0, follow_redirects=False) as client:
+            return client.post(
+                pinned.url,
+                content=body,
+                headers={**headers, **pinned.headers},
+                extensions=pinned.extensions,
+            )
+
+    @classmethod
+    def _refuse_delivery(
+        cls, db: Session, delivery: WebhookDelivery, reason: str
+    ) -> bool:
+        """
+        Record a delivery we will not attempt, and stop.
+
+        Exhausted rather than failed, because retrying changes nothing: the
+        destination is not one we are willing to connect to, and the backoff
+        schedule would otherwise turn one rejected request into several probes
+        spread over an hour.
+
+        Nothing is written to `response_status_code` or `response_body`. Those
+        are the fields `GET /webhooks/deliveries` hands back, and the point of
+        refusing is that we learned nothing about the destination worth
+        returning.
+        """
+        delivery.status = WebhookDeliveryStatus.EXHAUSTED
+        delivery.next_retry_at = None
+        delivery.last_attempt_at = datetime.now(timezone.utc)
+        delivery.error_message = f"Refused: {reason}"
+        delivery.response_status_code = None
+        delivery.response_body = None
+        db.commit()
+
+        logger.warning(
+            "webhook_target_refused",
+            delivery_id=str(delivery.id),
+            target_url=delivery.target_url,
+            reason=reason,
+        )
+
+        cls._move_to_dlq(db, delivery)
+        return False
 
     @classmethod
     def _execute_delivery(cls, db: Session, delivery: WebhookDelivery) -> bool:
+        # Before the attempt counter moves: nothing was attempted.
+        try:
+            target = cls.validate_target(delivery.target_url)
+        except UnsafeURL as exc:
+            return cls._refuse_delivery(db, delivery, str(exc))
+
         now = datetime.now(timezone.utc)
         delivery.attempts += 1
         delivery.last_attempt_at = now
@@ -118,7 +219,7 @@ class WebhookService:
 
         try:
             response = cls._send_http_request(
-                delivery.target_url, delivery.payload, req_headers
+                target, cls.canonical_body(delivery.payload), req_headers
             )
             status_code = response.status_code
             resp_text = response.text[:2000] if response.text else ""

--- a/backend/tests/test_webhook_retry_dlq.py
+++ b/backend/tests/test_webhook_retry_dlq.py
@@ -11,6 +11,29 @@ from app.models.webhook import (
 )
 from app.services.webhook_service import WebhookService, calculate_backoff_delay
 from app.core.security import create_access_token
+from app.utils.url_safety import validate_outbound_url
+
+
+@pytest.fixture(autouse=True)
+def offline_url_validation(monkeypatch):
+    """
+    Apply the real destination rules without asking DNS.
+
+    `WebhookService.validate_target` resolves the hostname, and these tests
+    post to `api.example.com`, which does not exist. Substituting the resolver
+    rather than the whole validator keeps every other rule live -- scheme, port,
+    credentials, and the private-address check -- so a test that points at
+    something it should not still fails.
+    """
+
+    def resolver(host: str) -> tuple[str, ...]:
+        return ("93.184.216.34",)  # a public address, and not one we talk to
+
+    monkeypatch.setattr(
+        WebhookService,
+        "validate_target",
+        staticmethod(lambda url: validate_outbound_url(url, resolver=resolver)),
+    )
 
 
 @pytest.fixture

--- a/backend/tests/test_webhook_signature_and_targets.py
+++ b/backend/tests/test_webhook_signature_and_targets.py
@@ -1,0 +1,301 @@
+"""
+The bytes we sign are the bytes we send, and we only send them somewhere we
+checked (#1319).
+
+Two faults, independent, each enough on its own to make the feature not do what
+it says.
+
+`generate_signature` hashed `json.dumps(payload, sort_keys=True)` while
+`_send_http_request` handed the dict to `httpx` and let it serialise again.
+Different separators, different `ensure_ascii`, different key order -- so the
+`X-DevLink-Signature` header described a payload that was never transmitted and
+no receiver could verify it.
+
+And `_send_http_request` posted wherever it was told. `app/utils/url_safety.py`
+had done this job for link previews since #1196; webhook delivery never used it,
+while `POST /api/webhooks/dispatch` takes a caller-supplied URL from any
+authenticated user and `GET /api/webhooks/deliveries` hands the response body
+back to them.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import ipaddress
+import json
+import uuid
+
+import httpx
+import pytest
+from sqlalchemy import select
+
+from app.models.webhook import (
+    WebhookDeadLetterQueue,
+    WebhookDelivery,
+    WebhookDeliveryStatus,
+)
+from app.services.webhook_service import WebhookService
+from app.utils.url_safety import UnsafeURL, validate_outbound_url
+
+SECRET = "shared-secret"
+
+# A payload with every difference between the two serialisers in it: keys out
+# of order, and a character that `ensure_ascii` would escape.
+PAYLOAD = {"b": 1, "a": "café", "c": [1, 2], "nested": {"z": True, "y": None}}
+
+
+@pytest.fixture
+def offline_validation(monkeypatch):
+    """The real rules, with a stub resolver, so nothing here needs DNS."""
+
+    addresses = {
+        "metadata.internal": ("169.254.169.254",),
+        "localhost": ("127.0.0.1",),
+        "example.com": ("93.184.216.34",),
+    }
+
+    def resolver(host: str) -> tuple[str, ...]:
+        # An IP literal resolves to itself, which is what the real resolver
+        # does and what makes the private-address rule apply to it.
+        try:
+            ipaddress.ip_address(host)
+        except ValueError:
+            pass
+        else:
+            return (host,)
+
+        return addresses.get(host, ("93.184.216.34",))
+
+    monkeypatch.setattr(
+        WebhookService,
+        "validate_target",
+        staticmethod(lambda url: validate_outbound_url(url, resolver=resolver)),
+    )
+    return resolver
+
+
+# ---------------------------------------------------------------------------
+# Signature over the transmitted body
+# ---------------------------------------------------------------------------
+
+
+class TestSignature:
+    def _verify_as_a_receiver_would(self, body: bytes, header: str) -> bool:
+        """
+        The only procedure a receiver has: HMAC what arrived, compare.
+
+        No knowledge of how we serialise, because a receiver has none.
+        """
+        expected = hmac.new(SECRET.encode("utf-8"), body, hashlib.sha256).hexdigest()
+        return hmac.compare_digest(f"sha256={expected}", header)
+
+    def test_the_signature_verifies_against_the_body_we_send(self):
+        body = WebhookService.canonical_body(PAYLOAD)
+        header = WebhookService.generate_signature(PAYLOAD, SECRET)
+
+        assert self._verify_as_a_receiver_would(body, header) is True
+
+    def test_the_body_httpx_puts_on_the_wire_is_the_body_we_signed(self):
+        """
+        The actual regression. Building the request is what the old code let
+        `httpx` do from the dict, and the bytes came out different.
+        """
+        body = WebhookService.canonical_body(PAYLOAD)
+        request = httpx.Request("POST", "https://example.com/hook", content=body)
+
+        assert request.content == body
+        assert self._verify_as_a_receiver_would(
+            request.content, WebhookService.generate_signature(PAYLOAD, SECRET)
+        )
+
+    def test_letting_httpx_serialise_would_not_have_verified(self):
+        """
+        Pins the bug itself, so nobody reintroduces `json=payload` here and
+        assumes it is equivalent.
+        """
+        httpx_body = httpx.Request(
+            "POST", "https://example.com/hook", json=PAYLOAD
+        ).content
+        old_signed_bytes = json.dumps(PAYLOAD, sort_keys=True).encode("utf-8")
+
+        assert httpx_body != old_signed_bytes
+
+    def test_key_order_does_not_change_the_signature(self):
+        """A retry rebuilds the payload from JSONB; ordering must not matter."""
+        reordered = {k: PAYLOAD[k] for k in reversed(list(PAYLOAD))}
+
+        assert WebhookService.generate_signature(
+            reordered, SECRET
+        ) == WebhookService.generate_signature(PAYLOAD, SECRET)
+
+    def test_a_different_payload_gives_a_different_signature(self):
+        other = dict(PAYLOAD, b=2)
+
+        assert WebhookService.generate_signature(
+            other, SECRET
+        ) != WebhookService.generate_signature(PAYLOAD, SECRET)
+
+    def test_a_different_secret_gives_a_different_signature(self):
+        assert WebhookService.generate_signature(
+            PAYLOAD, "other"
+        ) != WebhookService.generate_signature(PAYLOAD, SECRET)
+
+    def test_a_string_payload_is_signed_as_given(self):
+        raw = "already serialised"
+
+        assert WebhookService.canonical_body(raw) == raw.encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Where we are willing to connect
+# ---------------------------------------------------------------------------
+
+
+def _delivery(db, url: str) -> WebhookDelivery:
+    row = WebhookDelivery(
+        id=uuid.uuid4(),
+        event_type="test.event",
+        target_url=url,
+        payload={"a": 1},
+        status=WebhookDeliveryStatus.PENDING,
+        attempts=0,
+        max_retries=3,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+class TestDestinationValidation:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://metadata.internal/latest/meta-data/",  # resolves link-local
+            "http://127.0.0.1/hook",
+            "http://localhost/hook",
+            "file:///etc/passwd",
+            "ftp://example.com/hook",
+            "https://user:pass@example.com/hook",
+            "https://example.com:9200/hook",
+        ],
+    )
+    def test_dispatch_refuses_a_destination_we_will_not_connect_to(
+        self, db, offline_validation, url
+    ):
+        with pytest.raises(UnsafeURL):
+            WebhookService.dispatch_webhook(
+                db=db,
+                event_type="test.event",
+                target_url=url,
+                payload={"a": 1},
+            )
+
+        # And nothing was recorded, because nothing was attempted.
+        assert db.scalars(select(WebhookDelivery)).all() == []
+
+    def test_the_api_answers_400_rather_than_storing_a_failure(
+        self, client, register_and_login, offline_validation
+    ):
+        _, token = register_and_login("hooker@example.com", "hooker")
+
+        response = client.post(
+            "/api/webhooks/dispatch",
+            json={
+                "event_type": "test.event",
+                "target_url": "http://metadata.internal/latest/meta-data/",
+                "payload": {"a": 1},
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert response.status_code == 400
+        assert "non-public" in response.json()["detail"]
+
+    def test_a_retry_revalidates(self, db, offline_validation, monkeypatch):
+        """
+        A row can already be in the table -- from before this check, or from a
+        DNS answer that has since changed. `process_pending_retries` must not
+        take the stored URL on trust.
+        """
+        delivery = _delivery(db, "http://metadata.internal/latest/meta-data/")
+
+        def explode(*args, **kwargs):
+            raise AssertionError("should not have reached the network")
+
+        monkeypatch.setattr(WebhookService, "_send_http_request", explode)
+
+        assert WebhookService._execute_delivery(db, delivery) is False
+
+        db.refresh(delivery)
+        assert delivery.status == WebhookDeliveryStatus.EXHAUSTED
+        assert delivery.attempts == 0
+        assert "Refused" in delivery.error_message
+
+    def test_a_refused_delivery_returns_nothing_about_the_destination(
+        self, db, offline_validation
+    ):
+        """
+        `response_body` is what `GET /webhooks/deliveries` hands back, and it
+        is what turned this from a blind SSRF into a read primitive. A refusal
+        must leave it empty rather than explaining what it found.
+        """
+        delivery = _delivery(db, "http://metadata.internal/latest/meta-data/")
+
+        WebhookService._execute_delivery(db, delivery)
+
+        db.refresh(delivery)
+        assert delivery.response_body is None
+        assert delivery.response_status_code is None
+
+    def test_a_refused_delivery_is_not_retried(self, db, offline_validation):
+        """
+        Exhausted, not failed. A backoff schedule would turn one rejected
+        request into several probes spread over an hour.
+        """
+        delivery = _delivery(db, "http://metadata.internal/latest/meta-data/")
+
+        WebhookService._execute_delivery(db, delivery)
+
+        db.refresh(delivery)
+        assert delivery.next_retry_at is None
+        assert WebhookService.process_pending_retries(db=db)["processed"] == 0
+
+    def test_a_refused_delivery_is_recorded_in_the_dlq(self, db, offline_validation):
+        delivery = _delivery(db, "http://metadata.internal/latest/meta-data/")
+
+        WebhookService._execute_delivery(db, delivery)
+
+        entry = db.scalar(
+            select(WebhookDeadLetterQueue).where(
+                WebhookDeadLetterQueue.delivery_id == delivery.id
+            )
+        )
+        assert entry is not None
+        assert "Refused" in entry.failure_reason
+
+    def test_an_allowed_destination_still_goes_through(
+        self, db, offline_validation, monkeypatch
+    ):
+        sent = {}
+
+        def capture(target, body, headers):
+            sent["target"] = target
+            sent["body"] = body
+            sent["headers"] = headers
+            return httpx.Response(200, text="ok")
+
+        monkeypatch.setattr(WebhookService, "_send_http_request", staticmethod(capture))
+
+        delivery = WebhookService.dispatch_webhook(
+            db=db,
+            event_type="test.event",
+            target_url="https://example.com/hook",
+            payload=PAYLOAD,
+        )
+
+        assert delivery.status == WebhookDeliveryStatus.DELIVERED
+        assert sent["body"] == WebhookService.canonical_body(PAYLOAD)
+        assert sent["target"].host == "example.com"
+        assert sent["headers"]["Content-Type"] == "application/json"


### PR DESCRIPTION
Fixes #1319.

Two faults, independent, each enough on its own to make the feature not do what
it says.

## Fault 1 — the signature described a payload nobody received

`generate_signature` serialised the payload itself; `_send_http_request` handed
the same dict to `httpx` and let it serialise again. `httpx` uses
`separators=(",", ":")`, `ensure_ascii=False` and insertion order; `json.dumps`
defaults to `", "` / `": "`, `ensure_ascii=True`, and here `sort_keys=True`.

```console
$ python -c '
import json, httpx
p = {"b": 1, "a": "é", "c": [1, 2]}
print("signed:", json.dumps(p, sort_keys=True).encode())
print("sent  :", httpx.Request("POST", "http://x/", json=p).content)'
signed: b'{"a": "\\u00e9", "b": 1, "c": [1, 2]}'
sent  : b'{"b":1,"a":"\xc3\xa9","c":[1,2]}'
```

A receiver's only verification procedure is: HMAC the bytes you received,
compare to `X-DevLink-Signature`. It could never match. The header was
decoration, and any receiver that appeared to work had either stopped checking
or reverse-engineered our `json.dumps` call — which then breaks the first time a
payload contains a non-ASCII character.

There is one serialiser now, `canonical_body`, and both sides use it.
`sort_keys` stays so a retry rebuilt from JSONB signs identically regardless of
dict ordering, and the separators match what the receiver actually gets.

## Fault 2 — arbitrary destination, with the answer returned

`_send_http_request` posted wherever it was told. `app/utils/url_safety.py`
exists and does exactly this job — scheme and port allowlists, credential
rejection, resolution of every address behind the host, a public-address check,
and a pinned connection so DNS cannot answer differently between check and
connect. `link_preview_service` has routed every fetch through it since #1196.
Webhook delivery never did.

What makes it more than a blind SSRF is that `_execute_delivery` keeps the
answer — `response.text[:2000]` and the status code — and
`GET /api/webhooks/deliveries` hands both back. Both endpoints are open to any
authenticated user:

```console
$ curl -XPOST -H "Authorization: Bearer $TOKEN" localhost:8000/api/webhooks/dispatch \
    -d '{"event_type":"x","target_url":"http://169.254.169.254/latest/meta-data/","payload":{}}'
$ curl -H "Authorization: Bearer $TOKEN" localhost:8000/api/webhooks/deliveries \
    | jq '.items[0].response_body'
```

Two kilobytes of any internal HTTP endpoint the pods can reach. The failure
side is a port scanner too — `Network/HTTP Exception: ...` for a closed port
versus a real status for an open one, recorded in `error_message` — and
`process_pending_retries` re-sends on a backoff, so one request buys several
probes.

### Where the check went

`_execute_delivery`, because it is the one place every path reaches: dispatch,
`process_pending_retries`, `replay_dlq_entry` and `replay_all_dlq_entries`. A
row already in the table — written before this check, or pointing at a DNS
answer that has since moved — is rechecked rather than trusted.

Before the attempt counter moves, since nothing was attempted. The connection is
then pinned to the address validation approved, the way link previews do it, and
redirects are not followed: a 302 to `169.254.169.254` is the whole attack, and
a webhook receiver that wants us somewhere else can say so in its configuration.

A refused destination is **Exhausted**, not Failed. Retrying changes nothing,
and the backoff schedule would turn one rejected request into several probes
spread over an hour. `response_body` and `response_status_code` stay `None` —
the point of refusing is that we learned nothing about the destination worth
handing back.

`dispatch_webhook` also checks up front, so the caller gets a 400 naming the
rule it broke rather than a stored delivery that quietly failed.

## `validate_target`

A class attribute rather than a direct call, so the resolver can be substituted.
Validation resolves the hostname, and a unit test that depends on DNS is a unit
test that fails on a train — `tests/test_webhook_retry_dlq.py` posts to
`api.example.com`, which does not resolve. Substituting the *resolver* rather
than the validator keeps every other rule live, so a test that points somewhere
it should not still fails.

## Tests

`backend/tests/test_webhook_signature_and_targets.py`, 20 cases.

Signature: it verifies the way a receiver would; the body `httpx` actually puts
on the wire is the body that was signed; key order does not change it; payload
and secret changes do. Plus one that pins the bug itself — asserting that
letting `httpx` serialise produces different bytes than the old signing did — so
nobody puts `json=payload` back assuming it is equivalent.

Destinations: dispatch refuses link-local, loopback, `localhost`, `file://`,
`ftp://`, credentials in the URL, and a non-allowlisted port, storing nothing;
the API answers 400; a retry revalidates and never reaches the network; a
refusal returns nothing about the destination, is not retried, and lands in the
DLQ; and an allowed destination still goes through with the canonical body and
the right `Content-Type`.

```console
$ cd backend && python -m pytest tests/test_webhook_signature_and_targets.py tests/test_webhook_retry_dlq.py -q
26 passed
```

## Not done here

The router still does not pass `secret`, so signing remains unreachable through
the API. Accepting a shared secret over the wire is a decision with its own
questions — where it is stored, whether it is per-endpoint — and belongs with
whoever wants the feature, not in a fix for the signature being wrong.
