### PR TITLE
fix(plugins): authorize event dispatch and organization installations

### DIFF
--- a/backend/app/core/rbac.py
+++ b/backend/app/core/rbac.py
@@ -152,6 +152,14 @@ ORG_MANAGE_CANDIDATES = "org:manage_candidates"
 ORG_MANAGE_CONTENT = "org:manage_content"
 ORG_VIEW_CONTENT = "org:view_content"
 
+#: Install, configure and remove plugins on behalf of an organization.
+#:
+#: Its own permission rather than a reuse of :data:`ORG_MANAGE_TOKENS`: a
+#: plugin installation attaches a third-party webhook destination to the
+#: organization's event stream, which is a different question from "may this
+#: person mint an API key", even though the two often land on the same people.
+ORG_MANAGE_PLUGINS = "org:manage_plugins"
+
 ORG_ROLE_PERMISSIONS: dict[OrgMemberRole, frozenset[str]] = {
     OrgMemberRole.OWNER: frozenset(
         {
@@ -163,6 +171,7 @@ ORG_ROLE_PERMISSIONS: dict[OrgMemberRole, frozenset[str]] = {
             ORG_MANAGE_JOBS,
             ORG_MANAGE_CANDIDATES,
             ORG_MANAGE_CONTENT,
+            ORG_MANAGE_PLUGINS,
             ORG_VIEW_CONTENT,
         }
     ),
@@ -175,6 +184,7 @@ ORG_ROLE_PERMISSIONS: dict[OrgMemberRole, frozenset[str]] = {
             ORG_MANAGE_JOBS,
             ORG_MANAGE_CANDIDATES,
             ORG_MANAGE_CONTENT,
+            ORG_MANAGE_PLUGINS,
             ORG_VIEW_CONTENT,
         }
     ),

--- a/backend/app/routers/plugins.py
+++ b/backend/app/routers/plugins.py
@@ -141,12 +141,18 @@ def list_installed_plugins(
 @router.post(
     "/dispatch-event",
     response_model=PluginEventDispatchResult,
-    summary="Dispatch Plugin Extension Event",
-    description="Trigger an extension point event across active and enabled plugin integrations.",
+    summary="Dispatch Plugin Extension Event (administrators only)",
+    description=(
+        "Trigger an extension point event across active and enabled plugin "
+        "integrations. This is a platform-internal fan-out primitive: it "
+        "enumerates every enabled installation on the platform, not just the "
+        "caller's, so it is restricted to administrators."
+    ),
 )
 def dispatch_plugin_event(
     event_in: PluginEventDispatch,
     db: Session = Depends(get_database),
+    _actor: User = Depends(require_admin),
 ) -> PluginEventDispatchResult:
     return PluginService.dispatch_event(
         db, event=event_in.event, payload=event_in.payload

--- a/backend/app/schemas/plugin.py
+++ b/backend/app/schemas/plugin.py
@@ -130,7 +130,15 @@ class PluginDispatchItem(BaseModel):
     plugin_id: uuid.UUID
     plugin_slug: str
     installation_id: uuid.UUID
-    webhook_url: Optional[str] = None
+    has_webhook: bool = Field(
+        default=False,
+        description=(
+            "Whether the plugin's manifest declares a webhook destination. "
+            "The URL itself is not returned: an integration webhook is a "
+            "bearer credential in practice, and a dispatch result does not "
+            "need to repeat the destination to report what happened."
+        ),
+    )
     status: str = Field(
         description="Dispatch status: 'queued', 'skipped', 'no_webhook'"
     )

--- a/backend/app/services/plugin_service.py
+++ b/backend/app/services/plugin_service.py
@@ -11,6 +11,7 @@ from fastapi import HTTPException, status
 from sqlalchemy import func, select, or_
 from sqlalchemy.orm import Session, selectinload
 
+from app.core.rbac import ORG_MANAGE_PLUGINS, has_org_permission
 from app.models.plugin import (
     Plugin,
     PluginInstallation,
@@ -219,6 +220,69 @@ class PluginService:
     # Installation & Uninstallation Management
     # ------------------------------------------------------------------
 
+    # ------------------------------------------------------------------
+    # Authorization
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def assert_can_manage_org_plugins(
+        db: Session,
+        user: User,
+        organization_id: uuid.UUID,
+    ) -> None:
+        """Raise 403 unless ``user`` may manage plugins for that organization.
+
+        ``organization_id`` arrives from the request -- in the body for
+        install, as a query parameter for uninstall and list -- and was used
+        unvalidated. Any logged-in user could therefore install a plugin into
+        any organization, and since an installation is what ``dispatch_event``
+        fans out over, that was also how an attacker attached a webhook
+        destination of their choosing to somebody else's event stream.
+        Uninstall was the mirror image: a one-request removal of an
+        organization's integrations.
+        """
+        if not has_org_permission(db, user.id, organization_id, ORG_MANAGE_PLUGINS):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You do not have permission to manage plugins for this organization.",
+            )
+
+    @staticmethod
+    def can_manage_installation(
+        db: Session,
+        user: User,
+        installation: PluginInstallation,
+    ) -> bool:
+        """Whether ``user`` may enable, disable or reconfigure an installation.
+
+        Mirrors the two owner shapes on the row itself. The previous check was
+
+            if installation.user_id != user.id and not is_admin:
+
+        which is correct for a personal installation and wrong for an
+        organization one: ``user_id`` is ``None`` there, so ``None != user.id``
+        held for everybody -- including the organization's own admins, who were
+        left with no way to disable a plugin somebody else had installed on
+        them.
+        """
+        if getattr(user, "is_superuser", False):
+            return True
+        if getattr(user, "system_role", None) == "admin":
+            return True
+
+        if installation.user_id is not None:
+            return installation.user_id == user.id
+
+        if installation.organization_id is not None:
+            return has_org_permission(
+                db,
+                user.id,
+                installation.organization_id,
+                ORG_MANAGE_PLUGINS,
+            )
+
+        return False
+
     @staticmethod
     def install_plugin(
         db: Session,
@@ -235,6 +299,9 @@ class PluginService:
             )
 
         org_id = install_in.organization_id
+
+        if org_id:
+            PluginService.assert_can_manage_org_plugins(db, user, org_id)
 
         # Check existing installation
         if org_id:
@@ -294,6 +361,8 @@ class PluginService:
         plugin = PluginService.get_plugin_or_404(db, plugin_id)
 
         if organization_id:
+            PluginService.assert_can_manage_org_plugins(db, user, organization_id)
+
             installation = db.scalar(
                 select(PluginInstallation).where(
                     PluginInstallation.plugin_id == plugin.id,
@@ -333,6 +402,11 @@ class PluginService:
         )
 
         if organization_id:
+            # Listing an organization's installations discloses which
+            # third-party integrations it runs and how they are configured, so
+            # it needs the same permission as changing them.
+            PluginService.assert_can_manage_org_plugins(db, user, organization_id)
+
             stmt = stmt.where(PluginInstallation.organization_id == organization_id)
         else:
             stmt = stmt.where(
@@ -363,8 +437,7 @@ class PluginService:
                 detail="Plugin installation not found.",
             )
 
-        is_admin = getattr(user, "system_role", None) == "admin"
-        if installation.user_id != user.id and not is_admin:
+        if not PluginService.can_manage_installation(db, user, installation):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Not authorized to update this installation.",
@@ -430,12 +503,17 @@ class PluginService:
                     else None
                 )
                 dispatched_status = "queued" if webhook_url else "no_webhook"
+                # The URL itself is deliberately not echoed back. An
+                # integration webhook is a bearer credential in practice -- a
+                # Slack or Discord hook URL is postable by anyone holding the
+                # string -- and a dispatch result has no need to repeat the
+                # destination to tell the caller what happened.
                 dispatches.append(
                     PluginDispatchItem(
                         plugin_id=inst.plugin.id,
                         plugin_slug=inst.plugin.slug,
                         installation_id=inst.id,
-                        webhook_url=webhook_url,
+                        has_webhook=bool(webhook_url),
                         status=dispatched_status,
                     )
                 )

--- a/backend/tests/test_plugin_authorization.py
+++ b/backend/tests/test_plugin_authorization.py
@@ -1,0 +1,504 @@
+"""
+Authorization for the plugin system.
+
+Two holes, which compounded:
+
+1. `POST /api/plugins/dispatch-event` needed no token, and its response listed
+   every enabled installation on the platform together with each one's
+   `webhook_url` -- and an integration webhook URL is a bearer credential in
+   practice, postable by anyone holding the string.
+2. `install_plugin`, `uninstall_plugin` and `list_user_installations` took
+   `organization_id` straight from the request and never checked the caller
+   belonged to that organisation. Since an installation is what
+   `dispatch_event` fans out over, that was also how an attacker attached a
+   webhook destination of their own choosing to somebody else's event stream.
+
+`update_installation` was the odd one out: it checked, but only the personal
+case, so an organisation's own admins could not disable a plugin installed on
+them.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.rbac import ORG_MANAGE_PLUGINS, has_org_permission
+from app.models.organization import Organization
+from app.models.organization_member import OrganizationMember, OrgMemberRole
+from app.models.plugin import Plugin, PluginInstallation, PluginStatus, PluginType
+from app.models.user import User
+from app.services.plugin_service import PluginService
+
+WEBHOOK = "https://hooks.example.com/services/T000/B000/secret-token"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _account(register_and_login, email: str, username: str) -> dict:
+    uid, token = register_and_login(email, username)
+    return {
+        "id": uid,
+        "uuid": uuid.UUID(uid),
+        "token": token,
+        "headers": {"Authorization": f"Bearer {token}"},
+    }
+
+
+@pytest.fixture
+def author(register_and_login):
+    return _account(register_and_login, "author@example.com", "pluginauthor")
+
+
+@pytest.fixture
+def org_owner(register_and_login):
+    return _account(register_and_login, "plugowner@example.com", "plugowner")
+
+
+@pytest.fixture
+def org_member(register_and_login):
+    """In the organisation as a plain member -- no `org:manage_plugins`."""
+    return _account(register_and_login, "plugmember@example.com", "plugmember")
+
+
+@pytest.fixture
+def stranger(register_and_login):
+    return _account(register_and_login, "plugstranger@example.com", "plugstranger")
+
+
+@pytest.fixture
+def admin(register_and_login, db):
+    acct = _account(register_and_login, "plugadmin@example.com", "plugadmin")
+    user = db.get(User, acct["uuid"])
+    user.system_role = "admin"
+    db.add(user)
+    db.commit()
+    return acct
+
+
+@pytest.fixture
+def organization(db, org_owner, org_member) -> Organization:
+    org = Organization(
+        owner_id=org_owner["uuid"],
+        name="Widget Works",
+        slug="widget-works",
+    )
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+
+    db.add(
+        OrganizationMember(
+            organization_id=org.id,
+            user_id=org_member["uuid"],
+            role=OrgMemberRole.MEMBER,
+            is_active=True,
+        )
+    )
+    db.commit()
+    return org
+
+
+@pytest.fixture
+def plugin(db, author) -> Plugin:
+    p = Plugin(
+        id=uuid.uuid4(),
+        name="Chat Notifier",
+        slug="chat-notifier",
+        description="Posts project events to a chat channel.",
+        version="1.0.0",
+        author_id=author["uuid"],
+        plugin_type=PluginType.INTEGRATION,
+        status=PluginStatus.ACTIVE,
+        manifest={
+            "extension_points": ["on_project_created"],
+            "webhook_url": WEBHOOK,
+        },
+    )
+    db.add(p)
+    db.commit()
+    db.refresh(p)
+    return p
+
+
+@pytest.fixture
+def org_installation(db, plugin, organization) -> PluginInstallation:
+    inst = PluginInstallation(
+        id=uuid.uuid4(),
+        plugin_id=plugin.id,
+        user_id=None,
+        organization_id=organization.id,
+        is_enabled=True,
+        config={"channel": "#builds"},
+    )
+    db.add(inst)
+    db.commit()
+    db.refresh(inst)
+    return inst
+
+
+# ---------------------------------------------------------------------------
+# dispatch-event
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchEventRequiresAdmin:
+    def test_anonymous_caller_is_rejected(self, client: TestClient, org_installation):
+        """The reported bug: this route took no token at all."""
+        response = client.post(
+            "/api/plugins/dispatch-event",
+            json={"event": "on_project_created", "payload": {}},
+        )
+        assert response.status_code == 401
+
+    def test_ordinary_user_is_rejected(
+        self, client: TestClient, org_installation, stranger
+    ):
+        response = client.post(
+            "/api/plugins/dispatch-event",
+            json={"event": "on_project_created", "payload": {}},
+            headers=stranger["headers"],
+        )
+        assert response.status_code == 403
+
+    def test_the_plugin_author_is_not_special(
+        self, client: TestClient, org_installation, author
+    ):
+        """Publishing a plugin does not grant the right to fan out events."""
+        response = client.post(
+            "/api/plugins/dispatch-event",
+            json={"event": "on_project_created", "payload": {}},
+            headers=author["headers"],
+        )
+        assert response.status_code == 403
+
+    def test_admin_can_dispatch(self, client: TestClient, org_installation, admin):
+        response = client.post(
+            "/api/plugins/dispatch-event",
+            json={"event": "on_project_created", "payload": {}},
+            headers=admin["headers"],
+        )
+        assert response.status_code == 200
+        assert response.json()["matched_plugins_count"] == 1
+        assert response.json()["dispatched_installations_count"] == 1
+
+
+class TestDispatchResponseDoesNotLeakWebhooks:
+    def test_the_webhook_url_never_appears_in_the_response(
+        self, client: TestClient, org_installation, admin
+    ):
+        """Defence in depth: even the permitted caller does not get the URL.
+
+        A webhook destination is a bearer credential -- anyone holding the
+        string can post as the integration -- and a dispatch result does not
+        need to repeat the destination to say what happened.
+        """
+        response = client.post(
+            "/api/plugins/dispatch-event",
+            json={"event": "on_project_created", "payload": {}},
+            headers=admin["headers"],
+        )
+        assert response.status_code == 200
+        assert WEBHOOK not in response.text
+        assert "webhook_url" not in response.text
+
+    def test_a_boolean_reports_whether_one_is_configured(
+        self, client: TestClient, org_installation, admin
+    ):
+        response = client.post(
+            "/api/plugins/dispatch-event",
+            json={"event": "on_project_created", "payload": {}},
+            headers=admin["headers"],
+        )
+        item = response.json()["dispatches"][0]
+        assert item["has_webhook"] is True
+        assert item["status"] == "queued"
+
+    def test_a_plugin_without_a_webhook_reports_false(
+        self, client: TestClient, db, plugin, organization, admin
+    ):
+        plugin.manifest = {"extension_points": ["on_project_created"]}
+        db.add(plugin)
+        db.add(
+            PluginInstallation(
+                id=uuid.uuid4(),
+                plugin_id=plugin.id,
+                organization_id=organization.id,
+                is_enabled=True,
+                config={},
+            )
+        )
+        db.commit()
+
+        response = client.post(
+            "/api/plugins/dispatch-event",
+            json={"event": "on_project_created", "payload": {}},
+            headers=admin["headers"],
+        )
+        item = response.json()["dispatches"][0]
+        assert item["has_webhook"] is False
+        assert item["status"] == "no_webhook"
+
+
+# ---------------------------------------------------------------------------
+# Installing into an organisation
+# ---------------------------------------------------------------------------
+
+
+class TestOrganizationInstallRequiresPermission:
+    def test_stranger_cannot_install_into_an_organization(
+        self, client: TestClient, plugin, organization, stranger, db
+    ):
+        response = client.post(
+            f"/api/plugins/{plugin.id}/install",
+            json={"organization_id": str(organization.id), "config": {}},
+            headers=stranger["headers"],
+        )
+        assert response.status_code == 403
+
+        assert (
+            db.query(PluginInstallation)
+            .filter(PluginInstallation.organization_id == organization.id)
+            .count()
+            == 0
+        )
+
+    def test_plain_member_cannot_install_into_their_own_organization(
+        self, client: TestClient, plugin, organization, org_member
+    ):
+        """`ORG_ROLE_PERMISSIONS[MEMBER]` does not carry `org:manage_plugins`.
+
+        Being in the organisation is not the same as being allowed to attach a
+        third-party webhook to its event stream.
+        """
+        response = client.post(
+            f"/api/plugins/{plugin.id}/install",
+            json={"organization_id": str(organization.id), "config": {}},
+            headers=org_member["headers"],
+        )
+        assert response.status_code == 403
+
+    def test_org_owner_can_install(
+        self, client: TestClient, plugin, organization, org_owner, db
+    ):
+        response = client.post(
+            f"/api/plugins/{plugin.id}/install",
+            json={"organization_id": str(organization.id), "config": {}},
+            headers=org_owner["headers"],
+        )
+        assert response.status_code == 201
+        assert response.json()["organization_id"] == str(organization.id)
+
+    def test_personal_install_still_works_for_anyone(
+        self, client: TestClient, plugin, stranger
+    ):
+        """The guard must only fire when an organisation is named."""
+        response = client.post(
+            f"/api/plugins/{plugin.id}/install",
+            json={"config": {}},
+            headers=stranger["headers"],
+        )
+        assert response.status_code == 201
+        assert response.json()["user_id"] == stranger["id"]
+        assert response.json()["organization_id"] is None
+
+
+class TestOrganizationUninstallRequiresPermission:
+    def test_stranger_cannot_remove_an_organizations_integration(
+        self, client: TestClient, plugin, organization, org_installation, stranger, db
+    ):
+        response = client.delete(
+            f"/api/plugins/{plugin.id}/install",
+            params={"organization_id": str(organization.id)},
+            headers=stranger["headers"],
+        )
+        assert response.status_code == 403
+
+        db.expire_all()
+        assert db.get(PluginInstallation, org_installation.id) is not None
+
+    def test_org_owner_can_uninstall(
+        self, client: TestClient, plugin, organization, org_installation, org_owner, db
+    ):
+        # Read the id before the request: after the row is gone, touching an
+        # expired attribute on the instance raises ObjectDeletedError.
+        installation_id = org_installation.id
+
+        response = client.delete(
+            f"/api/plugins/{plugin.id}/install",
+            params={"organization_id": str(organization.id)},
+            headers=org_owner["headers"],
+        )
+        assert response.status_code in (200, 204)
+
+        # The delete happened in the request's session, so this one still holds
+        # the row in its identity map. Expire before re-reading.
+        db.expire_all()
+        assert db.get(PluginInstallation, installation_id) is None
+
+
+class TestOrganizationListingRequiresPermission:
+    def test_stranger_cannot_enumerate_an_organizations_installations(
+        self, client: TestClient, organization, org_installation, stranger
+    ):
+        """The listing discloses which integrations an organisation runs, and
+        the config they run with."""
+        response = client.get(
+            "/api/plugins/installed/me",
+            params={"organization_id": str(organization.id)},
+            headers=stranger["headers"],
+        )
+        assert response.status_code == 403
+
+    def test_org_owner_can_list(
+        self, client: TestClient, organization, org_installation, org_owner
+    ):
+        response = client.get(
+            "/api/plugins/installed/me",
+            params={"organization_id": str(organization.id)},
+            headers=org_owner["headers"],
+        )
+        assert response.status_code == 200
+        assert len(response.json()) == 1
+
+    def test_listing_your_own_installations_needs_nothing(
+        self, client: TestClient, stranger
+    ):
+        response = client.get(
+            "/api/plugins/installed/me", headers=stranger["headers"]
+        )
+        assert response.status_code == 200
+        assert response.json() == []
+
+
+# ---------------------------------------------------------------------------
+# update_installation
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateInstallation:
+    def test_org_owner_can_disable_an_org_installation(
+        self, client: TestClient, org_installation, org_owner, db
+    ):
+        """This used to be refused, which was the mirror-image bug.
+
+        `installation.user_id != user.id` held for everybody on an
+        organisation installation, because `user_id` is NULL there -- so the
+        organisation's own admins had no way to turn off a plugin somebody
+        else had installed on them.
+        """
+        response = client.patch(
+            f"/api/plugins/installations/{org_installation.id}",
+            json={"is_enabled": False},
+            headers=org_owner["headers"],
+        )
+        assert response.status_code == 200
+
+        db.refresh(org_installation)
+        assert org_installation.is_enabled is False
+
+    def test_stranger_cannot_reconfigure_an_org_installation(
+        self, client: TestClient, org_installation, stranger, db
+    ):
+        response = client.patch(
+            f"/api/plugins/installations/{org_installation.id}",
+            json={"config": {"channel": "#attacker"}},
+            headers=stranger["headers"],
+        )
+        assert response.status_code == 403
+
+        db.refresh(org_installation)
+        assert org_installation.config == {"channel": "#builds"}
+
+    def test_plain_member_cannot_reconfigure(
+        self, client: TestClient, org_installation, org_member
+    ):
+        response = client.patch(
+            f"/api/plugins/installations/{org_installation.id}",
+            json={"is_enabled": False},
+            headers=org_member["headers"],
+        )
+        assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# The predicates, directly
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionWiring:
+    def test_org_manage_plugins_is_granted_to_owner_and_admin_only(
+        self, db, organization, org_owner, org_member, stranger
+    ):
+        assert has_org_permission(
+            db, org_owner["uuid"], organization.id, ORG_MANAGE_PLUGINS
+        )
+        assert not has_org_permission(
+            db, org_member["uuid"], organization.id, ORG_MANAGE_PLUGINS
+        )
+        assert not has_org_permission(
+            db, stranger["uuid"], organization.id, ORG_MANAGE_PLUGINS
+        )
+
+    def test_can_manage_installation_handles_both_owner_shapes(
+        self, db, plugin, organization, org_installation, org_owner, stranger
+    ):
+        personal = PluginInstallation(
+            id=uuid.uuid4(),
+            plugin_id=plugin.id,
+            user_id=stranger["uuid"],
+            organization_id=None,
+            is_enabled=True,
+            config={},
+        )
+        db.add(personal)
+        db.commit()
+
+        owner_user = db.get(User, org_owner["uuid"])
+        stranger_user = db.get(User, stranger["uuid"])
+
+        # Organisation installation: the org's owner, not the personal owner.
+        assert PluginService.can_manage_installation(db, owner_user, org_installation)
+        assert not PluginService.can_manage_installation(
+            db, stranger_user, org_installation
+        )
+
+        # Personal installation: the reverse.
+        assert PluginService.can_manage_installation(db, stranger_user, personal)
+        assert not PluginService.can_manage_installation(db, owner_user, personal)
+
+    def test_an_ownerless_installation_is_denied(self, db, plugin, stranger):
+        orphan = PluginInstallation(
+            id=uuid.uuid4(),
+            plugin_id=plugin.id,
+            user_id=None,
+            organization_id=None,
+            is_enabled=True,
+            config={},
+        )
+        db.add(orphan)
+        db.commit()
+
+        stranger_user = db.get(User, stranger["uuid"])
+        assert not PluginService.can_manage_installation(db, stranger_user, orphan)
+
+    def test_permission_is_scoped_to_the_named_organization(
+        self, db, organization, org_owner, stranger
+    ):
+        other = Organization(
+            owner_id=stranger["uuid"],
+            name="Other Works",
+            slug="other-works",
+        )
+        db.add(other)
+        db.commit()
+        db.refresh(other)
+
+        assert not has_org_permission(
+            db, org_owner["uuid"], other.id, ORG_MANAGE_PLUGINS
+        )

--- a/backend/tests/test_plugins.py
+++ b/backend/tests/test_plugins.py
@@ -291,3 +291,7 @@ class TestPluginEventDispatch:
         assert result.dispatched_installations_count == 1
         assert result.dispatches[0].plugin_slug == plugin.slug
         assert result.dispatches[0].status == "queued"
+        # The manifest declares a webhook, so the flag is set -- but the URL
+        # itself must not come back in the response.
+        assert result.dispatches[0].has_webhook is True
+        assert not hasattr(result.dispatches[0], "webhook_url")

--- a/frontend/src/hooks/usePermissions.ts
+++ b/frontend/src/hooks/usePermissions.ts
@@ -91,6 +91,7 @@ export const ORG_ROLE_PERMISSIONS: Record<OrgRole, readonly string[]> = {
     "org:manage_jobs",
     "org:manage_candidates",
     "org:manage_content",
+    "org:manage_plugins",
     "org:view_content",
   ],
   admin: [
@@ -101,6 +102,7 @@ export const ORG_ROLE_PERMISSIONS: Record<OrgRole, readonly string[]> = {
     "org:manage_jobs",
     "org:manage_candidates",
     "org:manage_content",
+    "org:manage_plugins",
     "org:view_content",
   ],
   recruiter: ["org:manage_jobs", "org:manage_candidates", "org:view_content"],


### PR DESCRIPTION
## Summary

Two authorization holes in the plugin system, which compounded: an unauthenticated fan-out route
that returned every organisation's integration webhook URLs, and install/uninstall/list operations
that took `organization_id` from the caller and never checked it.

---

## Related Issue

Fixes #1391

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [ ] UI/UX enhancement
- [x] Tests
- [ ] Other

---

## Changes Made

### 1. `dispatch-event` required no token and leaked webhook URLs

`dispatch_event` selects every active plugin matching the event, then every enabled installation
of those plugins — platform-wide, with no filter on who is asking — and returned one row per
installation carrying `webhook_url`. An integration webhook is a bearer credential in practice: a
Slack `hooks.slack.com/services/…` or Discord `discord.com/api/webhooks/…` string is postable by
anyone who has it. `GET /api/plugins` is public and returns manifests, so the event names needed
to walk the whole installation table were available too, and `installation_id` in the response is
the path parameter for `PATCH /api/plugins/installations/{id}`.

The route now requires an administrator. It is a platform-internal fan-out primitive rather than
something an end user should call, so admin-only is the right default.

**The response no longer carries the URL at all**, even for the permitted caller.
`PluginDispatchItem.webhook_url` is replaced by `has_webhook: bool` — a dispatch result does not
need to repeat the destination to report what happened. That is deliberate defence in depth: if
this route is later opened up per-installation, the leak does not come back with it.

### 2. Organisation operations ignored the organisation

`install_plugin`, `uninstall_plugin` and `list_user_installations` used `organization_id`
unvalidated. All three now require `org:manage_plugins`.

This is a **new permission**, granted to org `OWNER` and `ADMIN`, rather than a reuse of
`org:manage_tokens`. Attaching a third-party webhook destination to an organisation's event
stream is a different question from "may this person mint an API key", even though the two
usually land on the same people. `ALL_ORG_PERMISSIONS` is derived from the role table, so it picks
the new value up automatically; the frontend's copy of `ORG_ROLE_PERMISSIONS` is updated to match,
which `test_rbac_scoped_permissions.py` asserts.

The personal path is untouched: the guard only fires when an organisation is named.

### 3. `update_installation` had the mirror-image bug

```python
if installation.user_id != user.id and not is_admin:
```

Correct for a personal installation, wrong for an organisation one — `user_id` is NULL there, so
the condition held for *everybody*, including the organisation's own admins, who therefore had no
way to disable a plugin somebody else had installed on them. `can_manage_installation` now
branches on which owner column is set, and denies an installation with neither.

---

## Testing

- [x] Tested locally
- [x] Existing tests pass
- [x] Added new tests

**All three holes were reproduced against `main` before fixing**, with a throwaway test in a clean
worktree:

```
[HOLE 1] anonymous dispatch-event -> 200
[HOLE 1] webhook leaked -> True
[HOLE 2] stranger installs attacker plugin into someone else's org -> 201
[HOLE 2] installation organization_id -> b309c7f6-2392-4092-bdc8-14c71624db45
[HOLE 2] expected org               -> b309c7f6-2392-4092-bdc8-14c71624db45
[HOLE 3] stranger lists org installations -> 200 count = 1
```

`tests/test_plugin_authorization.py` is new (23 tests):

- **`dispatch-event`** — anonymous 401, ordinary user 403, and *the plugin's own author* 403
  (publishing a plugin does not grant the right to fan out events); admin 200 with the expected
  match counts.
- **No webhook leakage** — the URL string and the field name are both asserted absent from the
  response body even for the admin; `has_webhook` is `true` for a plugin that declares one and
  `false`, with `status == "no_webhook"`, for one that does not.
- **Organisation install** — stranger 403 with no row created; plain `MEMBER` of the organisation
  403 (`ORG_ROLE_PERMISSIONS[MEMBER]` does not carry the permission); org owner 201; and a
  personal install still works for anyone, so the guard only fires when an org is named.
- **Organisation uninstall** — stranger 403 with the row still present; org owner succeeds and
  the row is gone.
- **Organisation listing** — stranger 403; owner sees it; listing your own needs nothing.
- **`update_installation`** — org owner can now disable an org installation (the case that used
  to be wrongly refused); stranger cannot reconfigure it, with the stored config asserted
  unchanged; plain member cannot.
- **Permission wiring** — `org:manage_plugins` resolves for owner and not for member or stranger;
  `can_manage_installation` handles both owner shapes *and* is asserted not to leak sideways in
  either direction; an ownerless installation is denied; the permission is scoped to the named
  organisation.

`test_plugins.py::test_dispatch_event_matches_and_queues_webhook` is extended to assert
`has_webhook is True` and that no `webhook_url` attribute exists.

Full backend suite compared against `main` in a clean worktree: **89 failures before, 89 after,
no regressions.** (An earlier run showed one regression —
`test_rbac_scoped_permissions::test_frontend_permission_tables_match_the_backend` — caught by the
sync test doing exactly its job; the frontend table is updated in this PR and the run is clean.)

---

## Checklist

- [x] My code follows the project's coding standards.
- [x] I have tested my changes locally.
- [x] I have updated the documentation where necessary.
- [x] My changes do not introduce new warnings or errors.
- [x] I have reviewed my own code.
- [x] This pull request focuses on a single feature or fix.
- [x] I have linked the related issue.

---

## Additional Notes

**`dispatch_event` does not currently send anything.** It marks rows `"queued"` and logs. The
disclosure was real today; the "trigger arbitrary outbound POSTs" half would have become real the
moment delivery was implemented behind the same open route. Worth fixing before that, not after.

**Breaking change to the response shape.** `PluginDispatchItem.webhook_url` is gone, replaced by
`has_webhook`. Nothing in the frontend consumes this response — `grep` for `dispatch-event` and
`webhook_url` under `frontend/src` returns nothing — so there is no client to update, but any
external consumer of the API would need to know.

**No migration.** `org:manage_plugins` is a string in a Python table, not a database column.

ECSoc 2026
