### PR TITLE
fix(conversations): require membership on every route that names one

### DIFF
--- a/backend/app/models/conversation_member.py
+++ b/backend/app/models/conversation_member.py
@@ -15,7 +15,7 @@ from sqlalchemy import (
     Enum as SqlEnum,
 )
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, backref, mapped_column, relationship
 
 from app.database.base import Base
 
@@ -108,7 +108,20 @@ class ConversationMember(Base):
 
     conversation = relationship(
         "Conversation",
-        backref="members",
+        # The foreign key declares ``ondelete="CASCADE"``, but the ORM does not
+        # know that and defaults to disassociating children when the parent is
+        # deleted -- it issued ``UPDATE conversation_members SET
+        # conversation_id = NULL``, which the NOT NULL constraint then rejected,
+        # so deleting a conversation failed with a 409 rather than deleting it.
+        #
+        # ``passive_deletes`` tells the ORM to leave the rows to the database's
+        # cascade instead of loading and rewriting them, and the delete cascade
+        # keeps the identity map consistent for members already in the session.
+        backref=backref(
+            "members",
+            cascade="all, delete-orphan",
+            passive_deletes=True,
+        ),
     )
 
     user = relationship(

--- a/backend/app/models/message.py
+++ b/backend/app/models/message.py
@@ -16,7 +16,7 @@ from sqlalchemy import (
     Enum as SqlEnum,
 )
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, backref, mapped_column, relationship
 
 from app.database.base import Base
 
@@ -168,7 +168,14 @@ class Message(Base):
 
     conversation = relationship(
         "Conversation",
-        backref="messages",
+        # Same as ``ConversationMember.conversation``: the column is NOT NULL
+        # with an ON DELETE CASCADE, so the ORM must not try to null it out
+        # when the conversation goes.
+        backref=backref(
+            "messages",
+            cascade="all, delete-orphan",
+            passive_deletes=True,
+        ),
     )
 
     sender = relationship(

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -1,9 +1,23 @@
+"""
+Conversation routes.
+
+Every route below that names a ``conversation_id`` requires an authenticated
+caller who is a member of that conversation. That was not previously true: the
+create and list routes took ``current_user``, and the seven that read, mutated
+or destroyed a named conversation took only ``get_database``.
+
+The membership check is not cosmetic. ``POST /{id}/members/{user_id}`` grants
+exactly the predicate that ``app/routers/messages.py`` uses to authorise
+reads -- so an open add-member route meant anyone could join a private thread
+and then read all of it through the correctly-guarded messages API.
+"""
+
 from __future__ import annotations
 
 import uuid
 
 # pyrefly: ignore [missing-import]
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, status
 
 # pyrefly: ignore [missing-import]
 from sqlalchemy.orm import Session
@@ -45,22 +59,18 @@ def create_conversation(
 @router.get(
     "/{conversation_id}",
     response_model=ConversationResponse,
+    summary="Get a conversation you are a member of",
 )
 def get_conversation(
     conversation_id: uuid.UUID,
     db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
 ):
-
-    conversation = ConversationService.get_conversation(
+    conversation, _ = ConversationService.require_membership(
         db,
         conversation_id,
+        current_user.id,
     )
-
-    if conversation is None:
-        raise HTTPException(
-            status_code=404,
-            detail="Conversation not found",
-        )
 
     return conversation
 
@@ -83,23 +93,19 @@ def list_my_conversations(
 @router.put(
     "/{conversation_id}",
     response_model=ConversationResponse,
+    summary="Rename or reconfigure a conversation (owner or admin)",
 )
 def update_conversation(
     conversation_id: uuid.UUID,
     conversation: ConversationUpdate,
     db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
 ):
-
-    db_conversation = ConversationService.get_conversation(
+    db_conversation, _ = ConversationService.require_admin(
         db,
         conversation_id,
+        current_user.id,
     )
-
-    if db_conversation is None:
-        raise HTTPException(
-            status_code=404,
-            detail="Conversation not found",
-        )
 
     return ConversationService.update_conversation(
         db,
@@ -111,12 +117,24 @@ def update_conversation(
 @router.post(
     "/{conversation_id}/members/{user_id}",
     status_code=status.HTTP_201_CREATED,
+    summary="Add someone to a conversation (owner or admin)",
+    description=(
+        "Membership is what the messages API checks before returning a "
+        "thread, so this route hands out read access to everything already "
+        "said in it. Restricted to the conversation's owner and admins."
+    ),
 )
 def add_member(
     conversation_id: uuid.UUID,
     user_id: uuid.UUID,
     db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
 ):
+    ConversationService.require_admin(
+        db,
+        conversation_id,
+        current_user.id,
+    )
 
     return ConversationService.add_member(
         db,
@@ -128,12 +146,29 @@ def add_member(
 @router.delete(
     "/{conversation_id}/members/{user_id}",
     status_code=status.HTTP_204_NO_CONTENT,
+    summary="Remove a member, or leave the conversation yourself",
 )
 def remove_member(
     conversation_id: uuid.UUID,
     user_id: uuid.UUID,
     db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
 ):
+    # Leaving is not an administrative act. Requiring an admin role to remove
+    # yourself would trap a plain member in a thread they want no part of,
+    # with no route out of it.
+    if user_id == current_user.id:
+        ConversationService.require_membership(
+            db,
+            conversation_id,
+            current_user.id,
+        )
+    else:
+        ConversationService.require_admin(
+            db,
+            conversation_id,
+            current_user.id,
+        )
 
     ConversationService.remove_member(
         db,
@@ -145,22 +180,18 @@ def remove_member(
 @router.patch(
     "/{conversation_id}/archive",
     response_model=ConversationResponse,
+    summary="Archive a conversation (owner or admin)",
 )
 def archive_conversation(
     conversation_id: uuid.UUID,
     db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
 ):
-
-    conversation = ConversationService.get_conversation(
+    conversation, _ = ConversationService.require_admin(
         db,
         conversation_id,
+        current_user.id,
     )
-
-    if conversation is None:
-        raise HTTPException(
-            status_code=404,
-            detail="Conversation not found",
-        )
 
     return ConversationService.archive_conversation(
         db,
@@ -171,22 +202,18 @@ def archive_conversation(
 @router.patch(
     "/{conversation_id}/restore",
     response_model=ConversationResponse,
+    summary="Restore an archived conversation (owner or admin)",
 )
 def restore_conversation(
     conversation_id: uuid.UUID,
     db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
 ):
-
-    conversation = ConversationService.get_conversation(
+    conversation, _ = ConversationService.require_admin(
         db,
         conversation_id,
+        current_user.id,
     )
-
-    if conversation is None:
-        raise HTTPException(
-            status_code=404,
-            detail="Conversation not found",
-        )
 
     return ConversationService.restore_conversation(
         db,
@@ -197,22 +224,22 @@ def restore_conversation(
 @router.delete(
     "/{conversation_id}",
     status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete a conversation (owner only)",
+    description=(
+        "Irreversible. `conversation_members` and `messages` both cascade "
+        "from the conversation row, so this destroys the whole history."
+    ),
 )
 def delete_conversation(
     conversation_id: uuid.UUID,
     db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
 ):
-
-    conversation = ConversationService.get_conversation(
+    conversation, _ = ConversationService.require_owner(
         db,
         conversation_id,
+        current_user.id,
     )
-
-    if conversation is None:
-        raise HTTPException(
-            status_code=404,
-            detail="Conversation not found",
-        )
 
     ConversationService.delete_conversation(
         db,

--- a/backend/app/services/conversation_service.py
+++ b/backend/app/services/conversation_service.py
@@ -1,9 +1,28 @@
+"""
+Business logic for conversations, and the membership rules that guard them.
+
+Every route in ``app/routers/conversations.py`` that names a conversation used
+to take a ``conversation_id`` and no caller, so the authorization decisions had
+nowhere to live. They live here now, as four ``require_*`` helpers that the
+router calls before it does anything else.
+
+Two conventions worth stating, because the status codes are deliberate:
+
+* A caller who is **not a member** gets ``404``, not ``403``. A private
+  conversation they are not in should not be distinguishable from one that does
+  not exist -- otherwise the routes become an oracle for "is this a real
+  conversation id", which is exactly the enumeration step an attacker needs.
+* A caller who **is** a member but lacks the role gets ``403``. They already
+  know the conversation exists, so there is nothing left to hide, and ``403``
+  is the answer that tells a client to stop retrying.
+"""
+
 from __future__ import annotations
 
 import uuid
 
 from fastapi import HTTPException, status
-from sqlalchemy import and_, or_, select
+from sqlalchemy import and_, func, select
 from sqlalchemy.orm import Session
 
 from app.models.conversation import Conversation, ConversationType
@@ -13,11 +32,129 @@ from app.schemas.conversation import (
     ConversationUpdate,
 )
 
+#: Roles allowed to change a conversation or its membership.
+#:
+#: ``create_conversation`` has always stamped the creator ``OWNER`` and
+#: ``add_member`` has always defaulted everyone else to ``MEMBER``; until now
+#: nothing read either value back.
+CONVERSATION_ADMIN_ROLES = frozenset(
+    {ConversationRole.OWNER, ConversationRole.ADMIN}
+)
+
 
 class ConversationService:
     """
     Business logic for conversations.
     """
+
+    # ------------------------------------------------------------------
+    # Membership & authorization
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def get_membership(
+        db: Session,
+        conversation_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> ConversationMember | None:
+        """The caller's membership row, or ``None``.
+
+        One query against the unique ``(conversation_id, user_id)`` index. The
+        row itself is needed rather than a bare count because the role on it is
+        what the next check reads.
+        """
+        return db.scalar(
+            select(ConversationMember).where(
+                and_(
+                    ConversationMember.conversation_id == conversation_id,
+                    ConversationMember.user_id == user_id,
+                )
+            )
+        )
+
+    @staticmethod
+    def is_member(
+        db: Session,
+        conversation_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> bool:
+        return (
+            ConversationService.get_membership(db, conversation_id, user_id)
+            is not None
+        )
+
+    @staticmethod
+    def require_membership(
+        db: Session,
+        conversation_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> tuple[Conversation, ConversationMember]:
+        """Load a conversation the caller belongs to, or 404.
+
+        The conversation is fetched *after* the membership check rather than
+        before, so a caller who is not a member cannot tell an id that exists
+        from one that does not: both paths raise the same 404 with the same
+        detail.
+        """
+        member = ConversationService.get_membership(db, conversation_id, user_id)
+        conversation = db.get(Conversation, conversation_id)
+
+        if member is None or conversation is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Conversation not found",
+            )
+
+        return conversation, member
+
+    @staticmethod
+    def require_admin(
+        db: Session,
+        conversation_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> tuple[Conversation, ConversationMember]:
+        """Load a conversation the caller may administer.
+
+        404 if they are not in it at all, 403 if they are in it as a plain
+        member.
+        """
+        conversation, member = ConversationService.require_membership(
+            db, conversation_id, user_id
+        )
+
+        if member.role not in CONVERSATION_ADMIN_ROLES:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Only a conversation owner or admin can do this.",
+            )
+
+        return conversation, member
+
+    @staticmethod
+    def require_owner(
+        db: Session,
+        conversation_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> tuple[Conversation, ConversationMember]:
+        """Load a conversation the caller owns.
+
+        Reserved for deletion. ``delete_conversation`` is a hard ``db.delete``
+        and both ``conversation_members`` and ``messages`` cascade from it, so
+        it destroys the whole history irreversibly -- that is not something a
+        promoted admin should be able to do to the person who started the
+        thread.
+        """
+        conversation, member = ConversationService.require_membership(
+            db, conversation_id, user_id
+        )
+
+        if member.role != ConversationRole.OWNER:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Only the conversation owner can delete it.",
+            )
+
+        return conversation, member
 
     @staticmethod
     def create_conversation(
@@ -80,6 +217,20 @@ class ConversationService:
         user_a: uuid.UUID,
         user_b: uuid.UUID,
     ) -> Conversation | None:
+        """The one-to-one thread between two people, if it exists.
+
+        This used to ``or_`` the two membership predicates, which matches any
+        conversation where *either* of them is a member and then takes the
+        first row. For anyone with more than one conversation that returned an
+        arbitrary unrelated thread -- very often one ``user_b`` is not in at
+        all.
+
+        The predicate that actually expresses "both of them" is a restriction
+        to the two ids followed by a ``HAVING`` on the distinct count, which
+        also stays correct if a membership row is ever duplicated.
+        """
+        if user_a == user_b:
+            return None
 
         stmt = (
             select(Conversation)
@@ -88,14 +239,15 @@ class ConversationService:
                 Conversation.id == ConversationMember.conversation_id,
             )
             .where(
-                or_(
-                    ConversationMember.user_id == user_a,
-                    ConversationMember.user_id == user_b,
-                )
+                Conversation.type == ConversationType.DIRECT,
+                ConversationMember.user_id.in_([user_a, user_b]),
             )
+            .group_by(Conversation.id)
+            .having(func.count(func.distinct(ConversationMember.user_id)) == 2)
+            .order_by(Conversation.created_at.asc())
         )
 
-        return db.scalar(stmt)
+        return db.scalars(stmt).first()
 
     @staticmethod
     def add_member(

--- a/backend/tests/test_conversation_authorization.py
+++ b/backend/tests/test_conversation_authorization.py
@@ -1,0 +1,570 @@
+"""
+Authorization for the conversation routes.
+
+Seven routes under `/api/conversations` took a `conversation_id` and no caller.
+The worst of them was `POST /{id}/members/{user_id}`: membership is exactly the
+predicate `app/routers/messages.py` checks before returning a thread, so an
+open add-member route let anyone join a private conversation and then read all
+of it through the correctly-guarded messages API.
+
+The tests are organised as:
+
+* `TestAnonymousAccess`      -- no token, every route
+* `TestNonMemberAccess`      -- a token, but not in the conversation
+* `TestPlainMemberAccess`    -- in the conversation, no role
+* `TestAdminAccess`          -- promoted to admin
+* `TestOwnerAccess`          -- created it
+* `TestLeaving`              -- removing yourself
+* `TestPrivateThreadIsNotReadable` -- the end-to-end exploit, blocked
+* `TestGetDirectConversation`      -- the `or_` bug in the lookup
+
+Status codes are deliberate and asserted as such: a non-member gets 404 so the
+routes cannot be used to confirm that a conversation id is real; a member
+without the role gets 403.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.models.conversation import Conversation, ConversationType
+from app.models.conversation_member import ConversationMember, ConversationRole
+from app.models.user import User
+from app.schemas.conversation import ConversationCreate
+from app.services.conversation_service import ConversationService
+
+PASSWORD = "Vermilion-Kestrel97!"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _account(register_and_login, email: str, username: str) -> dict:
+    uid, token = register_and_login(email, username)
+    return {
+        "id": uid,
+        "uuid": uuid.UUID(uid),
+        "token": token,
+        "headers": {"Authorization": f"Bearer {token}"},
+    }
+
+
+@pytest.fixture
+def owner(register_and_login):
+    return _account(register_and_login, "owner@example.com", "convowner")
+
+
+@pytest.fixture
+def insider(register_and_login):
+    """A plain member of the conversation."""
+    return _account(register_and_login, "insider@example.com", "convinsider")
+
+
+@pytest.fixture
+def outsider(register_and_login):
+    """Authenticated, but has nothing to do with the conversation."""
+    return _account(register_and_login, "outsider@example.com", "convoutsider")
+
+
+@pytest.fixture
+def conversation(client: TestClient, owner, insider, db):
+    """A group conversation with an owner and one plain member."""
+    created = client.post(
+        "/api/conversations/",
+        json={"type": "group", "title": "Roadmap"},
+        headers=owner["headers"],
+    )
+    assert created.status_code == 201, created.text
+    conv_id = created.json()["id"]
+
+    db.add(
+        ConversationMember(
+            conversation_id=uuid.UUID(conv_id),
+            user_id=insider["uuid"],
+            role=ConversationRole.MEMBER,
+        )
+    )
+    db.commit()
+    return conv_id
+
+
+def _promote(db, conv_id: str, user_uuid: uuid.UUID, role: ConversationRole) -> None:
+    member = (
+        db.query(ConversationMember)
+        .filter(
+            ConversationMember.conversation_id == uuid.UUID(conv_id),
+            ConversationMember.user_id == user_uuid,
+        )
+        .one()
+    )
+    member.role = role
+    db.add(member)
+    db.commit()
+
+
+def _all_routes(conv_id: str, target_id: str) -> list[tuple[str, str]]:
+    """(method, path) for every route that names a conversation."""
+    return [
+        ("GET", f"/api/conversations/{conv_id}"),
+        ("PUT", f"/api/conversations/{conv_id}"),
+        ("POST", f"/api/conversations/{conv_id}/members/{target_id}"),
+        ("DELETE", f"/api/conversations/{conv_id}/members/{target_id}"),
+        ("PATCH", f"/api/conversations/{conv_id}/archive"),
+        ("PATCH", f"/api/conversations/{conv_id}/restore"),
+        ("DELETE", f"/api/conversations/{conv_id}"),
+    ]
+
+
+def _call(client: TestClient, method: str, path: str, headers: dict | None = None):
+    kwargs = {"headers": headers} if headers else {}
+    if method == "PUT":
+        kwargs["json"] = {"title": "renamed"}
+    return client.request(method, path, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Anonymous
+# ---------------------------------------------------------------------------
+
+
+class TestAnonymousAccess:
+    def test_every_route_rejects_an_anonymous_caller(
+        self, client: TestClient, conversation, outsider
+    ):
+        for method, path in _all_routes(conversation, outsider["id"]):
+            response = _call(client, method, path)
+            assert response.status_code == 401, f"{method} {path} returned {response.status_code}"
+
+    def test_anonymous_add_member_does_not_create_a_membership(
+        self, client: TestClient, conversation, outsider, db
+    ):
+        """The original report, stated directly."""
+        client.post(f"/api/conversations/{conversation}/members/{outsider['id']}")
+
+        assert not ConversationService.is_member(
+            db, uuid.UUID(conversation), outsider["uuid"]
+        )
+
+    def test_anonymous_delete_does_not_destroy_the_thread(
+        self, client: TestClient, conversation, db
+    ):
+        client.delete(f"/api/conversations/{conversation}")
+
+        assert db.get(Conversation, uuid.UUID(conversation)) is not None
+
+
+# ---------------------------------------------------------------------------
+# Authenticated non-member
+# ---------------------------------------------------------------------------
+
+
+class TestNonMemberAccess:
+    def test_every_route_returns_404_for_a_non_member(
+        self, client: TestClient, conversation, outsider
+    ):
+        for method, path in _all_routes(conversation, outsider["id"]):
+            response = _call(client, method, path, outsider["headers"])
+            assert response.status_code == 404, f"{method} {path} returned {response.status_code}"
+
+    def test_a_real_id_is_indistinguishable_from_a_missing_one(
+        self, client: TestClient, conversation, outsider
+    ):
+        """404 rather than 403, so the routes are not an id oracle."""
+        real = client.get(
+            f"/api/conversations/{conversation}", headers=outsider["headers"]
+        )
+        fake = client.get(
+            f"/api/conversations/{uuid.uuid4()}", headers=outsider["headers"]
+        )
+
+        assert real.status_code == fake.status_code == 404
+        assert real.json()["detail"] == fake.json()["detail"]
+
+    def test_non_member_cannot_add_themselves(
+        self, client: TestClient, conversation, outsider, db
+    ):
+        response = client.post(
+            f"/api/conversations/{conversation}/members/{outsider['id']}",
+            headers=outsider["headers"],
+        )
+        assert response.status_code == 404
+        assert not ConversationService.is_member(
+            db, uuid.UUID(conversation), outsider["uuid"]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Plain member
+# ---------------------------------------------------------------------------
+
+
+class TestPlainMemberAccess:
+    def test_member_can_read_the_conversation(
+        self, client: TestClient, conversation, insider
+    ):
+        response = client.get(
+            f"/api/conversations/{conversation}", headers=insider["headers"]
+        )
+        assert response.status_code == 200
+        assert response.json()["title"] == "Roadmap"
+
+    @pytest.mark.parametrize(
+        "method,suffix",
+        [
+            ("PUT", ""),
+            ("PATCH", "/archive"),
+            ("PATCH", "/restore"),
+            ("DELETE", ""),
+        ],
+    )
+    def test_member_cannot_administer(
+        self, client: TestClient, conversation, insider, method, suffix
+    ):
+        response = _call(
+            client,
+            method,
+            f"/api/conversations/{conversation}{suffix}",
+            insider["headers"],
+        )
+        assert response.status_code == 403
+
+    def test_member_cannot_add_someone(
+        self, client: TestClient, conversation, insider, outsider, db
+    ):
+        response = client.post(
+            f"/api/conversations/{conversation}/members/{outsider['id']}",
+            headers=insider["headers"],
+        )
+        assert response.status_code == 403
+        assert not ConversationService.is_member(
+            db, uuid.UUID(conversation), outsider["uuid"]
+        )
+
+    def test_member_cannot_remove_someone_else(
+        self, client: TestClient, conversation, insider, owner, db
+    ):
+        response = client.delete(
+            f"/api/conversations/{conversation}/members/{owner['id']}",
+            headers=insider["headers"],
+        )
+        assert response.status_code == 403
+        assert ConversationService.is_member(
+            db, uuid.UUID(conversation), owner["uuid"]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Admin
+# ---------------------------------------------------------------------------
+
+
+class TestAdminAccess:
+    @pytest.fixture(autouse=True)
+    def _promote_insider(self, db, conversation, insider):
+        _promote(db, conversation, insider["uuid"], ConversationRole.ADMIN)
+
+    def test_admin_can_rename(self, client: TestClient, conversation, insider):
+        response = client.put(
+            f"/api/conversations/{conversation}",
+            json={"title": "Roadmap Q3"},
+            headers=insider["headers"],
+        )
+        assert response.status_code == 200
+        assert response.json()["title"] == "Roadmap Q3"
+
+    def test_admin_can_archive_and_restore(
+        self, client: TestClient, conversation, insider
+    ):
+        archived = client.patch(
+            f"/api/conversations/{conversation}/archive", headers=insider["headers"]
+        )
+        assert archived.status_code == 200
+        assert archived.json()["archived"] is True
+
+        restored = client.patch(
+            f"/api/conversations/{conversation}/restore", headers=insider["headers"]
+        )
+        assert restored.status_code == 200
+        assert restored.json()["archived"] is False
+
+    def test_admin_can_add_a_member(
+        self, client: TestClient, conversation, insider, outsider, db
+    ):
+        response = client.post(
+            f"/api/conversations/{conversation}/members/{outsider['id']}",
+            headers=insider["headers"],
+        )
+        assert response.status_code == 201
+        assert ConversationService.is_member(
+            db, uuid.UUID(conversation), outsider["uuid"]
+        )
+
+    def test_admin_cannot_delete_the_conversation(
+        self, client: TestClient, conversation, insider, db
+    ):
+        """Deletion is irreversible and cascades to every message.
+
+        A promoted admin should not be able to do that to the person who
+        started the thread.
+        """
+        response = client.delete(
+            f"/api/conversations/{conversation}", headers=insider["headers"]
+        )
+        assert response.status_code == 403
+        assert db.get(Conversation, uuid.UUID(conversation)) is not None
+
+
+# ---------------------------------------------------------------------------
+# Owner
+# ---------------------------------------------------------------------------
+
+
+class TestOwnerAccess:
+    def test_creator_is_stamped_owner(self, client: TestClient, conversation, owner, db):
+        member = ConversationService.get_membership(
+            db, uuid.UUID(conversation), owner["uuid"]
+        )
+        assert member is not None
+        assert member.role == ConversationRole.OWNER
+
+    def test_owner_can_rename(self, client: TestClient, conversation, owner):
+        response = client.put(
+            f"/api/conversations/{conversation}",
+            json={"title": "Renamed by owner"},
+            headers=owner["headers"],
+        )
+        assert response.status_code == 200
+
+    def test_owner_can_add_and_remove_members(
+        self, client: TestClient, conversation, owner, outsider, db
+    ):
+        added = client.post(
+            f"/api/conversations/{conversation}/members/{outsider['id']}",
+            headers=owner["headers"],
+        )
+        assert added.status_code == 201
+
+        removed = client.delete(
+            f"/api/conversations/{conversation}/members/{outsider['id']}",
+            headers=owner["headers"],
+        )
+        assert removed.status_code == 204
+        assert not ConversationService.is_member(
+            db, uuid.UUID(conversation), outsider["uuid"]
+        )
+
+    def test_owner_can_delete(self, client: TestClient, conversation, owner, db):
+        response = client.delete(
+            f"/api/conversations/{conversation}", headers=owner["headers"]
+        )
+        assert response.status_code == 204
+        assert db.get(Conversation, uuid.UUID(conversation)) is None
+
+
+# ---------------------------------------------------------------------------
+# Leaving
+# ---------------------------------------------------------------------------
+
+
+class TestLeaving:
+    def test_a_plain_member_can_leave(
+        self, client: TestClient, conversation, insider, db
+    ):
+        """Leaving is not an administrative act.
+
+        Requiring an admin role to remove yourself would trap a member in a
+        thread they want no part of, with no route out.
+        """
+        response = client.delete(
+            f"/api/conversations/{conversation}/members/{insider['id']}",
+            headers=insider["headers"],
+        )
+        assert response.status_code == 204
+        assert not ConversationService.is_member(
+            db, uuid.UUID(conversation), insider["uuid"]
+        )
+
+    def test_leaving_a_conversation_you_are_not_in_is_404(
+        self, client: TestClient, conversation, outsider
+    ):
+        response = client.delete(
+            f"/api/conversations/{conversation}/members/{outsider['id']}",
+            headers=outsider["headers"],
+        )
+        assert response.status_code == 404
+
+    def test_after_leaving_the_conversation_is_no_longer_readable(
+        self, client: TestClient, conversation, insider
+    ):
+        client.delete(
+            f"/api/conversations/{conversation}/members/{insider['id']}",
+            headers=insider["headers"],
+        )
+
+        response = client.get(
+            f"/api/conversations/{conversation}", headers=insider["headers"]
+        )
+        assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# The end-to-end exploit
+# ---------------------------------------------------------------------------
+
+
+class TestPrivateThreadIsNotReadable:
+    def test_outsider_cannot_join_and_then_read_the_messages(
+        self, client: TestClient, conversation, owner, insider, outsider
+    ):
+        """The two-request attack from the report, end to end.
+
+        Step 1 used to succeed with no token at all; step 2 then passed the
+        messages API's membership check legitimately, because step 1 had made
+        it true.
+        """
+        sent = client.post(
+            "/api/messages/",
+            json={"conversation_id": conversation, "content": "internal only"},
+            headers=owner["headers"],
+        )
+        assert sent.status_code == 201, sent.text
+
+        # Step 1: try to join, anonymously and then as a logged-in stranger.
+        anonymous = client.post(
+            f"/api/conversations/{conversation}/members/{outsider['id']}"
+        )
+        assert anonymous.status_code == 401
+
+        authenticated = client.post(
+            f"/api/conversations/{conversation}/members/{outsider['id']}",
+            headers=outsider["headers"],
+        )
+        assert authenticated.status_code == 404
+
+        # Step 2: the messages API still refuses them.
+        read = client.get(
+            f"/api/messages/conversation/{conversation}",
+            headers=outsider["headers"],
+        )
+        assert read.status_code == 403
+
+    def test_a_real_member_can_still_read(
+        self, client: TestClient, conversation, owner, insider
+    ):
+        """The guard must not have broken the legitimate path."""
+        client.post(
+            "/api/messages/",
+            json={"conversation_id": conversation, "content": "hello team"},
+            headers=owner["headers"],
+        )
+
+        read = client.get(
+            f"/api/messages/conversation/{conversation}",
+            headers=insider["headers"],
+        )
+        assert read.status_code == 200
+        assert [m["content"] for m in read.json()] == ["hello team"]
+
+
+# ---------------------------------------------------------------------------
+# get_direct_conversation
+# ---------------------------------------------------------------------------
+
+
+def _user(db, email: str, username: str) -> User:
+    user = User(
+        email=email,
+        username=username,
+        first_name=username.capitalize(),
+        last_name="Test",
+        password_hash="fakehash",
+        is_active=True,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _direct(db, a: User, b: User) -> Conversation:
+    conv = ConversationService.create_conversation(
+        db, a.id, ConversationCreate(type=ConversationType.DIRECT)
+    )
+    db.add(
+        ConversationMember(
+            conversation_id=conv.id,
+            user_id=b.id,
+            role=ConversationRole.MEMBER,
+        )
+    )
+    db.commit()
+    return conv
+
+
+class TestGetDirectConversation:
+    def test_finds_the_thread_between_exactly_those_two(self, db):
+        alice = _user(db, "alice@example.com", "alice")
+        bob = _user(db, "bob@example.com", "bob")
+        conv = _direct(db, alice, bob)
+
+        found = ConversationService.get_direct_conversation(db, alice.id, bob.id)
+        assert found is not None
+        assert found.id == conv.id
+
+    def test_returns_none_when_there_is_no_shared_thread(self, db):
+        """The `or_` bug: this used to return one of alice's other threads.
+
+        The old predicate matched any conversation where *either* user was a
+        member and took the first row, so a user with an existing conversation
+        got an arbitrary unrelated one back -- typically one the other party
+        was not in at all.
+        """
+        alice = _user(db, "alice@example.com", "alice")
+        bob = _user(db, "bob@example.com", "bob")
+        carol = _user(db, "carol@example.com", "carol")
+
+        # alice already talks to carol; she has never talked to bob.
+        _direct(db, alice, carol)
+
+        assert ConversationService.get_direct_conversation(db, alice.id, bob.id) is None
+
+    def test_does_not_match_a_group_thread_containing_both(self, db):
+        alice = _user(db, "alice@example.com", "alice")
+        bob = _user(db, "bob@example.com", "bob")
+
+        group = ConversationService.create_conversation(
+            db,
+            alice.id,
+            ConversationCreate(type=ConversationType.GROUP, title="Team"),
+        )
+        db.add(
+            ConversationMember(
+                conversation_id=group.id,
+                user_id=bob.id,
+                role=ConversationRole.MEMBER,
+            )
+        )
+        db.commit()
+
+        assert ConversationService.get_direct_conversation(db, alice.id, bob.id) is None
+
+    def test_is_symmetric(self, db):
+        alice = _user(db, "alice@example.com", "alice")
+        bob = _user(db, "bob@example.com", "bob")
+        conv = _direct(db, alice, bob)
+
+        forward = ConversationService.get_direct_conversation(db, alice.id, bob.id)
+        backward = ConversationService.get_direct_conversation(db, bob.id, alice.id)
+
+        assert forward.id == backward.id == conv.id
+
+    def test_a_user_has_no_direct_conversation_with_themselves(self, db):
+        alice = _user(db, "alice@example.com", "alice")
+        _direct(db, alice, _user(db, "bob@example.com", "bob"))
+
+        assert ConversationService.get_direct_conversation(db, alice.id, alice.id) is None

--- a/backend/tests/test_conversations.py
+++ b/backend/tests/test_conversations.py
@@ -130,9 +130,11 @@ def test_router_prevent_self_messaging_integration(client):
     token = login_resp.json()["access_token"]
     headers = {"Authorization": f"Bearer {token}"}
 
-    # Create direct conversation via router
+    # Create direct conversation via router. The router is mounted under
+    # `/api` (app/main.py), so the un-prefixed path this used to post to was a
+    # 404 and the assertion below had never actually run.
     conv_resp = client.post(
-        "/conversations/",
+        "/api/conversations/",
         json={
             "type": "direct",
         },
@@ -144,7 +146,7 @@ def test_router_prevent_self_messaging_integration(client):
 
     # Try to add creator as member (which represents self-messaging)
     add_resp = client.post(
-        f"/conversations/{conv_id}/members/{creator_id}",
+        f"/api/conversations/{conv_id}/members/{creator_id}",
         headers=headers,
     )
     assert add_resp.status_code == 400


### PR DESCRIPTION
## Summary

Seven routes under `/api/conversations` took a `conversation_id` and no caller. The create and
list routes were authenticated; everything that read, mutated or destroyed a named conversation
was not.

The serious one is `POST /{id}/members/{user_id}`. Membership is exactly the predicate
`app/routers/messages.py` checks before returning a thread, so an open add-member route meant
anyone could make themselves a member of a private conversation and then read all of it through
the correctly-guarded messages API — passing its check legitimately, because the first request
had made it true.

---

## Related Issue

Fixes #1389

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [ ] UI/UX enhancement
- [x] Tests
- [ ] Other

---

## Changes Made

**Authorization, as four helpers on the service.** Reading needs membership; renaming, archiving,
restoring and changing membership need `OWNER` or `ADMIN`; deleting needs `OWNER`.
`ConversationRole` has existed since the model was written and `create_conversation` has always
stamped the creator `OWNER` — nothing read either value back until now.

**Status codes are deliberate.** A caller who is *not a member* gets `404`, not `403`: a private
conversation they are not in should not be distinguishable from one that does not exist,
otherwise the routes become an oracle for "is this a real conversation id", which is the
enumeration step that makes the rest cheap. A caller who *is* a member but lacks the role gets
`403` — they already know it exists, so there is nothing left to hide.

**Leaving is not an administrative act.** `DELETE /{id}/members/{user_id}` allows self-removal
with only membership. Requiring an admin role to remove yourself would trap a plain member in a
thread they want no part of, with no route out.

**Deletion is owner-only.** It is irreversible and cascades to every message, which is not
something a promoted admin should be able to do to the person who started the thread.

### Two further fixes in the same area

**`get_direct_conversation` returned the wrong conversation.** It `or_`-ed the two membership
predicates, so it matched any conversation where *either* user was a member and took the first
row. For anyone with an existing conversation that was an arbitrary unrelated thread — very often
one the other party was not in at all. It now restricts to the two ids and requires a distinct
count of two, and is scoped to `DIRECT`.

**Deleting a conversation has never worked, for anyone.** This surfaced when a new test reached a
successful delete for the first time. `ConversationMember.conversation` and `Message.conversation`
were plain backrefs with no cascade, so the ORM disassociated the children rather than deferring
to the database:

```
IntegrityError: NOT NULL constraint failed: conversation_members.conversation_id
[SQL: UPDATE conversation_members SET conversation_id=?, updated_at=CURRENT_TIMESTAMP
      WHERE conversation_members.id = ?]
[parameters: [(None, '2207ea9f...'), (None, '93ffe2e8...')]]
```

Both columns are `nullable=False` with `ondelete="CASCADE"`, so that `UPDATE` could never succeed
— the route was a guaranteed 409. Both relationships now use `cascade="all, delete-orphan"` with
`passive_deletes=True`, so the database's own cascade does the work and the identity map stays
consistent. I posted this correction on the issue as well, since the original report overstated
what the delete route could do.

**Stale test fixed.** `test_router_prevent_self_messaging_integration` posted to `/conversations/`
while the router is mounted under `/api`, so it asserted `201` against a `404` and had been
failing on `main`.

---

## Testing

- [x] Tested locally
- [x] Existing tests pass
- [x] Added new tests

`tests/test_conversation_authorization.py` is new (31 tests), organised by who is calling:

- **Anonymous** — all seven routes return 401; add-member creates no membership row; delete
  leaves the conversation in place.
- **Authenticated non-member** — all seven return 404; a real id and a random UUID return the same
  status *and the same detail string*, so the routes cannot confirm an id; cannot add themselves.
- **Plain member** — can read; 403 on rename, archive, restore, delete, adding anyone, and
  removing someone else.
- **Admin** — can rename, archive, restore and add members; still 403 on delete.
- **Owner** — can do everything, including delete, and the row is actually gone afterwards.
- **Leaving** — a plain member can remove themselves, someone not in it gets 404, and after
  leaving the conversation is no longer readable.
- **The exploit, end to end** — owner sends a message, an outsider tries to join anonymously
  (401) and then as a logged-in stranger (404), and the messages API still refuses them (403).
  Paired with a test that a real member can still read the thread, so the guard did not just
  break the legitimate path.
- **`get_direct_conversation`** — finds the right thread; returns `None` when there is no shared
  one (the `or_` bug, with a third user set up so the old code would have returned the wrong
  conversation); ignores a group thread containing both; symmetric; and no self-conversation.

Full backend suite compared against `main` in a clean worktree:

```
baseline: 89  branch: 88
=== REGRESSIONS ===
=== FIXED ===
FAILED tests/test_conversations.py::test_router_prevent_self_messaging_integration
```

No regressions, and one pre-existing failure cleared.

---

## Checklist

- [x] My code follows the project's coding standards.
- [x] I have tested my changes locally.
- [x] I have updated the documentation where necessary.
- [x] My changes do not introduce new warnings or errors.
- [x] I have reviewed my own code.
- [x] This pull request focuses on a single feature or fix.
- [x] I have linked the related issue.

---

## Additional Notes

**No API grants `ADMIN` within a conversation.** `create_conversation` sets `OWNER`, `add_member`
defaults to `MEMBER`, and nothing promotes. So in practice today only the creator can administer
a thread. That is the correct restrictive default and a separate route can add promotion later —
the role check is in place and tested for when it does.

**Existing conversations are unaffected.** No migration: the roles were already being written,
they were simply never read.

ECSoc 2026
