### PR TITLE
fix(upload): stop ImageCropUploadModal resetting state it does not own

### DIFF
--- a/frontend/src/components/shared/ImageCropUploadModal.tsx
+++ b/frontend/src/components/shared/ImageCropUploadModal.tsx
@@ -54,16 +54,23 @@ export function ImageCropUploadModal({
   const cropPreset = CROP_PRESETS[mode === "banner" ? "banner" : "avatar"];
   const modalTitle = title ?? (mode === "banner" ? "Upload Banner Image" : "Upload Avatar Image");
 
-  // Reset state when modal opens/closes
+  // Reset state when modal opens/closes.
+  //
+  // This used to also call setZoom / setRotation / setPanX / setPanY. None of
+  // them exist here -- that state belongs to ImageCropper, which owns it and is
+  // reached through cropperRef -- so the effect threw ReferenceError on the
+  // first render, and the guard is `!isOpen`, which is true on mount. A modal
+  // that is rendered closed took the throwing branch before anyone could open
+  // it (#1347).
+  //
+  // Nothing replaces them: clearing previewUrl below unmounts ImageCropper,
+  // which takes its crop state with it, and the cropper re-centres on every
+  // `src` load regardless.
   useEffect(() => {
     if (!isOpen) {
       setSelectedFile(null);
       setPreviewUrl(null);
       setError(null);
-      setZoom(1.0);
-      setRotation(0);
-      setPanX(0);
-      setPanY(0);
       setIsCameraActive(false);
       setIsUploading(false);
       setUploadProgress(0);

--- a/frontend/src/components/shared/__tests__/ImageCropUploadModal.test.tsx
+++ b/frontend/src/components/shared/__tests__/ImageCropUploadModal.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { ImageCropUploadModal } from "@/components/shared/ImageCropUploadModal";
+
+vi.mock("@/services/imageUpload", () => ({
+  uploadImage: vi.fn().mockResolvedValue("https://example.test/avatar.webp"),
+}));
+
+/**
+ * Regression tests for #1347.
+ *
+ * The reset effect called setZoom / setRotation / setPanX / setPanY, which are
+ * ImageCropper's state, not this component's. The effect is guarded on
+ * `!isOpen`, and a modal is rendered closed before it is opened, so the throw
+ * happened on mount -- `ReferenceError: setZoom is not defined` -- and took the
+ * surrounding subtree with it. Avatar and banner upload were both unusable.
+ */
+describe("ImageCropUploadModal", () => {
+  it("mounts closed without throwing", () => {
+    expect(() =>
+      render(
+        <ImageCropUploadModal
+          isOpen={false}
+          onClose={() => {}}
+          onUploadSuccess={() => {}}
+          mode="avatar"
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it("mounts closed without throwing in banner mode", () => {
+    expect(() =>
+      render(
+        <ImageCropUploadModal
+          isOpen={false}
+          onClose={() => {}}
+          onUploadSuccess={() => {}}
+          mode="banner"
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it("renders its title once opened", () => {
+    render(
+      <ImageCropUploadModal isOpen onClose={() => {}} onUploadSuccess={() => {}} mode="avatar" />,
+    );
+
+    expect(screen.getByText("Upload Avatar Image")).toBeInTheDocument();
+  });
+
+  it("survives being closed again after opening, which is when the effect reruns", () => {
+    const { rerender } = render(
+      <ImageCropUploadModal isOpen onClose={() => {}} onUploadSuccess={() => {}} mode="avatar" />,
+    );
+
+    expect(() =>
+      rerender(
+        <ImageCropUploadModal
+          isOpen={false}
+          onClose={() => {}}
+          onUploadSuccess={() => {}}
+          mode="avatar"
+        />,
+      ),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #1347.

## The bug

`ImageCropUploadModal`'s reset effect called `setZoom`, `setRotation`, `setPanX`
and `setPanY`. None of the four exist in this component. That state belongs to
`ImageCropper`, which owns it (`ImageCropper.tsx:83`) and is a *child* here,
reached through `cropperRef`.

The guard is `if (!isOpen)`, and a modal is rendered closed before anyone opens
it — so the branch that throws is the branch that runs on mount:

```
ReferenceError: setZoom is not defined
 ❯ src/components/shared/ImageCropUploadModal.tsx:63:7
     61|       setPreviewUrl(null);
     62|       setError(null);
     63|       setZoom(1.0);
       |       ^
```

The throw is inside an effect, so it propagates to the nearest boundary and
takes the surrounding subtree with it. Avatar and banner upload were both
unusable — and the settings page went with them, which is why
`settings-574.test.tsx` was failing on a test about *tabs*.

## The fix

The four lines are deleted, and nothing replaces them. Clearing `previewUrl` two
lines up unmounts `ImageCropper` (it is rendered only when `previewUrl` is
truthy), which takes its crop state with it, and the cropper re-centres on every
`src` load regardless. The crop state was never this component's to reset.

## Why it was not a type error

`tsc` does not currently reach this file — the parse failures in #1344 stop the
check earlier — and nothing in CI runs the frontend tests yet (#1316). The two
failing tests were the only signal.

## Tests

`ImageCropUploadModal.test.tsx` mounts the modal closed, in both `avatar` and
`banner` mode, renders it open, and closes it again after opening — which is
when the effect actually reruns.

```console
$ npx vitest run src/components/shared/__tests__/ImageCropUploadModal.test.tsx
 Tests  4 passed (4)
```

Put any one of the four setters back and 3 of the 4 fail.

`image-upload-experience.test.tsx` passes again as a result:

```console
$ npx vitest run .../ImageCropUploadModal.test.tsx .../image-upload-experience.test.tsx
 Test Files  2 passed (2)
      Tests  10 passed (10)
```
