### PR TITLE
fix(api-keys): authorize organization keys instead of skipping the check

### DIFF
--- a/backend/app/routers/api_keys.py
+++ b/backend/app/routers/api_keys.py
@@ -1,3 +1,18 @@
+"""
+API key routes.
+
+A key belongs either to a user or to an organisation, never both. The routes
+below are shared by the two shapes: there are no organisation-scoped read,
+update, regenerate or revoke routes, so an organisation key is managed through
+`/api/api-keys/{key_id}` like any other.
+
+That is why every one of them delegates the ownership decision to
+`ApiKeyService.assert_can_manage` rather than checking `key.user_id` inline.
+The inline version short-circuited on organisation keys -- where `user_id` is
+NULL -- and let any authenticated caller regenerate someone else's
+organisation secret and be handed the plaintext.
+"""
+
 from __future__ import annotations
 
 import uuid
@@ -99,11 +114,19 @@ def create_api_key(
 def list_api_keys(
     page: int = Query(1, ge=1),
     limit: int = Query(20, ge=1, le=100),
+    include_revoked: bool = Query(
+        False,
+        description="Include keys that have been revoked. Off by default.",
+    ),
     db: Session = Depends(get_database),
     current_user: User = Depends(get_current_user),
 ) -> PaginatedApiKeysResponse:
     res = ApiKeyService.list_api_keys(
-        db, user_id=current_user.id, page=page, limit=limit
+        db,
+        user_id=current_user.id,
+        page=page,
+        limit=limit,
+        include_revoked=include_revoked,
     )
     items = [ApiKeyResponse.model_validate(k) for k in res["items"]]
     return PaginatedApiKeysResponse(
@@ -119,18 +142,21 @@ def list_api_keys(
     "/{key_id}",
     response_model=ApiKeyResponse,
     summary="Get API Key Details",
-    description="Retrieve metadata for a specific API key.",
+    description=(
+        "Retrieve metadata for a specific API key. Personal keys are readable "
+        "by their owner; organisation keys by anyone holding "
+        "`org:manage_tokens` in that organisation."
+    ),
 )
 def get_api_key(
     key_id: uuid.UUID,
     db: Session = Depends(get_database),
     current_user: User = Depends(get_current_user),
 ) -> ApiKeyResponse:
-    key = ApiKeyService.get_api_key(db, key_id)
-    if key.user_id and key.user_id != current_user.id and not current_user.is_superuser:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN, detail="Permission denied"
-        )
+    # This route used to carry its own copy of the ownership condition, and
+    # the copy had the same short-circuit bug as the three in the service.
+    # One helper, one place to get it wrong.
+    key = ApiKeyService.get_manageable_api_key(db, key_id, current_user)
     return ApiKeyResponse.model_validate(key)
 
 
@@ -236,10 +262,18 @@ def list_org_api_keys(
     organization_id: uuid.UUID,
     page: int = Query(1, ge=1),
     limit: int = Query(20, ge=1, le=100),
+    include_revoked: bool = Query(
+        False,
+        description="Include keys that have been revoked. Off by default.",
+    ),
     db: Session = Depends(get_database),
 ) -> PaginatedApiKeysResponse:
     res = ApiKeyService.list_api_keys(
-        db, organization_id=organization_id, page=page, limit=limit
+        db,
+        organization_id=organization_id,
+        page=page,
+        limit=limit,
+        include_revoked=include_revoked,
     )
     items = [ApiKeyResponse.model_validate(k) for k in res["items"]]
     return PaginatedApiKeysResponse(

--- a/backend/app/services/api_key_service.py
+++ b/backend/app/services/api_key_service.py
@@ -10,6 +10,7 @@ from fastapi import HTTPException, status
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
+from app.core.rbac import ORG_MANAGE_TOKENS, has_org_permission
 from app.models.api_key import ApiKey
 from app.models.audit_log import AuditAction
 from app.models.user import User
@@ -24,6 +25,17 @@ from app.services.audit_log_service import AuditLogService
 class ApiKeyService:
     """
     Business logic for API Key Management (#605)
+
+    A key has exactly one owner, expressed as one of two mutually exclusive
+    columns: a personal key sets ``user_id`` and leaves ``organization_id``
+    NULL, an organisation key does the opposite. Every ownership check used to
+    be spelled ``if key.user_id and key.user_id != actor.id and not
+    actor.is_superuser`` -- which, for an organisation key, short-circuits on
+    the first operand and skips the check entirely.
+
+    All four management operations now route through
+    :meth:`assert_can_manage`, which branches on which owner column is set
+    instead of assuming there is only one.
     """
 
     @staticmethod
@@ -35,6 +47,69 @@ class ApiKeyService:
         # codeql[py/weak-sensitive-data-hashing] These are high entropy tokens, not passwords
         hashed_key = hashlib.sha256(raw_key.encode("utf-8")).hexdigest()
         return raw_key, prefix, hashed_key
+
+    # ------------------------------------------------------------------
+    # Authorization
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def can_manage(db: Session, key: ApiKey, actor: User) -> bool:
+        """Whether ``actor`` may read or change ``key``.
+
+        Three cases, in the order they are cheapest to answer:
+
+        * a superuser may manage anything;
+        * a personal key is managed by the user it belongs to;
+        * an organisation key is managed by anyone holding
+          ``org:manage_tokens`` in that organisation -- the same grant the
+          create and list routes already require.
+
+        A key with neither owner column set is a data error, not a free-for-all.
+        It falls through to ``False`` deliberately: the previous expression
+        treated it as unowned and therefore unguarded, which is the opposite of
+        what an unattributable credential deserves.
+        """
+        if getattr(actor, "is_superuser", False):
+            return True
+
+        if key.user_id is not None:
+            return key.user_id == actor.id
+
+        if key.organization_id is not None:
+            return has_org_permission(
+                db,
+                actor.id,
+                key.organization_id,
+                ORG_MANAGE_TOKENS,
+            )
+
+        return False
+
+    @classmethod
+    def assert_can_manage(cls, db: Session, key: ApiKey, actor: User) -> None:
+        """Raise 403 unless ``actor`` may manage ``key``."""
+        if not cls.can_manage(db, key, actor):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Permission denied",
+            )
+
+    @classmethod
+    def get_manageable_api_key(
+        cls,
+        db: Session,
+        key_id: uuid.UUID,
+        actor: User,
+    ) -> ApiKey:
+        """Load a key the actor is allowed to touch, or fail.
+
+        One call site for the two steps, so a route cannot fetch a key and
+        then forget to check it -- which is how ``GET /api/api-keys/{key_id}``
+        ended up with its own hand-rolled copy of the broken condition.
+        """
+        key = cls.get_api_key(db, key_id)
+        cls.assert_can_manage(db, key, actor)
+        return key
 
     @classmethod
     def validate_scopes(cls, scopes: List[str]) -> List[str]:
@@ -114,8 +189,20 @@ class ApiKeyService:
         organization_id: Optional[uuid.UUID] = None,
         page: int = 1,
         limit: int = 20,
+        include_revoked: bool = False,
     ) -> Dict[str, Any]:
-        """List API keys for user or organization."""
+        """List API keys for user or organization.
+
+        Revoked keys are excluded by default. The filter used to be a comment
+        and an unrelated ``order_by``::
+
+            # Exclude revoked/deleted keys or order active first
+            stmt = stmt.order_by(ApiKey.created_at.desc())
+
+        so a revoked key stayed in the list looking much like a live one, and
+        the pagination totals counted it. ``include_revoked`` keeps the audit
+        view available for a management UI that wants the history.
+        """
         stmt = select(ApiKey)
 
         if organization_id:
@@ -128,7 +215,9 @@ class ApiKeyService:
                 detail="Must provide user_id or organization_id",
             )
 
-        # Exclude revoked/deleted keys or order active first
+        if not include_revoked:
+            stmt = stmt.where(ApiKey.is_active.is_(True))
+
         stmt = stmt.order_by(ApiKey.created_at.desc())
 
         count_stmt = select(func.count()).select_from(stmt.subquery())
@@ -166,10 +255,7 @@ class ApiKeyService:
         key = cls.get_api_key(db, key_id)
 
         # Authorization check
-        if key.user_id and key.user_id != actor.id and not actor.is_superuser:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail="Permission denied"
-            )
+        cls.assert_can_manage(db, key, actor)
 
         if payload.name is not None:
             key.name = payload.name
@@ -210,10 +296,7 @@ class ApiKeyService:
         """
         key = cls.get_api_key(db, key_id)
 
-        if key.user_id and key.user_id != actor.id and not actor.is_superuser:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail="Permission denied"
-            )
+        cls.assert_can_manage(db, key, actor)
 
         raw_key, prefix, hashed_key = cls.generate_raw_key()
         key.prefix = prefix
@@ -248,10 +331,7 @@ class ApiKeyService:
         """Revoke API Key immediately."""
         key = cls.get_api_key(db, key_id)
 
-        if key.user_id and key.user_id != actor.id and not actor.is_superuser:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail="Permission denied"
-            )
+        cls.assert_can_manage(db, key, actor)
 
         key.is_active = False
         key.updated_at = datetime.now(timezone.utc)

--- a/backend/tests/test_api_key_organization_authz.py
+++ b/backend/tests/test_api_key_organization_authz.py
@@ -1,0 +1,464 @@
+"""
+Ownership checks for API keys, for both owner shapes.
+
+An `ApiKey` belongs either to a user (`user_id` set, `organization_id` NULL) or
+to an organisation (the reverse). Every ownership check was written as::
+
+    if key.user_id and key.user_id != actor.id and not actor.is_superuser:
+
+For an organisation key `key.user_id` is `None`, the `and` short-circuits on
+the first operand, and no check runs at all. There are no organisation-scoped
+read/update/regenerate/revoke routes, so organisation keys are managed through
+the personal `/api/v1/api-keys/{key_id}` routes -- which meant any authenticated
+user could regenerate an organisation's key and be handed the new plaintext in
+the response.
+
+These tests are integration tests against a real session rather than the
+`MagicMock` style of `test_api_key_management.py`, because the bug is about
+which *row* is being authorised against, and a mock will happily agree with
+whatever the code asks it.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.models.api_key import ApiKey
+from app.models.organization import Organization
+from app.models.organization_member import OrganizationMember, OrgMemberRole
+from app.models.user import User
+from app.services.api_key_service import ApiKeyService
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _account(register_and_login, email: str, username: str) -> dict:
+    uid, token = register_and_login(email, username)
+    return {
+        "id": uid,
+        "uuid": uuid.UUID(uid),
+        "token": token,
+        "headers": {"Authorization": f"Bearer {token}"},
+    }
+
+
+@pytest.fixture
+def org_owner(register_and_login):
+    return _account(register_and_login, "orgowner@example.com", "orgowner")
+
+
+@pytest.fixture
+def org_member(register_and_login):
+    """In the organisation, but as a plain member -- no `org:manage_tokens`."""
+    return _account(register_and_login, "orgmember@example.com", "orgmember")
+
+
+@pytest.fixture
+def org_admin(register_and_login):
+    """In the organisation as an admin, which does carry `org:manage_tokens`."""
+    return _account(register_and_login, "orgadmin@example.com", "orgadmin")
+
+
+@pytest.fixture
+def stranger(register_and_login):
+    """Authenticated, and has nothing to do with the organisation."""
+    return _account(register_and_login, "stranger@example.com", "strangeruser")
+
+
+@pytest.fixture
+def organization(db, org_owner, org_member, org_admin) -> Organization:
+    org = Organization(
+        owner_id=org_owner["uuid"],
+        name="Acme Robotics",
+        slug="acme-robotics",
+    )
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+
+    db.add_all(
+        [
+            OrganizationMember(
+                organization_id=org.id,
+                user_id=org_member["uuid"],
+                role=OrgMemberRole.MEMBER,
+                is_active=True,
+            ),
+            OrganizationMember(
+                organization_id=org.id,
+                user_id=org_admin["uuid"],
+                role=OrgMemberRole.ADMIN,
+                is_active=True,
+            ),
+        ]
+    )
+    db.commit()
+    return org
+
+
+@pytest.fixture
+def org_key(db, organization, org_owner) -> ApiKey:
+    """An organisation key: `user_id` NULL, `organization_id` set.
+
+    Built directly rather than through the create route so the test does not
+    depend on that route's own guard being correct.
+    """
+    raw, prefix, hashed = ApiKeyService.generate_raw_key()
+    key = ApiKey(
+        id=uuid.uuid4(),
+        user_id=None,
+        organization_id=organization.id,
+        created_by_id=org_owner["uuid"],
+        name="CI deploy key",
+        prefix=prefix,
+        hashed_key=hashed,
+        scopes=["read:projects"],
+        is_active=True,
+    )
+    db.add(key)
+    db.commit()
+    db.refresh(key)
+    return key
+
+
+@pytest.fixture
+def personal_key(db, org_owner) -> ApiKey:
+    raw, prefix, hashed = ApiKeyService.generate_raw_key()
+    key = ApiKey(
+        id=uuid.uuid4(),
+        user_id=org_owner["uuid"],
+        organization_id=None,
+        created_by_id=org_owner["uuid"],
+        name="Laptop key",
+        prefix=prefix,
+        hashed_key=hashed,
+        scopes=["read:projects"],
+        is_active=True,
+    )
+    db.add(key)
+    db.commit()
+    db.refresh(key)
+    return key
+
+
+def _routes(key_id) -> list[tuple[str, str]]:
+    return [
+        ("GET", f"/api/v1/api-keys/{key_id}"),
+        ("PATCH", f"/api/v1/api-keys/{key_id}"),
+        ("POST", f"/api/v1/api-keys/{key_id}/regenerate"),
+        ("POST", f"/api/v1/api-keys/{key_id}/revoke"),
+        ("DELETE", f"/api/v1/api-keys/{key_id}"),
+    ]
+
+
+def _call(client: TestClient, method: str, path: str, headers: dict | None = None):
+    kwargs = {"headers": headers} if headers else {}
+    if method == "PATCH":
+        kwargs["json"] = {"name": "renamed"}
+    return client.request(method, path, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# The reported bug
+# ---------------------------------------------------------------------------
+
+
+class TestOrganizationKeyIsNotOpenToEveryone:
+    def test_stranger_is_refused_on_every_management_route(
+        self, client: TestClient, org_key, stranger
+    ):
+        for method, path in _routes(org_key.id):
+            response = _call(client, method, path, stranger["headers"])
+            assert response.status_code == 403, (
+                f"{method} {path} returned {response.status_code}"
+            )
+
+    def test_stranger_cannot_regenerate_and_be_handed_the_secret(
+        self, client: TestClient, org_key, stranger, db
+    ):
+        """The sharpest form of the bug.
+
+        `regenerate` writes a fresh `hashed_key` and returns the plaintext, so
+        the attacker did not read an existing secret -- they replaced it with
+        one they knew and were given it, breaking the organisation's real
+        integrations in the same request.
+        """
+        before = org_key.hashed_key
+
+        response = client.post(
+            f"/api/v1/api-keys/{org_key.id}/regenerate",
+            headers=stranger["headers"],
+        )
+        assert response.status_code == 403
+        assert "raw_key" not in response.text
+
+        db.refresh(org_key)
+        assert org_key.hashed_key == before
+
+    def test_stranger_cannot_widen_the_scopes(
+        self, client: TestClient, org_key, stranger, db
+    ):
+        """`full_access` validates, and `authenticate_api_key` treats it as a
+        wildcard, so a successful PATCH here was a full privilege escalation."""
+        response = client.patch(
+            f"/api/v1/api-keys/{org_key.id}",
+            headers=stranger["headers"],
+            json={"scopes": ["full_access"]},
+        )
+        assert response.status_code == 403
+
+        db.refresh(org_key)
+        assert org_key.scopes == ["read:projects"]
+
+    def test_stranger_cannot_revoke_the_key(
+        self, client: TestClient, org_key, stranger, db
+    ):
+        """Revocation is the denial-of-service form: one request per key."""
+        response = client.post(
+            f"/api/v1/api-keys/{org_key.id}/revoke", headers=stranger["headers"]
+        )
+        assert response.status_code == 403
+
+        db.refresh(org_key)
+        assert org_key.is_active is True
+
+    def test_stranger_cannot_read_the_metadata(
+        self, client: TestClient, org_key, stranger
+    ):
+        """The read route is how you pick a target worth regenerating."""
+        response = client.get(
+            f"/api/v1/api-keys/{org_key.id}", headers=stranger["headers"]
+        )
+        assert response.status_code == 403
+
+    def test_anonymous_caller_is_refused(self, client: TestClient, org_key):
+        for method, path in _routes(org_key.id):
+            response = _call(client, method, path)
+            assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Membership is not enough; the permission is
+# ---------------------------------------------------------------------------
+
+
+class TestOrganizationMembershipIsNotEnough:
+    def test_plain_member_is_refused(self, client: TestClient, org_key, org_member):
+        """`ORG_ROLE_PERMISSIONS[MEMBER]` does not include `org:manage_tokens`.
+
+        Being in the organisation is not the same as being allowed to manage
+        its credentials -- which is exactly the distinction the create and list
+        routes already draw with `require_org_permission(ORG_MANAGE_TOKENS)`.
+        """
+        for method, path in _routes(org_key.id):
+            response = _call(client, method, path, org_member["headers"])
+            assert response.status_code == 403
+
+
+class TestPermittedCallers:
+    def test_org_owner_can_read(self, client: TestClient, org_key, org_owner):
+        response = client.get(
+            f"/api/v1/api-keys/{org_key.id}", headers=org_owner["headers"]
+        )
+        assert response.status_code == 200
+        assert response.json()["name"] == "CI deploy key"
+
+    def test_org_owner_can_regenerate(
+        self, client: TestClient, org_key, org_owner, db
+    ):
+        before = org_key.hashed_key
+
+        response = client.post(
+            f"/api/v1/api-keys/{org_key.id}/regenerate", headers=org_owner["headers"]
+        )
+        assert response.status_code == 200
+        assert response.json()["raw_key"].startswith("dlk_live_")
+
+        db.refresh(org_key)
+        assert org_key.hashed_key != before
+
+    def test_org_admin_can_manage(self, client: TestClient, org_key, org_admin, db):
+        """`ADMIN` carries `org:manage_tokens`, so it passes."""
+        renamed = client.patch(
+            f"/api/v1/api-keys/{org_key.id}",
+            headers=org_admin["headers"],
+            json={"name": "CI deploy key v2"},
+        )
+        assert renamed.status_code == 200
+        assert renamed.json()["name"] == "CI deploy key v2"
+
+    def test_org_admin_can_revoke(self, client: TestClient, org_key, org_admin, db):
+        response = client.post(
+            f"/api/v1/api-keys/{org_key.id}/revoke", headers=org_admin["headers"]
+        )
+        assert response.status_code == 200
+
+        db.refresh(org_key)
+        assert org_key.is_active is False
+
+
+# ---------------------------------------------------------------------------
+# Personal keys must still behave exactly as before
+# ---------------------------------------------------------------------------
+
+
+class TestPersonalKeysUnchanged:
+    def test_owner_can_manage_their_own_key(
+        self, client: TestClient, personal_key, org_owner
+    ):
+        response = client.get(
+            f"/api/v1/api-keys/{personal_key.id}", headers=org_owner["headers"]
+        )
+        assert response.status_code == 200
+
+    def test_someone_else_cannot(self, client: TestClient, personal_key, stranger):
+        for method, path in _routes(personal_key.id):
+            response = _call(client, method, path, stranger["headers"])
+            assert response.status_code == 403
+
+    def test_an_org_admin_has_no_claim_on_a_personal_key(
+        self, client: TestClient, personal_key, org_admin
+    ):
+        """Holding `org:manage_tokens` must not reach across into personal keys."""
+        response = client.get(
+            f"/api/v1/api-keys/{personal_key.id}", headers=org_admin["headers"]
+        )
+        assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# The service predicate, directly
+# ---------------------------------------------------------------------------
+
+
+class TestCanManage:
+    def test_ownerless_key_is_denied(self, db, organization, org_owner, stranger):
+        """A key with neither owner column set is a data error, not a free-for-all.
+
+        The old expression treated it as unowned and therefore unguarded --
+        precisely backwards for an unattributable credential.
+        """
+        raw, prefix, hashed = ApiKeyService.generate_raw_key()
+        orphan = ApiKey(
+            id=uuid.uuid4(),
+            user_id=None,
+            organization_id=None,
+            created_by_id=org_owner["uuid"],
+            name="Orphan",
+            prefix=prefix,
+            hashed_key=hashed,
+            scopes=[],
+            is_active=True,
+        )
+        db.add(orphan)
+        db.commit()
+
+        actor = db.get(User, stranger["uuid"])
+        assert ApiKeyService.can_manage(db, orphan, actor) is False
+
+    def test_superuser_can_manage_anything(self, db, org_key, stranger):
+        actor = db.get(User, stranger["uuid"])
+        actor.is_superuser = True
+        db.add(actor)
+        db.commit()
+
+        assert ApiKeyService.can_manage(db, org_key, actor) is True
+
+    def test_org_permission_is_scoped_to_the_right_organization(
+        self, db, org_key, org_admin, org_owner
+    ):
+        """Admin of *another* organisation gets nothing.
+
+        A permission check that ignored `key.organization_id` would pass here.
+        """
+        other = Organization(
+            owner_id=org_admin["uuid"],
+            name="Other Corp",
+            slug="other-corp",
+        )
+        db.add(other)
+        db.commit()
+        db.refresh(other)
+
+        raw, prefix, hashed = ApiKeyService.generate_raw_key()
+        other_key = ApiKey(
+            id=uuid.uuid4(),
+            user_id=None,
+            organization_id=other.id,
+            created_by_id=org_admin["uuid"],
+            name="Other key",
+            prefix=prefix,
+            hashed_key=hashed,
+            scopes=[],
+            is_active=True,
+        )
+        db.add(other_key)
+        db.commit()
+
+        owner_actor = db.get(User, org_owner["uuid"])
+        assert ApiKeyService.can_manage(db, other_key, owner_actor) is False
+        assert ApiKeyService.can_manage(db, org_key, owner_actor) is True
+
+
+# ---------------------------------------------------------------------------
+# Revoked keys are not listed
+# ---------------------------------------------------------------------------
+
+
+class TestRevokedKeysAreExcluded:
+    def test_revoked_key_is_not_listed_by_default(
+        self, client: TestClient, personal_key, org_owner, db
+    ):
+        """The filter was a comment and an unrelated `order_by`.
+
+        A revoked key stayed in the list looking much like a live one, and the
+        pagination total counted it.
+        """
+        listed = client.get("/api/v1/api-keys/", headers=org_owner["headers"])
+        assert listed.status_code == 200
+        assert listed.json()["total"] == 1
+
+        personal_key.is_active = False
+        db.add(personal_key)
+        db.commit()
+
+        listed = client.get("/api/v1/api-keys/", headers=org_owner["headers"])
+        assert listed.json()["total"] == 0
+        assert listed.json()["items"] == []
+
+    def test_include_revoked_brings_it_back(
+        self, client: TestClient, personal_key, org_owner, db
+    ):
+        personal_key.is_active = False
+        db.add(personal_key)
+        db.commit()
+
+        listed = client.get(
+            "/api/v1/api-keys/",
+            params={"include_revoked": True},
+            headers=org_owner["headers"],
+        )
+        assert listed.json()["total"] == 1
+        assert listed.json()["items"][0]["name"] == "Laptop key"
+
+    def test_org_listing_excludes_revoked_too(
+        self, client: TestClient, organization, org_key, org_owner, db
+    ):
+        base = f"/api/v1/organizations/{organization.id}/api-keys/"
+
+        listed = client.get(base, headers=org_owner["headers"])
+        assert listed.status_code == 200
+        assert listed.json()["total"] == 1
+
+        org_key.is_active = False
+        db.add(org_key)
+        db.commit()
+
+        listed = client.get(base, headers=org_owner["headers"])
+        assert listed.json()["total"] == 0


### PR DESCRIPTION
## Summary

An `ApiKey` has one owner, in one of two mutually exclusive columns: a personal key sets
`user_id`, an organisation key sets `organization_id` and leaves `user_id` NULL. Every ownership
check in the module was written as

```python
if key.user_id and key.user_id != actor.id and not actor.is_superuser:
```

which short-circuits on the first operand for an organisation key — so no check ran at all. There
are no organisation-scoped read/update/regenerate/revoke routes; those go through the personal
`/api/v1/api-keys/{key_id}` routes, which is where the broken guard lived. Any authenticated user
could manage any organisation's key.

---

## Related Issue

Fixes #1390

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [ ] UI/UX enhancement
- [x] Tests
- [ ] Other

---

## Changes Made

**One authorization helper, used everywhere.** `ApiKeyService.assert_can_manage` branches on which
owner column is actually set rather than assuming there is only one:

- a superuser may manage anything;
- a personal key is managed by the user it belongs to;
- an organisation key is managed by anyone holding `org:manage_tokens` in **that** organisation —
  the same grant `require_org_permission(ORG_MANAGE_TOKENS)` already applies to the create and
  list routes;
- a key with neither column set is **denied**. The old expression treated it as unowned and
  therefore unguarded, which is precisely backwards for an unattributable credential.

`update_api_key`, `regenerate_api_key` and `revoke_api_key` all call it. So does
`GET /api/v1/api-keys/{key_id}`, which previously carried its own inline copy of the condition —
and the copy had the same bug. `get_manageable_api_key` puts the fetch and the check behind one
call so a route cannot do one without the other.

**Revoked keys are excluded from listings.** The filter was a comment sitting above an unrelated
`order_by`:

```python
# Exclude revoked/deleted keys or order active first
stmt = stmt.order_by(ApiKey.created_at.desc())
```

so a revoked key stayed in the list looking much like a live one, and the pagination `total`
counted it. `include_revoked=true` keeps the history available for a management UI.

### Why this mattered

`POST /{key_id}/regenerate` writes a fresh `hashed_key` and returns the plaintext under
`ApiKeyCreateResponse`. The attacker was not reading an existing secret — they replaced it with
one they knew and were handed it, breaking the organisation's real integrations in the same
request. `PATCH` could set `scopes` to `full_access`, which `authenticate_api_key` treats as a
wildcard. `POST /revoke` was a denial of service, one id at a time. `GET` supplied the metadata to
pick a target worth doing it to.

---

## Testing

- [x] Tested locally
- [x] Existing tests pass
- [x] Added new tests

`tests/test_api_key_organization_authz.py` is new (20 tests). These are integration tests against
a real session rather than the `MagicMock` style of the existing `test_api_key_management.py`,
deliberately: the bug is about *which row* is being authorised against, and a mock will happily
agree with whatever the code asks it. That is a large part of why the existing suite passed
throughout.

- **The reported bug** — a stranger is refused on all five management routes; cannot regenerate
  (and `raw_key` does not appear in the response, with the stored hash asserted unchanged);
  cannot widen scopes to `full_access`; cannot revoke; cannot read the metadata; anonymous gets
  401.
- **Membership is not the permission** — a plain `MEMBER` of the organisation is refused on all
  five. `ORG_ROLE_PERMISSIONS[MEMBER]` does not include `org:manage_tokens`.
- **Permitted callers** — the org owner can read and regenerate (new hash asserted different); an
  org `ADMIN` can rename and revoke.
- **Personal keys unchanged** — owner can manage, a stranger cannot, and an org admin has no
  claim on a personal key (the permission must not leak sideways).
- **`can_manage` directly** — an ownerless key is denied; a superuser passes; and an admin of a
  *different* organisation is refused, which is the case a check that ignored
  `key.organization_id` would wrongly pass.
- **Listing** — revoked keys drop out of both the personal and organisation listings and out of
  `total`; `include_revoked=true` brings them back.

**These tests were run against `main` to confirm they catch the bug** — 11 of the 20 fail there,
including every one of the stranger/member authorization cases:

```
tests/test_api_key_organization_authz.py  11 failed, 9 passed   (on main)
tests/test_api_key_organization_authz.py  20 passed             (on this branch)
```

Full backend suite compared against `main` in a clean worktree: **89 failures before, 89 after,
no regressions.**

---

## Checklist

- [x] My code follows the project's coding standards.
- [x] I have tested my changes locally.
- [x] I have updated the documentation where necessary.
- [x] My changes do not introduce new warnings or errors.
- [x] I have reviewed my own code.
- [x] This pull request focuses on a single feature or fix.
- [x] I have linked the related issue.

---

## Additional Notes

**No migration.** Both owner columns already exist and are already populated correctly by
`create_api_key`; only the reading of them was wrong.

**`authenticate_api_key` still has no callers.** `verify_api_key` builds the dependency and no
route depends on it, so keys can be minted and managed but authenticate nothing. Out of scope
here — it is a feature gap rather than the vulnerability — but it is worth a separate issue, and
it is part of why this went unnoticed: nobody exercises the path.

**This router is the only one mounted under `/api/v1`.** Everything else is under `/api`. Not
changed here, since moving it would break any client that has already integrated, but it is worth
knowing when reading the paths above. I have noted it on the issue.

ECSoc 2026
