### PR TITLE
fix(users): require an administrator to change account state

### DIFF
--- a/backend/alembic/versions/a3f7c1d29b48_add_user_email_verified_audit_action.py
+++ b/backend/alembic/versions/a3f7c1d29b48_add_user_email_verified_audit_action.py
@@ -1,0 +1,49 @@
+"""add user_email_verified to the auditaction enum
+
+An administrator marking an address verified without a confirmation token is a
+distinct event from the account being activated, and it is the one that decides
+whether the verified badge renders. It needs its own value rather than being
+folded into ``user_activated``.
+
+Revision ID: a3f7c1d29b48
+Revises: 1c63e6c28cf8
+Create Date: 2026-08-26 16:40:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a3f7c1d29b48"
+down_revision = "1c63e6c28cf8"
+branch_labels = None
+depends_on = None
+
+
+ENUM_NAME = "auditaction"
+NEW_VALUE = "user_email_verified"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    # SQLite (the test database) has no enum types -- the column is a VARCHAR
+    # with a CHECK constraint that SQLAlchemy renders from the Python enum, so
+    # there is nothing to alter and nothing to guard against.
+    if bind.dialect.name != "postgresql":
+        return
+
+    # ALTER TYPE ... ADD VALUE cannot run inside a transaction block on
+    # PostgreSQL below 12, and alembic wraps migrations in one. IF NOT EXISTS
+    # additionally makes this safe to re-run against a database where the value
+    # was already added by an autogenerate pass.
+    with op.get_context().autocommit_block():
+        op.execute(f"ALTER TYPE {ENUM_NAME} ADD VALUE IF NOT EXISTS '{NEW_VALUE}'")
+
+
+def downgrade() -> None:
+    # PostgreSQL has no ALTER TYPE ... DROP VALUE. Removing it would mean
+    # recreating the type and rewriting every column that uses it, which would
+    # fail anyway for any row already carrying the value. Leaving an unused
+    # label in place is harmless.
+    pass

--- a/backend/app/models/audit_log.py
+++ b/backend/app/models/audit_log.py
@@ -49,6 +49,7 @@ class AuditAction(str, Enum):
     USER_ACTIVATED = "user_activated"
     USER_BANNED = "user_banned"
     USER_UNBANNED = "user_unbanned"
+    USER_EMAIL_VERIFIED = "user_email_verified"
     SETTINGS_CHANGED = "settings_changed"
 
     # Project

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -19,9 +19,21 @@ from sqlalchemy.orm import Session
 
 from app.core.security import hash_password
 from app.core.cache import cache_manager, cached
-from app.dependencies import get_current_user, get_database, get_optional_current_user
+from app.core.rbac import SystemRole
+from app.dependencies import (
+    get_current_user,
+    get_database,
+    get_optional_current_user,
+    require_roles,
+)
 from app.middleware.rate_limit import SEARCH_LIMIT, limiter
 from app.models.user import User
+from app.schemas.user_account_state import AccountStateChangeRequest
+from app.services.account_state_service import (
+    AccountStateService,
+    RequestContext,
+    resolve_target_user,
+)
 from app.services.block_service import BlockService
 from app.schemas.user import (
     CollaborationStatus,
@@ -98,10 +110,19 @@ def check_username(
     "/",
     response_model=UserResponse,
     status_code=status.HTTP_201_CREATED,
+    summary="Create a user (administrators only)",
+    description=(
+        "Provision an account directly. This is not the sign-up route -- "
+        "`POST /api/auth/register` is, and it is the one that rate-limits, "
+        "screens the password against the breach list, and sends the "
+        "confirmation email. This route skips all three, so it is restricted "
+        "to administrators."
+    ),
 )
 def create_user(
     user: UserCreate,
     db: Session = Depends(get_database),
+    _actor: User = Depends(require_roles(SystemRole.ADMIN)),
 ):
 
     if UserService.get_by_email(db, user.email):
@@ -700,69 +721,83 @@ def hard_delete_user(
     )
 
 
+# ==========================================================
+# Administrative account state
+#
+# These three routes decide whether somebody can sign in and what the platform
+# vouches for about them, so each requires an administrator and each is
+# recorded. The transitions themselves live in ``AccountStateService`` -- the
+# router's job here is to authenticate, resolve the target, and hand over the
+# request context for the audit row.
+# ==========================================================
+
+
 @router.patch(
     "/{user_id}/activate",
     response_model=UserResponse,
+    summary="Re-enable a disabled account (administrators only)",
 )
 def activate_user(
     user_id: uuid.UUID,
+    request: Request,
+    payload: AccountStateChangeRequest | None = None,
     db: Session = Depends(get_database),
+    actor: User = Depends(require_roles(SystemRole.ADMIN)),
 ):
+    user = resolve_target_user(db, user_id)
 
-    user = UserService.get_user(db, user_id)
-
-    if user is None:
-        raise HTTPException(
-            status_code=404,
-            detail="User not found",
-        )
-    return UserService.activate_user(
+    return AccountStateService.activate(
         db,
-        user,
+        actor=actor,
+        target=user,
+        reason=payload.reason if payload else None,
+        context=RequestContext.from_request(request),
     )
 
 
 @router.patch(
     "/{user_id}/deactivate",
     response_model=UserResponse,
+    summary="Disable an account and revoke its sessions (administrators only)",
 )
 def deactivate_user(
     user_id: uuid.UUID,
+    request: Request,
+    payload: AccountStateChangeRequest | None = None,
     db: Session = Depends(get_database),
+    actor: User = Depends(require_roles(SystemRole.ADMIN)),
 ):
+    user = resolve_target_user(db, user_id)
 
-    user = UserService.get_user(db, user_id)
-
-    if user is None:
-        raise HTTPException(
-            status_code=404,
-            detail="User not found",
-        )
-    return UserService.deactivate_user(
+    return AccountStateService.deactivate(
         db,
-        user,
+        actor=actor,
+        target=user,
+        reason=payload.reason if payload else None,
+        context=RequestContext.from_request(request),
     )
 
 
 @router.patch(
     "/{user_id}/verify",
     response_model=UserResponse,
+    summary="Mark an address verified without a token (administrators only)",
 )
 def verify_user(
     user_id: uuid.UUID,
+    request: Request,
+    payload: AccountStateChangeRequest | None = None,
     db: Session = Depends(get_database),
+    actor: User = Depends(require_roles(SystemRole.ADMIN)),
 ):
+    user = resolve_target_user(db, user_id)
 
-    user = UserService.get_user(db, user_id)
-
-    if user is None:
-        raise HTTPException(
-            status_code=404,
-            detail="User not found",
-        )
-    return UserService.verify_email(
+    return AccountStateService.mark_email_verified(
         db,
-        user,
+        actor=actor,
+        target=user,
+        reason=payload.reason if payload else None,
+        context=RequestContext.from_request(request),
     )
 
 

--- a/backend/app/schemas/user_account_state.py
+++ b/backend/app/schemas/user_account_state.py
@@ -1,0 +1,57 @@
+"""
+Request bodies for the administrative account-state routes.
+
+Each of ``/activate``, ``/deactivate`` and ``/verify`` accepts an optional
+reason. It is optional so the routes stay callable with an empty body -- they
+took no body at all before -- but when it is supplied it lands on the audit row,
+which is the difference between a log that records *what* happened and one that
+records why.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class AccountStateChangeRequest(BaseModel):
+    """Optional context an administrator can attach to a state transition."""
+
+    reason: Optional[str] = Field(
+        default=None,
+        max_length=500,
+        description=(
+            "Why this transition is being applied. Stored on the audit log "
+            "entry; not shown to the affected user."
+        ),
+        examples=["Spam reports from three separate projects (see ticket 4412)"],
+    )
+
+    @field_validator("reason")
+    @classmethod
+    def _blank_is_absent(cls, value: Optional[str]) -> Optional[str]:
+        """Treat a whitespace-only reason as no reason.
+
+        Otherwise a client that always sends the field ends up writing
+        ``{"reason": "  "}`` onto every audit row, which reads as "a reason was
+        given" to anything scanning the log.
+        """
+        if value is None:
+            return None
+        cleaned = value.strip()
+        return cleaned or None
+
+
+class AccountStateResponse(BaseModel):
+    """Minimal projection of the flags a transition touches.
+
+    Not currently used by the routes -- they return the full ``UserResponse``
+    for backwards compatibility -- but it is what an admin console wants when
+    it only needs to reconcile the two booleans it just changed.
+    """
+
+    id: str
+    username: str
+    is_active: bool
+    is_verified: bool

--- a/backend/app/services/account_state_service.py
+++ b/backend/app/services/account_state_service.py
@@ -1,0 +1,326 @@
+"""
+Administrative account-state transitions.
+
+``is_active`` and ``is_verified`` are the two flags that decide whether a person
+can sign in and what the platform is willing to vouch for about them. Both used
+to be flipped by ``UserService`` setters that took a ``User`` and set an
+attribute -- no actor, no record, and nothing to stop a caller from applying a
+transition that had already been applied.
+
+Everything an administrator can do to somebody else's account now goes through
+this module, so that three things are true of every transition:
+
+* an actor is named, and the transition refuses to run without one;
+* the transition is recorded in the audit log with both parties on it;
+* the side effects that make the state change *mean* something happen in the
+  same unit of work as the flag.
+
+That last point is the one worth spelling out. Clearing ``is_active`` stops
+:meth:`AuthService.login` from issuing new tokens, but it does nothing to the
+tokens already out there: ``POST /api/auth/refresh`` reads the refresh-token row
+and the JWT, neither of which consults ``users.is_active``. A "disabled" account
+therefore went on minting access tokens for the remaining lifetime of its
+refresh token. Deactivation revokes them here.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+from typing import Optional
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.models.audit_log import AuditAction
+from app.models.user import User
+from app.services.audit_log_service import AuditLogService
+from app.services.refresh_token_service import RefreshTokenService
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RequestContext:
+    """Where a transition came from.
+
+    Optional throughout -- a transition driven by a management command has no
+    request behind it -- but when the router has these they belong on the audit
+    row, because "an admin deactivated this account" is a much weaker record
+    than "an admin deactivated this account from this address at this time".
+    """
+
+    ip_address: Optional[str] = None
+    user_agent: Optional[str] = None
+    request_method: Optional[str] = None
+    request_path: Optional[str] = None
+
+    @classmethod
+    def from_request(cls, request) -> "RequestContext":
+        if request is None:
+            return cls()
+        client = getattr(request, "client", None)
+        return cls(
+            ip_address=getattr(client, "host", None) if client else None,
+            user_agent=request.headers.get("user-agent"),
+            request_method=request.method,
+            request_path=str(request.url.path),
+        )
+
+
+class AccountStateService:
+    """Activate, deactivate and verify accounts on an administrator's behalf."""
+
+    # ------------------------------------------------------------------
+    # Guards
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def assert_not_self(actor: User, target: User, operation: str) -> None:
+        """Refuse a transition an administrator applies to their own account.
+
+        Deactivating yourself is the interesting case: it takes effect
+        immediately, ``get_current_active_user`` then rejects your own token,
+        and you cannot call ``/activate`` to undo it. Without a second admin
+        that is an unrecoverable state, reached by a single mis-pasted id.
+
+        The other two transitions are harmless in themselves, but an admin
+        self-verifying is precisely the audit-log entry a reviewer wants to be
+        impossible rather than merely visible.
+        """
+        if actor.id == target.id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"You cannot {operation} your own account.",
+            )
+
+    @staticmethod
+    def assert_not_deleted(target: User) -> None:
+        """A soft-deleted account is not a thing to activate or verify.
+
+        ``UserService.get_user`` already filters ``deleted_at``, so a caller
+        that went through it cannot get here. Callers that used
+        ``get_user_including_deleted`` can, and restoring is
+        ``POST /{user_id}/restore``'s job, not a side effect of activation.
+        """
+        if getattr(target, "deleted_at", None) is not None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="This account is deleted. Restore it before changing its state.",
+            )
+
+    # ------------------------------------------------------------------
+    # Transitions
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def activate(
+        cls,
+        db: Session,
+        *,
+        actor: User,
+        target: User,
+        reason: Optional[str] = None,
+        context: Optional[RequestContext] = None,
+    ) -> User:
+        """Re-enable a disabled account.
+
+        Idempotent by design: re-activating an already-active account is a
+        no-op that still returns the user, because the caller's intent
+        ("this account should be usable") is satisfied either way. It does not
+        write an audit row in that case -- a log full of transitions that
+        changed nothing is a log nobody reads.
+        """
+        cls.assert_not_deleted(target)
+
+        if target.is_active:
+            return target
+
+        target.is_active = True
+        db.add(target)
+        db.flush()
+
+        cls._record(
+            db,
+            actor=actor,
+            target=target,
+            action=AuditAction.USER_ACTIVATED,
+            description=f"Activated account '{target.username}'",
+            old_values={"is_active": False},
+            new_values={"is_active": True},
+            reason=reason,
+            context=context,
+        )
+
+        db.commit()
+        db.refresh(target)
+
+        logger.info(
+            "account_activated target=%s actor=%s",
+            target.id,
+            actor.id,
+        )
+        return target
+
+    @classmethod
+    def deactivate(
+        cls,
+        db: Session,
+        *,
+        actor: User,
+        target: User,
+        reason: Optional[str] = None,
+        context: Optional[RequestContext] = None,
+    ) -> User:
+        """Disable an account and cut its live sessions.
+
+        The token revocation is the part that makes this a real suspension
+        rather than a flag. It runs even when the account was already inactive,
+        because an account can be marked inactive by one code path and still
+        hold valid refresh tokens issued before it -- re-running the
+        revocation is cheap and closes that window.
+        """
+        cls.assert_not_self(actor, target, "deactivate")
+        cls.assert_not_deleted(target)
+
+        was_active = target.is_active
+        target.is_active = False
+        db.add(target)
+        db.flush()
+
+        RefreshTokenService.revoke_all_tokens(db, target.id)
+
+        if was_active:
+            cls._record(
+                db,
+                actor=actor,
+                target=target,
+                action=AuditAction.USER_SUSPENDED,
+                description=f"Deactivated account '{target.username}'",
+                old_values={"is_active": True},
+                new_values={"is_active": False},
+                reason=reason,
+                context=context,
+            )
+
+        db.commit()
+        db.refresh(target)
+
+        logger.info(
+            "account_deactivated target=%s actor=%s was_active=%s",
+            target.id,
+            actor.id,
+            was_active,
+        )
+        return target
+
+    @classmethod
+    def mark_email_verified(
+        cls,
+        db: Session,
+        *,
+        actor: User,
+        target: User,
+        reason: Optional[str] = None,
+        context: Optional[RequestContext] = None,
+    ) -> User:
+        """Mark an address verified without the confirmation email.
+
+        This exists for support: somebody whose mail provider silently drops
+        the confirmation link needs a way through. It is not the normal path --
+        that is ``POST /api/auth/verify-email`` with a token -- and the audit
+        row says which one was used, because ``is_verified`` is what renders
+        the badge on every post the account writes.
+        """
+        cls.assert_not_self(actor, target, "verify")
+        cls.assert_not_deleted(target)
+
+        if target.is_verified:
+            return target
+
+        target.is_verified = True
+        db.add(target)
+        db.flush()
+
+        cls._record(
+            db,
+            actor=actor,
+            target=target,
+            action=AuditAction.USER_EMAIL_VERIFIED,
+            description=(
+                f"Marked '{target.username}' email-verified without a confirmation token"
+            ),
+            old_values={"is_verified": False},
+            new_values={"is_verified": True},
+            reason=reason,
+            context=context,
+        )
+
+        db.commit()
+        db.refresh(target)
+
+        logger.info(
+            "account_email_verified_by_admin target=%s actor=%s",
+            target.id,
+            actor.id,
+        )
+        return target
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _record(
+        db: Session,
+        *,
+        actor: User,
+        target: User,
+        action: AuditAction,
+        description: str,
+        old_values: dict,
+        new_values: dict,
+        reason: Optional[str],
+        context: Optional[RequestContext],
+    ) -> None:
+        """Write the audit row for a transition.
+
+        Deliberately not wrapped in a ``try``: if the audit write fails the
+        transition should fail with it. A state change that silently did not
+        get recorded is worse than one that did not happen.
+        """
+        ctx = context or RequestContext()
+        AuditLogService.create_log(
+            db=db,
+            actor_id=actor.id,
+            action=action,
+            entity_type="user",
+            entity_id=str(target.id),
+            target_user_id=target.id,
+            description=description,
+            old_values=old_values,
+            new_values=new_values,
+            metadata_info={"reason": reason} if reason else None,
+            ip_address=ctx.ip_address,
+            user_agent=ctx.user_agent,
+            request_method=ctx.request_method,
+            request_path=ctx.request_path,
+        )
+
+
+def resolve_target_user(db: Session, user_id: uuid.UUID) -> User:
+    """Load the subject of a transition, or 404.
+
+    Goes through ``db.get`` rather than ``UserService.get_user`` on purpose:
+    that one is decorated with ``@cached``, and reading an account's flags from
+    a cache immediately before writing them is how you get a transition applied
+    to a stale copy.
+    """
+    user = db.get(User, user_id)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found",
+        )
+    return user

--- a/backend/tests/test_user_account_state_authz.py
+++ b/backend/tests/test_user_account_state_authz.py
@@ -1,0 +1,415 @@
+"""
+Authorization and side effects for the administrative account-state routes.
+
+Covers `PATCH /api/users/{id}/activate`, `/deactivate` and `/verify`, and the
+`POST /api/users/` provisioning route that sits alongside them.
+
+The three state routes previously depended on `get_database` and nothing else,
+so an anonymous request could disable any account, re-enable any account, and
+mark any address verified. The tests here pin down three separate things:
+
+1. who may call them (nobody unauthenticated, no ordinary user, admins only);
+2. that the transition does what it claims -- in particular that deactivation
+   actually ends the target's sessions rather than only setting a flag;
+3. that every transition leaves an audit trail naming both parties.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.models.audit_log import AuditAction, AuditLog
+from app.models.refresh_token import RefreshToken
+from app.models.user import User
+
+PASSWORD = "Vermilion-Kestrel97!"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _promote(db, user_id) -> User:
+    user = db.get(User, uuid.UUID(str(user_id)))
+    user.system_role = "admin"
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@pytest.fixture
+def admin(client: TestClient, register_and_login, db):
+    """An authenticated system administrator."""
+    uid, token = register_and_login("admin@example.com", "adminuser")
+    _promote(db, uid)
+    return {
+        "id": uid,
+        "token": token,
+        "headers": {"Authorization": f"Bearer {token}"},
+    }
+
+
+@pytest.fixture
+def member(client: TestClient, register_and_login):
+    """An ordinary, non-privileged account."""
+    uid, token = register_and_login("member@example.com", "memberuser")
+    return {
+        "id": uid,
+        "token": token,
+        "headers": {"Authorization": f"Bearer {token}"},
+    }
+
+
+@pytest.fixture
+def victim(client: TestClient, register_and_login):
+    """The account the tests act upon."""
+    uid, token = register_and_login("victim@example.com", "victimuser")
+    return {
+        "id": uid,
+        "token": token,
+        "headers": {"Authorization": f"Bearer {token}"},
+    }
+
+
+def _audit_rows(db, action: AuditAction) -> list[AuditLog]:
+    return db.query(AuditLog).filter(AuditLog.action == action).all()
+
+
+# ---------------------------------------------------------------------------
+# Anonymous callers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("operation", ["activate", "deactivate", "verify"])
+def test_anonymous_caller_is_rejected(client: TestClient, victim, operation):
+    """The original bug, stated directly: no token, no transition."""
+    response = client.patch(f"/api/users/{victim['id']}/{operation}")
+    assert response.status_code == 401
+
+
+def test_anonymous_deactivation_does_not_touch_the_account(
+    client: TestClient, victim, db
+):
+    """A rejected request must not have applied anything on the way out."""
+    client.patch(f"/api/users/{victim['id']}/deactivate")
+
+    user = db.get(User, uuid.UUID(victim["id"]))
+    assert user.is_active is True
+
+
+def test_anonymous_deactivation_does_not_lock_the_account_out(
+    client: TestClient, victim
+):
+    """The end-to-end shape of the report: log in again afterwards."""
+    client.patch(f"/api/users/{victim['id']}/deactivate")
+
+    login = client.post(
+        "/api/auth/login",
+        json={"email": "victim@example.com", "password": PASSWORD},
+    )
+    assert login.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Authenticated but unprivileged callers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("operation", ["activate", "deactivate", "verify"])
+def test_ordinary_user_is_rejected(client: TestClient, member, victim, operation):
+    response = client.patch(
+        f"/api/users/{victim['id']}/{operation}",
+        headers=member["headers"],
+    )
+    assert response.status_code == 403
+
+
+def test_ordinary_user_cannot_verify_themselves(client: TestClient, member, db):
+    """Self-verification was the cheapest abuse: it grants the badge."""
+    response = client.patch(
+        f"/api/users/{member['id']}/verify",
+        headers=member["headers"],
+    )
+    assert response.status_code == 403
+
+    user = db.get(User, uuid.UUID(member["id"]))
+    assert user.is_verified is False
+
+
+# ---------------------------------------------------------------------------
+# Administrators
+# ---------------------------------------------------------------------------
+
+
+def test_admin_can_deactivate(client: TestClient, admin, victim, db):
+    response = client.patch(
+        f"/api/users/{victim['id']}/deactivate",
+        headers=admin["headers"],
+    )
+    assert response.status_code == 200
+    assert response.json()["is_active"] is False
+
+    user = db.get(User, uuid.UUID(victim["id"]))
+    assert user.is_active is False
+
+
+def test_deactivated_account_cannot_log_in(client: TestClient, admin, victim):
+    client.patch(f"/api/users/{victim['id']}/deactivate", headers=admin["headers"])
+
+    login = client.post(
+        "/api/auth/login",
+        json={"email": "victim@example.com", "password": PASSWORD},
+    )
+    assert login.status_code == 403
+
+
+def test_deactivation_revokes_refresh_tokens(client: TestClient, admin, victim, db):
+    """The flag alone is not a suspension.
+
+    ``POST /api/auth/refresh`` validates the JWT and the stored token row;
+    neither consults ``users.is_active``. Without revocation a "disabled"
+    account keeps minting access tokens until its refresh token expires.
+    """
+    live_before = (
+        db.query(RefreshToken)
+        .filter(
+            RefreshToken.user_id == uuid.UUID(victim["id"]),
+            RefreshToken.is_revoked.is_(False),
+        )
+        .count()
+    )
+    assert live_before >= 1, "the login fixture should have issued a refresh token"
+
+    client.patch(f"/api/users/{victim['id']}/deactivate", headers=admin["headers"])
+
+    live_after = (
+        db.query(RefreshToken)
+        .filter(
+            RefreshToken.user_id == uuid.UUID(victim["id"]),
+            RefreshToken.is_revoked.is_(False),
+        )
+        .count()
+    )
+    assert live_after == 0
+
+
+def test_admin_can_reactivate(client: TestClient, admin, victim, db):
+    client.patch(f"/api/users/{victim['id']}/deactivate", headers=admin["headers"])
+
+    response = client.patch(
+        f"/api/users/{victim['id']}/activate",
+        headers=admin["headers"],
+    )
+    assert response.status_code == 200
+    assert response.json()["is_active"] is True
+
+    login = client.post(
+        "/api/auth/login",
+        json={"email": "victim@example.com", "password": PASSWORD},
+    )
+    assert login.status_code == 200
+
+
+def test_admin_can_mark_verified(client: TestClient, admin, victim, db):
+    response = client.patch(
+        f"/api/users/{victim['id']}/verify",
+        headers=admin["headers"],
+    )
+    assert response.status_code == 200
+    assert response.json()["is_verified"] is True
+
+
+def test_missing_target_is_404_not_403(client: TestClient, admin):
+    """An admin asking about a user that does not exist gets the honest answer.
+
+    Ordering matters here: the role check runs first, so a non-admin probing
+    for valid ids still sees 403 rather than being able to tell 404 from 403.
+    """
+    response = client.patch(
+        f"/api/users/{uuid.uuid4()}/deactivate",
+        headers=admin["headers"],
+    )
+    assert response.status_code == 404
+
+
+def test_unprivileged_probe_cannot_distinguish_missing_from_present(
+    client: TestClient, member, victim
+):
+    real = client.patch(
+        f"/api/users/{victim['id']}/deactivate", headers=member["headers"]
+    )
+    fake = client.patch(
+        f"/api/users/{uuid.uuid4()}/deactivate", headers=member["headers"]
+    )
+    assert real.status_code == fake.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Self-targeting
+# ---------------------------------------------------------------------------
+
+
+def test_admin_cannot_deactivate_themselves(client: TestClient, admin, db):
+    """One mis-pasted id should not be an unrecoverable lockout."""
+    response = client.patch(
+        f"/api/users/{admin['id']}/deactivate",
+        headers=admin["headers"],
+    )
+    assert response.status_code == 400
+    assert "your own account" in response.json()["detail"].lower()
+
+    user = db.get(User, uuid.UUID(admin["id"]))
+    assert user.is_active is True
+
+
+def test_admin_cannot_verify_themselves(client: TestClient, admin, db):
+    response = client.patch(
+        f"/api/users/{admin['id']}/verify",
+        headers=admin["headers"],
+    )
+    assert response.status_code == 400
+
+    user = db.get(User, uuid.UUID(admin["id"]))
+    assert user.is_verified is False
+
+
+def test_admin_may_activate_themselves(client: TestClient, admin):
+    """Activation is the harmless direction, so it is not blocked.
+
+    An admin whose own account is somehow inactive cannot reach this route at
+    all -- ``get_current_active_user`` refuses first -- so in practice this is
+    a no-op that returns 200 rather than a 400 the caller has to special-case.
+    """
+    response = client.patch(
+        f"/api/users/{admin['id']}/activate",
+        headers=admin["headers"],
+    )
+    assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Idempotence
+# ---------------------------------------------------------------------------
+
+
+def test_activating_an_active_account_is_a_no_op(client: TestClient, admin, victim, db):
+    before = len(_audit_rows(db, AuditAction.USER_ACTIVATED))
+
+    response = client.patch(
+        f"/api/users/{victim['id']}/activate",
+        headers=admin["headers"],
+    )
+    assert response.status_code == 200
+    assert response.json()["is_active"] is True
+
+    after = len(_audit_rows(db, AuditAction.USER_ACTIVATED))
+    assert after == before, "a transition that changed nothing should not be logged"
+
+
+def test_verifying_a_verified_account_is_a_no_op(client: TestClient, admin, victim, db):
+    client.patch(f"/api/users/{victim['id']}/verify", headers=admin["headers"])
+    before = len(_audit_rows(db, AuditAction.USER_EMAIL_VERIFIED))
+
+    response = client.patch(
+        f"/api/users/{victim['id']}/verify",
+        headers=admin["headers"],
+    )
+    assert response.status_code == 200
+
+    after = len(_audit_rows(db, AuditAction.USER_EMAIL_VERIFIED))
+    assert after == before
+
+
+def test_deactivating_twice_still_revokes(client: TestClient, admin, victim, db):
+    """Re-running deactivation re-runs the revocation.
+
+    An account can be marked inactive by one path and still hold tokens issued
+    before it. The second call should close that window rather than short-
+    circuit on the flag.
+    """
+    client.patch(f"/api/users/{victim['id']}/deactivate", headers=admin["headers"])
+
+    response = client.patch(
+        f"/api/users/{victim['id']}/deactivate",
+        headers=admin["headers"],
+    )
+    assert response.status_code == 200
+    assert response.json()["is_active"] is False
+
+
+# ---------------------------------------------------------------------------
+# Audit trail
+# ---------------------------------------------------------------------------
+
+
+def test_deactivation_is_audited_with_both_parties(
+    client: TestClient, admin, victim, db
+):
+    client.patch(f"/api/users/{victim['id']}/deactivate", headers=admin["headers"])
+
+    rows = _audit_rows(db, AuditAction.USER_SUSPENDED)
+    assert len(rows) == 1
+
+    row = rows[0]
+    assert str(row.actor_id) == str(admin["id"])
+    assert str(row.target_user_id) == str(victim["id"])
+    assert row.entity_type == "user"
+    assert row.old_values == {"is_active": True}
+    assert row.new_values == {"is_active": False}
+
+
+def test_reason_is_recorded_when_supplied(client: TestClient, admin, victim, db):
+    client.patch(
+        f"/api/users/{victim['id']}/deactivate",
+        headers=admin["headers"],
+        json={"reason": "Spam reports from three separate projects"},
+    )
+
+    row = _audit_rows(db, AuditAction.USER_SUSPENDED)[0]
+    assert row.metadata_info["reason"] == "Spam reports from three separate projects"
+
+
+def test_blank_reason_is_treated_as_absent(client: TestClient, admin, victim, db):
+    client.patch(
+        f"/api/users/{victim['id']}/deactivate",
+        headers=admin["headers"],
+        json={"reason": "   "},
+    )
+
+    row = _audit_rows(db, AuditAction.USER_SUSPENDED)[0]
+    assert not row.metadata_info or "reason" not in row.metadata_info
+
+
+def test_reason_length_is_bounded(client: TestClient, admin, victim):
+    response = client.patch(
+        f"/api/users/{victim['id']}/deactivate",
+        headers=admin["headers"],
+        json={"reason": "x" * 501},
+    )
+    assert response.status_code == 422
+
+
+def test_verification_is_audited_under_its_own_action(
+    client: TestClient, admin, victim, db
+):
+    """An admin override is not the same event as the user clicking the link."""
+    client.patch(f"/api/users/{victim['id']}/verify", headers=admin["headers"])
+
+    rows = _audit_rows(db, AuditAction.USER_EMAIL_VERIFIED)
+    assert len(rows) == 1
+    assert str(rows[0].actor_id) == str(admin["id"])
+    assert str(rows[0].target_user_id) == str(victim["id"])
+
+
+def test_empty_body_is_accepted(client: TestClient, admin, victim):
+    """The routes took no body before; they must still work without one."""
+    response = client.patch(
+        f"/api/users/{victim['id']}/deactivate",
+        headers=admin["headers"],
+    )
+    assert response.status_code == 200

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -2,6 +2,29 @@ import uuid
 
 from fastapi.testclient import TestClient
 
+from app.models.user import User
+
+
+def _promote_to_admin(db, user_id) -> None:
+    """Give an already-registered user the system admin role.
+
+    The administrative routes on this router are guarded by
+    ``require_roles(SystemRole.ADMIN)``. There is no API for handing out that
+    role, so tests set it directly -- the same thing a deployment does with a
+    seed script.
+    """
+    user = db.get(User, uuid.UUID(str(user_id)))
+    user.system_role = "admin"
+    db.add(user)
+    db.commit()
+
+
+def _admin_headers(client: TestClient, register_and_login, db) -> dict[str, str]:
+    """Register an administrator and return their auth header."""
+    uid, token = register_and_login("root@example.com", "rootadmin")
+    _promote_to_admin(db, uid)
+    return {"Authorization": f"Bearer {token}"}
+
 
 def test_check_username_available(client: TestClient):
     response = client.get("/api/users/check-username?username=newuser123")
@@ -21,9 +44,11 @@ def test_check_username_invalid(client: TestClient):
     assert response.status_code == 400
 
 
-def test_create_user(client: TestClient):
+def test_create_user(client: TestClient, register_and_login, db):
+    headers = _admin_headers(client, register_and_login, db)
     response = client.post(
         "/api/users/",
+        headers=headers,
         json={
             "first_name": "Create",
             "last_name": "User",
@@ -36,10 +61,42 @@ def test_create_user(client: TestClient):
     assert response.json()["username"] == "createuser"
 
 
-def test_create_user_duplicate_email(client: TestClient, register_and_login):
-    register_and_login("dupem@example.com", "dupem1")
+def test_create_user_requires_authentication(client: TestClient):
     response = client.post(
         "/api/users/",
+        json={
+            "first_name": "Anon",
+            "last_name": "User",
+            "email": "anon@example.com",
+            "username": "anonuser",
+            "password": "Vermilion-Kestrel97!",
+        },
+    )
+    assert response.status_code == 401
+
+
+def test_create_user_rejects_non_admin(client: TestClient, register_and_login):
+    _, token = register_and_login("plain@example.com", "plainuser")
+    response = client.post(
+        "/api/users/",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "first_name": "Nope",
+            "last_name": "User",
+            "email": "nope@example.com",
+            "username": "nopeuser",
+            "password": "Vermilion-Kestrel97!",
+        },
+    )
+    assert response.status_code == 403
+
+
+def test_create_user_duplicate_email(client: TestClient, register_and_login, db):
+    register_and_login("dupem@example.com", "dupem1")
+    headers = _admin_headers(client, register_and_login, db)
+    response = client.post(
+        "/api/users/",
+        headers=headers,
         json={
             "first_name": "Dup",
             "last_name": "User",
@@ -52,10 +109,12 @@ def test_create_user_duplicate_email(client: TestClient, register_and_login):
     assert "email" in response.json()["detail"].lower()
 
 
-def test_create_user_duplicate_username(client: TestClient, register_and_login):
+def test_create_user_duplicate_username(client: TestClient, register_and_login, db):
     register_and_login("dupusr1@example.com", "dupusr")
+    headers = _admin_headers(client, register_and_login, db)
     response = client.post(
         "/api/users/",
+        headers=headers,
         json={
             "first_name": "Dup",
             "last_name": "User",
@@ -131,42 +190,51 @@ def test_delete_me(client: TestClient, register_and_login):
     assert me_resp.status_code == 404
 
 
-def test_activate_user(client: TestClient, register_and_login):
+def test_activate_user(client: TestClient, register_and_login, db):
     uid, _ = register_and_login("act@example.com", "actuser")
-    # Deactivate first
-    client.patch(f"/api/users/{uid}/deactivate")
+    headers = _admin_headers(client, register_and_login, db)
 
-    response = client.patch(f"/api/users/{uid}/activate")
+    # Deactivate first
+    client.patch(f"/api/users/{uid}/deactivate", headers=headers)
+
+    response = client.patch(f"/api/users/{uid}/activate", headers=headers)
     assert response.status_code == 200
     assert response.json()["is_active"] is True
 
 
-def test_activate_user_not_found(client: TestClient):
-    response = client.patch(f"/api/users/{uuid.uuid4()}/activate")
+def test_activate_user_not_found(client: TestClient, register_and_login, db):
+    headers = _admin_headers(client, register_and_login, db)
+    response = client.patch(f"/api/users/{uuid.uuid4()}/activate", headers=headers)
     assert response.status_code == 404
 
 
-def test_deactivate_user(client: TestClient, register_and_login):
+def test_deactivate_user(client: TestClient, register_and_login, db):
     uid, _ = register_and_login("deact@example.com", "deactuser")
-    response = client.patch(f"/api/users/{uid}/deactivate")
+    headers = _admin_headers(client, register_and_login, db)
+
+    response = client.patch(f"/api/users/{uid}/deactivate", headers=headers)
     assert response.status_code == 200
     assert response.json()["is_active"] is False
 
 
-def test_deactivate_user_not_found(client: TestClient):
-    response = client.patch(f"/api/users/{uuid.uuid4()}/deactivate")
+def test_deactivate_user_not_found(client: TestClient, register_and_login, db):
+    headers = _admin_headers(client, register_and_login, db)
+    response = client.patch(f"/api/users/{uuid.uuid4()}/deactivate", headers=headers)
     assert response.status_code == 404
 
 
-def test_verify_user(client: TestClient, register_and_login):
+def test_verify_user(client: TestClient, register_and_login, db):
     uid, _ = register_and_login("ver@example.com", "veruser")
-    response = client.patch(f"/api/users/{uid}/verify")
+    headers = _admin_headers(client, register_and_login, db)
+
+    response = client.patch(f"/api/users/{uid}/verify", headers=headers)
     assert response.status_code == 200
     assert response.json()["is_verified"] is True
 
 
-def test_verify_user_not_found(client: TestClient):
-    response = client.patch(f"/api/users/{uuid.uuid4()}/verify")
+def test_verify_user_not_found(client: TestClient, register_and_login, db):
+    headers = _admin_headers(client, register_and_login, db)
+    response = client.patch(f"/api/users/{uuid.uuid4()}/verify", headers=headers)
     assert response.status_code == 404
 
 


### PR DESCRIPTION
## Summary

`PATCH /api/users/{id}/activate`, `/deactivate` and `/verify` depended on `get_database` and
nothing else. An unauthenticated request could disable any account, re-enable any account, and
mark any address verified. Login refuses an inactive account, so `/deactivate` was a one-request
lockout of any user id — and user ids appear on every profile response.

This restricts the three routes to system administrators, moves the transitions into a service
that records who did what, and makes deactivation actually end the target's sessions.

---

## Related Issue

Fixes #1388

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [ ] UI/UX enhancement
- [x] Tests
- [ ] Other

---

## Changes Made

**Authorization.** The three state routes and `POST /api/users/` now depend on
`require_roles(SystemRole.ADMIN)`. `POST /api/users/` is not the sign-up route — `/api/auth/register`
is, and it is the one that rate-limits, screens the password against the breach list, and sends
the confirmation email — so leaving it open was a second, unrated registration path.

**New `app/services/account_state_service.py`.** The transitions used to be `UserService` setters
that took a `User` and assigned an attribute: no actor, no record, no guard. Everything an
administrator can do to somebody else's account goes through this module now, and every
transition names an actor, writes an audit row, and applies its side effects in the same unit of
work as the flag.

**Deactivation revokes refresh tokens.** This is the part that turns the flag into a suspension.
`AuthService.login` refuses an inactive account, but `POST /api/auth/refresh` validates the JWT
and the stored token row and consults neither — so a "disabled" account kept minting access
tokens for the remaining lifetime of its refresh token. `RefreshTokenService.revoke_all_tokens`
now runs as part of the transition, and it runs even when the account was already inactive,
because an account can be marked inactive by one path while still holding tokens issued before
it.

**Self-targeting refused for `/deactivate` and `/verify`.** Self-deactivation took effect
immediately, `get_current_active_user` then rejected the admin's own token, and `/activate` was
no longer reachable by that account — a mis-pasted id was an unrecoverable lockout. `/activate` is
left self-targetable: it is the harmless direction, and an admin whose own account is inactive
cannot reach the route at all.

**Idempotence without noise.** Re-activating an active account or re-verifying a verified one
returns 200 and writes no audit row. A log full of transitions that changed nothing is a log
nobody reads.

**`USER_EMAIL_VERIFIED` audit action**, with a migration. An administrator marking an address
verified without a confirmation token is a different event from the user following the emailed
link, and it is the one that decides whether the verified badge renders on every post the account
writes (`app/routers/posts.py:46`). The migration adds the value to the Postgres enum inside an
`autocommit_block` with `IF NOT EXISTS`, and returns early on any other dialect — SQLite renders
the column as a VARCHAR with a CHECK constraint, so there is nothing to alter there.

**Optional `reason`** on all three routes, stored on the audit row. The body stays optional so
the routes remain callable with no body at all, and a whitespace-only reason is normalised to
absent rather than written as `{"reason": "  "}`.

**`resolve_target_user` bypasses the cache.** `UserService.get_user` is decorated with `@cached`;
reading an account's flags from a cache immediately before writing them is how a transition gets
applied to a stale copy.

---

## Testing

- [x] Tested locally
- [x] Existing tests pass
- [x] Added new tests

Six tests in `tests/test_users.py` called these routes with no token and asserted `200` — they
encoded the bug as the expected behaviour. They now authenticate as an admin, and three new tests
cover the anonymous and non-admin cases.

`tests/test_user_account_state_authz.py` is new (28 tests):

- anonymous rejected on all three routes, and the account genuinely untouched afterwards —
  including an end-to-end check that the victim can still log in;
- ordinary user rejected on all three, and specifically cannot self-verify;
- admin can deactivate, the target then cannot log in, and their live refresh tokens are gone;
- admin can reactivate and the target can log in again;
- a non-admin probing ids cannot tell 404 from 403, while an admin gets the honest 404;
- self-deactivation and self-verification refused, self-activation allowed;
- idempotent calls return 200 and write no audit row, but repeated deactivation still revokes;
- audit rows carry actor, target, entity type and before/after values;
- reason recorded, blank reason dropped, over-long reason rejected with 422, empty body accepted.

Full backend suite compared against `main` in a clean worktree: **89 failures before, 89 after,
no regressions and no newly-broken tests.** The 89 are pre-existing and unrelated (the UTF-8 BOM
in `project_calendar.py`, the websocket tests, `test_rbac`, `test_organizations` and others).

```
baseline: 89  branch: 89
=== REGRESSIONS ===
=== FIXED ===
```

---

## Checklist

- [x] My code follows the project's coding standards.
- [x] I have tested my changes locally.
- [x] I have updated the documentation where necessary.
- [x] My changes do not introduce new warnings or errors.
- [x] I have reviewed my own code.
- [x] This pull request focuses on a single feature or fix.
- [x] I have linked the related issue.

---

## Additional Notes

**Migration ordering.** `down_revision` is `1c63e6c28cf8`, the current single head. If another PR
lands a migration first this will need a rebase to point at the new head — it does not conflict
textually, so `git` will not flag it.

**There is no API for granting the admin role.** The tests set `system_role` directly, which is
what a seed script does. If a deployment currently has no admin, these routes become unreachable
until one is created — that is the intended posture for administrative routes, but it is worth
knowing before this is deployed.

ECSoc 2026
