### PR TITLE
fix(reputation): require an administrator to adjust a score

### DIFF
--- a/backend/alembic/versions/b7e4d2f8c916_add_granted_by_to_reputation_logs.py
+++ b/backend/alembic/versions/b7e4d2f8c916_add_granted_by_to_reputation_logs.py
@@ -1,9 +1,18 @@
 """add granted_by_id to reputation_logs
 
-The log recorded who received points and never who granted them, so a manual
-adjustment could not be attributed to anyone. Nullable: entries the platform
-awards itself have no human actor, and neither does any row that already
-exists.
+``ReputationLog`` recorded who *received* points and had no column for who
+granted them, so a manual adjustment could not be attributed to anyone.
+``granted_by_id`` is nullable: entries the platform awards itself have no human
+actor, and neither does any row that already exists.
+
+``reputation_logs`` is also one of the tables that ``app/models`` declares and
+no migration ever created -- see #1235 -- so ``alembic upgrade head`` produces a
+database without it, and an unconditional ``ALTER TABLE`` here fails with
+``relation "reputation_logs" does not exist``. This migration therefore creates
+the table when it is absent and only adds the column when it is already there.
+That is a little more than the title promises, but a migration that cannot run
+against a migrated database is not a migration -- and it means ``downgrade``
+drops the table, since no earlier revision has it.
 
 Revision ID: b7e4d2f8c916
 Revises: 1c63e6c28cf8
@@ -13,6 +22,7 @@ Create Date: 2026-08-26 17:30:00.000000
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy import inspect
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
@@ -21,39 +31,103 @@ down_revision = "1c63e6c28cf8"
 branch_labels = None
 depends_on = None
 
+TABLE = "reputation_logs"
+COLUMN = "granted_by_id"
+INDEX = "ix_reputation_logs_granted_by_id"
 
-def upgrade() -> None:
+
+def _table_exists(bind) -> bool:
+    return TABLE in inspect(bind).get_table_names()
+
+
+def _column_exists(bind) -> bool:
+    return COLUMN in {c["name"] for c in inspect(bind).get_columns(TABLE)}
+
+
+def _create_table() -> None:
+    """Create ``reputation_logs`` in the shape ``app/models/reputation.py`` declares."""
+    op.create_table(
+        TABLE,
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("action", sa.String(length=50), nullable=False),
+        sa.Column("points", sa.Integer(), nullable=False),
+        sa.Column("description", sa.String(length=255), nullable=True),
+        sa.Column(
+            COLUMN,
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_reputation_logs_user_id", TABLE, ["user_id"])
+    op.create_index("ix_reputation_logs_action", TABLE, ["action"])
+    op.create_index(INDEX, TABLE, [COLUMN])
+
+
+def _add_column(bind) -> None:
     op.add_column(
-        "reputation_logs",
-        sa.Column("granted_by_id", postgresql.UUID(as_uuid=True), nullable=True),
+        TABLE,
+        sa.Column(COLUMN, postgresql.UUID(as_uuid=True), nullable=True),
     )
-    op.create_index(
-        "ix_reputation_logs_granted_by_id",
-        "reputation_logs",
-        ["granted_by_id"],
-    )
+    op.create_index(INDEX, TABLE, [COLUMN])
 
     # SQLite cannot add a foreign key to an existing table with ALTER, and the
     # test database is SQLite. The constraint is skipped there; the column and
     # the index -- which is what queries need -- are created either way.
-    if op.get_bind().dialect.name == "postgresql":
+    if bind.dialect.name == "postgresql":
         op.create_foreign_key(
             "fk_reputation_logs_granted_by_id_users",
-            "reputation_logs",
+            TABLE,
             "users",
-            ["granted_by_id"],
+            [COLUMN],
             ["id"],
             ondelete="SET NULL",
         )
 
 
-def downgrade() -> None:
-    if op.get_bind().dialect.name == "postgresql":
-        op.drop_constraint(
-            "fk_reputation_logs_granted_by_id_users",
-            "reputation_logs",
-            type_="foreignkey",
-        )
+def upgrade() -> None:
+    bind = op.get_bind()
 
-    op.drop_index("ix_reputation_logs_granted_by_id", table_name="reputation_logs")
-    op.drop_column("reputation_logs", "granted_by_id")
+    if not _table_exists(bind):
+        _create_table()
+        return
+
+    if not _column_exists(bind):
+        _add_column(bind)
+
+
+def downgrade() -> None:
+    """Drop the table.
+
+    No earlier revision knows about ``reputation_logs`` -- the model was added
+    without a migration -- so the state this reverts to is one where the table
+    does not exist, and dropping it is the honest inverse. Leaving it behind
+    also breaks ``alembic downgrade base``: its foreign key to ``users`` blocks
+    ``DROP TABLE users`` further down the chain.
+
+    Reputation history is lost on downgrade, which is what "downgrade past the
+    revision that introduced the table" means. Take a backup first.
+    """
+    bind = op.get_bind()
+
+    if not _table_exists(bind):
+        return
+
+    op.drop_table(TABLE)

--- a/backend/alembic/versions/b7e4d2f8c916_add_granted_by_to_reputation_logs.py
+++ b/backend/alembic/versions/b7e4d2f8c916_add_granted_by_to_reputation_logs.py
@@ -1,0 +1,59 @@
+"""add granted_by_id to reputation_logs
+
+The log recorded who received points and never who granted them, so a manual
+adjustment could not be attributed to anyone. Nullable: entries the platform
+awards itself have no human actor, and neither does any row that already
+exists.
+
+Revision ID: b7e4d2f8c916
+Revises: 1c63e6c28cf8
+Create Date: 2026-08-26 17:30:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "b7e4d2f8c916"
+down_revision = "1c63e6c28cf8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "reputation_logs",
+        sa.Column("granted_by_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.create_index(
+        "ix_reputation_logs_granted_by_id",
+        "reputation_logs",
+        ["granted_by_id"],
+    )
+
+    # SQLite cannot add a foreign key to an existing table with ALTER, and the
+    # test database is SQLite. The constraint is skipped there; the column and
+    # the index -- which is what queries need -- are created either way.
+    if op.get_bind().dialect.name == "postgresql":
+        op.create_foreign_key(
+            "fk_reputation_logs_granted_by_id_users",
+            "reputation_logs",
+            "users",
+            ["granted_by_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+
+def downgrade() -> None:
+    if op.get_bind().dialect.name == "postgresql":
+        op.drop_constraint(
+            "fk_reputation_logs_granted_by_id_users",
+            "reputation_logs",
+            type_="foreignkey",
+        )
+
+    op.drop_index("ix_reputation_logs_granted_by_id", table_name="reputation_logs")
+    op.drop_column("reputation_logs", "granted_by_id")

--- a/backend/app/models/reputation.py
+++ b/backend/app/models/reputation.py
@@ -52,10 +52,32 @@ class ReputationLog(Base):
         nullable=True,
     )
 
+    #: The administrator who applied a manual adjustment.
+    #:
+    #: The log recorded who *received* points and never who granted them, so
+    #: an entry could not be attributed to anyone. Nullable because entries
+    #: the platform awards itself have no human actor -- and because every row
+    #: that already exists has none either.
+    granted_by_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
         nullable=False,
     )
 
-    user = relationship("User", backref="reputation_logs")
+    user = relationship(
+        "User",
+        foreign_keys=[user_id],
+        backref="reputation_logs",
+    )
+
+    granted_by = relationship(
+        "User",
+        foreign_keys=[granted_by_id],
+    )

--- a/backend/app/routers/reputation.py
+++ b/backend/app/routers/reputation.py
@@ -6,11 +6,17 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, Depends, Query, status
+from fastapi import APIRouter, Depends, Query, Request, status
 from sqlalchemy.orm import Session
 
+from app.core.rbac import SystemRole
 from app.database.session import get_db
-from app.dependencies import get_current_user, get_optional_current_user
+from app.dependencies import (
+    get_current_user,
+    get_optional_current_user,
+    require_roles,
+)
+from app.models.audit_log import AuditAction
 from app.models.user import User
 from app.schemas.reputation import (
     LeaderboardResponse,
@@ -18,6 +24,7 @@ from app.schemas.reputation import (
     ReputationLogResponse,
     ReputationSummaryResponse,
 )
+from app.services.audit_log_service import AuditLogService
 from app.services.reputation_service import ReputationService
 
 router = APIRouter(prefix="/reputation", tags=["User Reputation System"])
@@ -74,25 +81,58 @@ def get_leaderboard(
     "/award",
     response_model=ReputationLogResponse,
     status_code=status.HTTP_201_CREATED,
-    summary="Award reputation points to a user",
+    summary="Adjust a user's reputation (administrators only)",
+    description=(
+        "Grant or deduct reputation points. Restricted to administrators: "
+        "reputation is meant to be a derived signal, and an endpoint that "
+        "lets a caller name the target, the action and the number of points "
+        "is a write primitive for anybody's score."
+    ),
 )
 def award_reputation(
     payload: ReputationAwardRequest,
-    current_user: User = Depends(get_current_user),
+    request: Request,
     db: Session = Depends(get_db),
+    actor: User = Depends(require_roles(SystemRole.ADMIN)),
 ):
     """
     Awards reputation points for activities like merged pull requests, completed projects,
     contributions, discussions, profile completions, or mentor recognitions.
-    """
-    target_user_id = payload.user_id or current_user.id
 
+    ``payload.user_id`` is required and is never defaulted to the caller. The
+    previous behaviour -- "omit the target and it means me" -- is the shape of
+    a self-service score, which is not what this endpoint is for.
+    """
     _, log_entry = ReputationService.award_reputation(
         db=db,
-        user_id=target_user_id,
-        action=payload.action,
+        user_id=payload.user_id,
+        action=payload.action.value,
         points_override=payload.points,
         description=payload.description,
+        granted_by_id=actor.id,
     )
+
+    # The log row names the recipient and the actor; the audit trail is where
+    # a reviewer goes looking for "what did this administrator do", so the
+    # adjustment belongs in both.
+    client = getattr(request, "client", None)
+    AuditLogService.create_log(
+        db=db,
+        actor_id=actor.id,
+        action=AuditAction.SETTINGS_CHANGED,
+        entity_type="reputation_log",
+        entity_id=str(log_entry.id),
+        target_user_id=payload.user_id,
+        description=(
+            f"Adjusted reputation by {log_entry.points} "
+            f"for action '{log_entry.action}'"
+        ),
+        new_values={"points": log_entry.points, "action": log_entry.action},
+        ip_address=getattr(client, "host", None) if client else None,
+        user_agent=request.headers.get("user-agent"),
+        request_method=request.method,
+        request_path=str(request.url.path),
+    )
+    db.commit()
 
     return ReputationLogResponse.model_validate(log_entry)

--- a/backend/app/schemas/reputation.py
+++ b/backend/app/schemas/reputation.py
@@ -1,41 +1,80 @@
 """
 Reputation System Schemas (#597)
+
+``ReputationAwardRequest`` used to accept an optional target, an arbitrary
+free-text action, and an unbounded integer. The router applied all three
+verbatim, with no authorization, which made the endpoint a write primitive for
+any user's score. The constraints live here now, so an invalid request is a 422
+before any of it reaches the service.
 """
 
 from __future__ import annotations
 
 import uuid
 from datetime import datetime
+from enum import Enum
 from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
 
+class ReputationAction(str, Enum):
+    """The activities that earn reputation.
+
+    ``action`` was a bare ``str`` with an ``examples=[...]`` list, which is
+    documentation, not validation -- anything at all was accepted, and
+    ``ACTION_POINTS.get(action.lower(), 10)`` then silently awarded ten points
+    for a typo or an invented name. An enum makes an unknown action a 422 and
+    keeps the wire values identical to the keys the service already uses.
+    """
+
+    MERGED_PULL_REQUEST = "merged_pull_request"
+    COMPLETED_PROJECT = "completed_project"
+    COMMUNITY_CONTRIBUTION = "community_contribution"
+    HELPFUL_DISCUSSION = "helpful_discussion"
+    PROFILE_COMPLETION = "profile_completion"
+    MENTOR_RECOGNITION = "mentor_recognition"
+    MANUAL_ADJUSTMENT = "manual_adjustment"
+
+
+#: Largest magnitude a single award may carry, in either direction.
+#:
+#: The action table's own values top out at 100. The ceiling exists so that a
+#: mis-typed override is a validation error rather than a leaderboard rewrite,
+#: and so a negative award cannot zero somebody out in one request -- the
+#: service floors the score at 0, which made deduction the cheaper attack.
+MAX_POINTS_PER_AWARD = 500
+
+
 class ReputationAwardRequest(BaseModel):
-    user_id: Optional[uuid.UUID] = Field(
-        default=None,
-        description="Target user ID to award points to. If null, awards points to authenticated user.",
-    )
-    action: str = Field(
+    """An administrator granting or deducting points.
+
+    ``user_id`` is required. It was optional, defaulting to the caller, and
+    "award points to myself" is not an operation this system should offer over
+    HTTP at all -- reputation is meant to be derived from activity.
+    """
+
+    user_id: uuid.UUID = Field(
         ...,
-        examples=[
-            "merged_pull_request",
-            "completed_project",
-            "community_contribution",
-            "helpful_discussion",
-            "profile_completion",
-            "mentor_recognition",
-        ],
-        description="Type of activity earning reputation points.",
+        description="The user receiving the adjustment.",
+    )
+    action: ReputationAction = Field(
+        ...,
+        description="The activity being recognised.",
     )
     points: Optional[int] = Field(
         default=None,
-        description="Optional custom point value override.",
+        ge=-MAX_POINTS_PER_AWARD,
+        le=MAX_POINTS_PER_AWARD,
+        description=(
+            "Override the points for this action. Omit to use the standard "
+            "value from the action table. Negative values deduct."
+        ),
     )
     description: Optional[str] = Field(
         default=None,
         max_length=255,
-        description="Optional description or note.",
+        description="Optional note stored on the log entry.",
     )
 
 
@@ -47,6 +86,13 @@ class ReputationLogResponse(BaseModel):
     action: str
     points: int
     description: Optional[str] = None
+    granted_by_id: Optional[uuid.UUID] = Field(
+        default=None,
+        description=(
+            "The administrator who applied this adjustment, when it came from "
+            "the award endpoint. Null for entries the platform awarded itself."
+        ),
+    )
     created_at: datetime
 
 
@@ -71,4 +117,10 @@ class LeaderboardEntry(BaseModel):
 
 class LeaderboardResponse(BaseModel):
     entries: list[LeaderboardEntry] = Field(default_factory=list)
-    total: int
+    total: int = Field(
+        description=(
+            "Total number of ranked users. Counts the same set the entries are "
+            "drawn from -- active, non-deleted accounts -- so a client can page "
+            "through it."
+        )
+    )

--- a/backend/app/services/reputation_service.py
+++ b/backend/app/services/reputation_service.py
@@ -14,21 +14,43 @@ from sqlalchemy.orm import Session
 from app.models.reputation import ReputationLog
 from app.models.user import User
 from app.schemas.reputation import (
+    MAX_POINTS_PER_AWARD,
     LeaderboardEntry,
     LeaderboardResponse,
+    ReputationAction,
     ReputationLogResponse,
     ReputationSummaryResponse,
 )
 
-# Points awarded per action source
+# Points awarded per action source.
+#
+# Keyed by the wire values of :class:`ReputationAction`. Every member must
+# appear here -- ``_assert_action_table_is_complete`` below enforces that at
+# import time, so adding an enum member without a point value is a startup
+# error rather than a silent fallback to ten points.
 ACTION_POINTS: dict[str, int] = {
-    "merged_pull_request": 50,
-    "completed_project": 100,
-    "community_contribution": 25,
-    "helpful_discussion": 15,
-    "profile_completion": 10,
-    "mentor_recognition": 30,
+    ReputationAction.MERGED_PULL_REQUEST.value: 50,
+    ReputationAction.COMPLETED_PROJECT.value: 100,
+    ReputationAction.COMMUNITY_CONTRIBUTION.value: 25,
+    ReputationAction.HELPFUL_DISCUSSION.value: 15,
+    ReputationAction.PROFILE_COMPLETION.value: 10,
+    ReputationAction.MENTOR_RECOGNITION.value: 30,
+    # A correction applied by hand. Zero on its own: it exists so that an
+    # explicit `points` override has an action to travel under, rather than
+    # being smuggled in under "merged_pull_request".
+    ReputationAction.MANUAL_ADJUSTMENT.value: 0,
 }
+
+
+def _assert_action_table_is_complete() -> None:
+    missing = {a.value for a in ReputationAction} - set(ACTION_POINTS)
+    if missing:
+        raise RuntimeError(
+            f"ACTION_POINTS is missing point values for: {sorted(missing)}"
+        )
+
+
+_assert_action_table_is_complete()
 
 # Rank Tier thresholds
 RANK_TIERS: list[tuple[int, str]] = [
@@ -50,15 +72,53 @@ def calculate_rank_tier(score: int) -> str:
 
 class ReputationService:
     @staticmethod
+    def resolve_points(action: str, points_override: Optional[int]) -> int:
+        """How many points an award is worth.
+
+        ``ACTION_POINTS.get(action.lower(), 10)`` used to accept any string and
+        fall back to ten, so a typo scored. The action is validated against the
+        table instead, and an override is bounded on both sides -- the schema
+        enforces the same range, and this repeats it because the service is
+        also called from places that do not go through the schema.
+        """
+        if points_override is not None:
+            if abs(points_override) > MAX_POINTS_PER_AWARD:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=(
+                        f"points must be between -{MAX_POINTS_PER_AWARD} and "
+                        f"{MAX_POINTS_PER_AWARD}."
+                    ),
+                )
+            return points_override
+
+        normalised = action.lower()
+        if normalised not in ACTION_POINTS:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    f"Unknown reputation action '{action}'. "
+                    f"Valid actions: {sorted(ACTION_POINTS)}"
+                ),
+            )
+        return ACTION_POINTS[normalised]
+
+    @staticmethod
     def award_reputation(
         db: Session,
         user_id: uuid.UUID,
         action: str,
         points_override: Optional[int] = None,
         description: Optional[str] = None,
+        granted_by_id: Optional[uuid.UUID] = None,
     ) -> Tuple[User, ReputationLog]:
         """
         Awards (or deducts) reputation points to a user and logs the transaction.
+
+        ``granted_by_id`` records the administrator behind a manual
+        adjustment. It is optional so the platform can award points to itself
+        later, without a human actor, but the award endpoint always supplies it
+        -- an adjustment nobody is named on is not auditable.
         """
         user = db.scalar(select(User).where(User.id == user_id))
         if not user:
@@ -67,11 +127,7 @@ class ReputationService:
                 detail=f"User with ID {user_id} not found.",
             )
 
-        # Determine points to award
-        if points_override is not None:
-            pts = points_override
-        else:
-            pts = ACTION_POINTS.get(action.lower(), 10)
+        pts = ReputationService.resolve_points(action, points_override)
 
         # Update user's aggregate reputation score
         user.reputation_score = (user.reputation_score or 0) + pts
@@ -85,6 +141,7 @@ class ReputationService:
             points=pts,
             description=description
             or f"Earned {pts} pts for {action.replace('_', ' ')}",
+            granted_by_id=granted_by_id,
         )
         db.add(log_entry)
         db.commit()
@@ -161,11 +218,22 @@ class ReputationService:
         """
         Fetches the community leaderboard sorted by reputation_score descending.
         """
-        total_stmt = select(func.count(User.id))
-        total = db.scalar(total_stmt) or 0
+        # Both statements share one predicate so the count and the page are
+        # drawn from the same set. Neither used to filter at all, so the
+        # leaderboard ranked deactivated and soft-deleted accounts alongside
+        # live ones -- publishing their username, name and avatar -- and
+        # ``total`` was the count of every row in ``users``, which made the
+        # client's page count wrong.
+        ranked = (
+            User.is_active.is_(True),
+            User.deleted_at.is_(None),
+        )
+
+        total = db.scalar(select(func.count(User.id)).where(*ranked)) or 0
 
         users_stmt = (
             select(User)
+            .where(*ranked)
             .order_by(desc(User.reputation_score), desc(User.created_at))
             .offset(skip)
             .limit(limit)

--- a/backend/tests/test_reputation_award_authz.py
+++ b/backend/tests/test_reputation_award_authz.py
@@ -1,0 +1,378 @@
+"""
+Authorization and validation for reputation adjustments.
+
+`POST /api/reputation/award` authenticated the caller and then did nothing with
+that identity except use it as the default target. It took the recipient, the
+action and the number of points as given:
+
+    target_user_id = payload.user_id or current_user.id
+
+`points` was an unbounded optional integer and `action` a free `str`, so one
+request from a day-old account put it at the top of the leaderboard -- or, with
+a minus sign, zeroed out everybody above it, since the service floors the score
+at 0.
+
+Also covered: the leaderboard, which counted and ranked deactivated and
+soft-deleted accounts.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.models.reputation import ReputationLog
+from app.models.user import User
+from app.schemas.reputation import MAX_POINTS_PER_AWARD
+from app.services.reputation_service import ACTION_POINTS, ReputationService
+
+
+def _account(register_and_login, email: str, username: str) -> dict:
+    uid, token = register_and_login(email, username)
+    return {
+        "id": uid,
+        "uuid": uuid.UUID(uid),
+        "token": token,
+        "headers": {"Authorization": f"Bearer {token}"},
+    }
+
+
+@pytest.fixture
+def admin(register_and_login, db):
+    acct = _account(register_and_login, "repadmin@example.com", "repadmin")
+    user = db.get(User, acct["uuid"])
+    user.system_role = "admin"
+    db.add(user)
+    db.commit()
+    return acct
+
+
+@pytest.fixture
+def member(register_and_login):
+    return _account(register_and_login, "repmember@example.com", "repmember")
+
+
+@pytest.fixture
+def rival(register_and_login):
+    return _account(register_and_login, "reprival@example.com", "reprival")
+
+
+def _score(db, user_uuid) -> int:
+    db.expire_all()
+    return db.get(User, user_uuid).reputation_score or 0
+
+
+# ---------------------------------------------------------------------------
+# Who may call it
+# ---------------------------------------------------------------------------
+
+
+class TestAwardRequiresAdmin:
+    def test_anonymous_caller_is_rejected(self, client: TestClient, member):
+        response = client.post(
+            "/api/reputation/award",
+            json={"user_id": member["id"], "action": "merged_pull_request"},
+        )
+        assert response.status_code == 401
+
+    def test_ordinary_user_cannot_award_themselves(
+        self, client: TestClient, member, db
+    ):
+        """The reported bug, in its cheapest form."""
+        response = client.post(
+            "/api/reputation/award",
+            headers=member["headers"],
+            json={
+                "user_id": member["id"],
+                "action": "manual_adjustment",
+                "points": 999,
+            },
+        )
+        assert response.status_code == 403
+        assert _score(db, member["uuid"]) == 0
+
+    def test_ordinary_user_cannot_award_someone_else(
+        self, client: TestClient, member, rival, db
+    ):
+        response = client.post(
+            "/api/reputation/award",
+            headers=member["headers"],
+            json={"user_id": rival["id"], "action": "merged_pull_request"},
+        )
+        assert response.status_code == 403
+        assert _score(db, rival["uuid"]) == 0
+
+    def test_ordinary_user_cannot_deduct_from_a_rival(
+        self, client: TestClient, admin, member, rival, db
+    ):
+        """Deduction was the cheaper attack.
+
+        The service floors the score at 0, so zeroing out everyone above you
+        was one request each rather than an arms race of inflation.
+        """
+        client.post(
+            "/api/reputation/award",
+            headers=admin["headers"],
+            json={"user_id": rival["id"], "action": "completed_project"},
+        )
+        assert _score(db, rival["uuid"]) == 100
+
+        response = client.post(
+            "/api/reputation/award",
+            headers=member["headers"],
+            json={
+                "user_id": rival["id"],
+                "action": "manual_adjustment",
+                "points": -500,
+            },
+        )
+        assert response.status_code == 403
+        assert _score(db, rival["uuid"]) == 100
+
+    def test_admin_can_award(self, client: TestClient, admin, member, db):
+        response = client.post(
+            "/api/reputation/award",
+            headers=admin["headers"],
+            json={"user_id": member["id"], "action": "merged_pull_request"},
+        )
+        assert response.status_code == 201
+        assert response.json()["points"] == ACTION_POINTS["merged_pull_request"]
+        assert _score(db, member["uuid"]) == 50
+
+
+# ---------------------------------------------------------------------------
+# The target is required
+# ---------------------------------------------------------------------------
+
+
+class TestTargetIsRequired:
+    def test_omitting_user_id_is_a_422(self, client: TestClient, admin):
+        """It used to mean "me", which is the shape of a self-service score."""
+        response = client.post(
+            "/api/reputation/award",
+            headers=admin["headers"],
+            json={"action": "merged_pull_request"},
+        )
+        assert response.status_code == 422
+
+    def test_unknown_user_is_a_404(self, client: TestClient, admin):
+        response = client.post(
+            "/api/reputation/award",
+            headers=admin["headers"],
+            json={"user_id": str(uuid.uuid4()), "action": "merged_pull_request"},
+        )
+        assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Action and points validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_unknown_action_is_rejected(self, client: TestClient, admin, member, db):
+        """`ACTION_POINTS.get(action.lower(), 10)` used to award ten for a typo."""
+        response = client.post(
+            "/api/reputation/award",
+            headers=admin["headers"],
+            json={"user_id": member["id"], "action": "definitely_not_an_action"},
+        )
+        assert response.status_code == 422
+        assert _score(db, member["uuid"]) == 0
+
+    def test_points_above_the_ceiling_are_rejected(
+        self, client: TestClient, admin, member, db
+    ):
+        response = client.post(
+            "/api/reputation/award",
+            headers=admin["headers"],
+            json={
+                "user_id": member["id"],
+                "action": "manual_adjustment",
+                "points": MAX_POINTS_PER_AWARD + 1,
+            },
+        )
+        assert response.status_code == 422
+        assert _score(db, member["uuid"]) == 0
+
+    def test_points_below_the_floor_are_rejected(
+        self, client: TestClient, admin, member
+    ):
+        response = client.post(
+            "/api/reputation/award",
+            headers=admin["headers"],
+            json={
+                "user_id": member["id"],
+                "action": "manual_adjustment",
+                "points": -(MAX_POINTS_PER_AWARD + 1),
+            },
+        )
+        assert response.status_code == 422
+
+    def test_an_override_at_the_ceiling_is_accepted(
+        self, client: TestClient, admin, member, db
+    ):
+        response = client.post(
+            "/api/reputation/award",
+            headers=admin["headers"],
+            json={
+                "user_id": member["id"],
+                "action": "manual_adjustment",
+                "points": MAX_POINTS_PER_AWARD,
+            },
+        )
+        assert response.status_code == 201
+        assert _score(db, member["uuid"]) == MAX_POINTS_PER_AWARD
+
+    def test_an_admin_deduction_still_floors_at_zero(
+        self, client: TestClient, admin, member, db
+    ):
+        client.post(
+            "/api/reputation/award",
+            headers=admin["headers"],
+            json={"user_id": member["id"], "action": "helpful_discussion"},
+        )
+        assert _score(db, member["uuid"]) == 15
+
+        client.post(
+            "/api/reputation/award",
+            headers=admin["headers"],
+            json={
+                "user_id": member["id"],
+                "action": "manual_adjustment",
+                "points": -100,
+            },
+        )
+        assert _score(db, member["uuid"]) == 0
+
+
+class TestResolvePoints:
+    def test_every_action_has_a_point_value(self):
+        """Guards the fallback that used to make a typo worth ten points."""
+        from app.schemas.reputation import ReputationAction
+
+        for action in ReputationAction:
+            assert action.value in ACTION_POINTS
+
+    def test_resolve_points_rejects_an_unknown_action(self):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc:
+            ReputationService.resolve_points("not_a_real_action", None)
+        assert exc.value.status_code == 422
+
+    def test_resolve_points_bounds_an_override(self):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc:
+            ReputationService.resolve_points(
+                "manual_adjustment", MAX_POINTS_PER_AWARD * 10
+            )
+        assert exc.value.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Attribution
+# ---------------------------------------------------------------------------
+
+
+class TestAttribution:
+    def test_the_log_records_who_granted_the_points(
+        self, client: TestClient, admin, member, db
+    ):
+        """`ReputationLog` recorded who received points and never who granted."""
+        response = client.post(
+            "/api/reputation/award",
+            headers=admin["headers"],
+            json={"user_id": member["id"], "action": "mentor_recognition"},
+        )
+        assert response.status_code == 201
+        assert response.json()["granted_by_id"] == admin["id"]
+
+        log = db.query(ReputationLog).one()
+        assert str(log.user_id) == member["id"]
+        assert str(log.granted_by_id) == admin["id"]
+
+    def test_a_service_level_award_may_have_no_actor(self, db, member):
+        """The platform awarding points to itself has no human behind it."""
+        _, log = ReputationService.award_reputation(
+            db=db,
+            user_id=member["uuid"],
+            action="profile_completion",
+        )
+        assert log.granted_by_id is None
+
+
+# ---------------------------------------------------------------------------
+# Leaderboard
+# ---------------------------------------------------------------------------
+
+
+class TestLeaderboard:
+    def test_deactivated_accounts_are_not_ranked(
+        self, client: TestClient, admin, member, rival, db
+    ):
+        """The leaderboard published the username and avatar of disabled accounts."""
+        before = client.get("/api/reputation/leaderboard").json()
+        assert any(e["username"] == "reprival" for e in before["entries"])
+
+        user = db.get(User, rival["uuid"])
+        user.is_active = False
+        db.add(user)
+        db.commit()
+
+        after = client.get("/api/reputation/leaderboard").json()
+        assert not any(e["username"] == "reprival" for e in after["entries"])
+
+    def test_soft_deleted_accounts_are_not_ranked(
+        self, client: TestClient, member, rival, db
+    ):
+        from datetime import datetime, timezone
+
+        user = db.get(User, rival["uuid"])
+        user.deleted_at = datetime.now(timezone.utc)
+        db.add(user)
+        db.commit()
+
+        entries = client.get("/api/reputation/leaderboard").json()["entries"]
+        assert not any(e["username"] == "reprival" for e in entries)
+
+    def test_total_counts_the_same_set_it_ranks(
+        self, client: TestClient, member, rival, db
+    ):
+        """`total` was `count(User.id)` with no predicate at all, so it counted
+        rows the listing would never return, and the client's page count was
+        wrong."""
+        body = client.get("/api/reputation/leaderboard", params={"limit": 100}).json()
+        assert body["total"] == len(body["entries"])
+
+        user = db.get(User, rival["uuid"])
+        user.is_active = False
+        db.add(user)
+        db.commit()
+
+        body = client.get("/api/reputation/leaderboard", params={"limit": 100}).json()
+        assert body["total"] == len(body["entries"])
+
+    def test_ranking_is_by_score_descending(
+        self, client: TestClient, admin, member, rival, db
+    ):
+        client.post(
+            "/api/reputation/award",
+            headers=admin["headers"],
+            json={"user_id": rival["id"], "action": "completed_project"},
+        )
+        client.post(
+            "/api/reputation/award",
+            headers=admin["headers"],
+            json={"user_id": member["id"], "action": "helpful_discussion"},
+        )
+
+        entries = client.get(
+            "/api/reputation/leaderboard", params={"limit": 100}
+        ).json()["entries"]
+        scores = [e["reputation_score"] for e in entries]
+        assert scores == sorted(scores, reverse=True)
+        assert entries[0]["username"] == "reprival"

--- a/frontend/src/api/modules/reputation.ts
+++ b/frontend/src/api/modules/reputation.ts
@@ -1,11 +1,32 @@
 import { api } from "../client";
 
+/**
+ * The activities that earn reputation.
+ *
+ * Mirrors `ReputationAction` in `backend/app/schemas/reputation.py`. The
+ * backend validates against this set, so an unrecognised string is a 422
+ * rather than a silent ten points.
+ */
+export type ReputationAction =
+  | "merged_pull_request"
+  | "completed_project"
+  | "community_contribution"
+  | "helpful_discussion"
+  | "profile_completion"
+  | "mentor_recognition"
+  | "manual_adjustment";
+
+/** Largest magnitude a single adjustment may carry, in either direction. */
+export const MAX_POINTS_PER_AWARD = 500;
+
 export interface ReputationLog {
   id: string;
   user_id: string;
   action: string;
   points: number;
   description?: string | null;
+  /** The administrator behind a manual adjustment; null when the platform awarded it. */
+  granted_by_id?: string | null;
   created_at: string;
 }
 
@@ -32,8 +53,13 @@ export interface LeaderboardResponse {
 }
 
 export interface AwardReputationInput {
-  user_id?: string;
-  action: string;
+  /**
+   * The user receiving the adjustment. Required: it used to be optional and
+   * default to the caller, which is the shape of a self-service score.
+   */
+  user_id: string;
+  action: ReputationAction;
+  /** Omit to use the standard value for the action. Negative values deduct. */
   points?: number;
   description?: string;
 }
@@ -54,6 +80,10 @@ export const reputationApi = {
     return api.get<LeaderboardResponse>("/api/reputation/leaderboard", { query: params });
   },
 
+  /**
+   * Adjust a user's reputation. Administrators only -- a non-admin caller gets
+   * a 403, and an unauthenticated one a 401.
+   */
   awardReputation: async (data: AwardReputationInput): Promise<ReputationLog> => {
     return api.post<ReputationLog>("/api/reputation/award", data);
   },

--- a/frontend/src/routes/_app.leaderboard.tsx
+++ b/frontend/src/routes/_app.leaderboard.tsx
@@ -6,7 +6,6 @@ import {
   Medal,
   Crown,
   Sparkles,
-  Zap,
   CheckCircle,
   GitPullRequest,
   FolderCheck,
@@ -14,28 +13,10 @@ import {
   MessageSquare,
   UserCheck,
   Flame,
-  Plus,
 } from "lucide-react";
-import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, EmptyState } from "@/components/shared/primitives";
 import { UserAvatar } from "@/components/user-avatar";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-} from "@/components/ui/dialog";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Input } from "@/components/ui/input";
-import { toast } from "sonner";
 import { reputationApi, type LeaderboardEntry, type ReputationSummary } from "@/api";
 import { TypoSection, TypoCaption, TypoCard, TypoHeading } from "@/components/shared/Typography";
 
@@ -52,6 +33,14 @@ export const Route = createFileRoute("/_app/leaderboard")({
   component: LeaderboardPage,
 });
 
+// Reference table for the "How to Earn Reputation Points" card.
+//
+// This page used to carry a "Claim Reputation Points" dialog that posted
+// straight to `/api/reputation/award` with no target, which the API resolved
+// to the caller -- a self-service score, and only ever functional because that
+// endpoint had no authorization. Awarding is an administrative action now, so
+// the control is gone; what remains is the explanation of how points are
+// earned.
 const ACTION_POINTS_LABEL: Record<string, { label: string; points: number; icon: any }> = {
   merged_pull_request: { label: "Merged Pull Request", points: 50, icon: GitPullRequest },
   completed_project: { label: "Completed Project", points: 100, icon: FolderCheck },
@@ -66,10 +55,6 @@ function LeaderboardPage() {
   const [total, setTotal] = useState<number>(0);
   const [mySummary, setMySummary] = useState<ReputationSummary | null>(null);
   const [loading, setLoading] = useState(true);
-  const [awardModalOpen, setAwardModalOpen] = useState(false);
-  const [selectedAction, setSelectedAction] = useState("merged_pull_request");
-  const [actionDesc, setActionDesc] = useState("");
-  const [submitting, setSubmitting] = useState(false);
 
   const fetchData = async () => {
     setLoading(true);
@@ -97,24 +82,6 @@ function LeaderboardPage() {
     fetchData();
   }, []);
 
-  const handleAwardSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setSubmitting(true);
-    try {
-      await reputationApi.awardReputation({
-        action: selectedAction,
-        description: actionDesc || undefined,
-      });
-      toast.success("Reputation points awarded successfully!");
-      setAwardModalOpen(false);
-      setActionDesc("");
-      fetchData();
-    } catch (err) {
-      toast.error("Failed to log reputation points.");
-    } finally {
-      setSubmitting(false);
-    }
-  };
 
   const getRankBadge = (rank: number) => {
     if (rank === 1) {
@@ -156,9 +123,6 @@ function LeaderboardPage() {
           </TypoCaption>
         </div>
 
-        <Button onClick={() => setAwardModalOpen(true)} className="gap-2 shrink-0">
-          <Plus size={16} /> Claim Reputation Points
-        </Button>
       </div>
 
       {/* Grid: My Summary + Point System Breakdown */}
@@ -304,57 +268,6 @@ function LeaderboardPage() {
         )}
       </Card>
 
-      {/* Claim Reputation Modal */}
-      <Dialog open={awardModalOpen} onOpenChange={setAwardModalOpen}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <Zap className="h-5 w-5 text-amber-500" /> Claim Reputation Points
-            </DialogTitle>
-            <DialogDescription>
-              Select your completed community activity to log reputation points.
-            </DialogDescription>
-          </DialogHeader>
-
-          <form onSubmit={handleAwardSubmit} className="space-y-4 py-2">
-            <div className="space-y-2">
-              <label className="text-xs font-semibold text-foreground">Action Type</label>
-              <Select value={selectedAction} onValueChange={setSelectedAction}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Select activity" />
-                </SelectTrigger>
-                <SelectContent>
-                  {Object.entries(ACTION_POINTS_LABEL).map(([key, item]) => (
-                    <SelectItem key={key} value={key}>
-                      {item.label} (+{item.points} pts)
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="space-y-2">
-              <label className="text-xs font-semibold text-foreground">
-                Description / Reference (Optional)
-              </label>
-              <Input
-                placeholder="e.g., Merged PR #868 in DevLink repo"
-                value={actionDesc}
-                onChange={(e) => setActionDesc(e.target.value)}
-              />
-            </div>
-
-            <div className="flex justify-end gap-2 pt-2">
-              <Button type="button" variant="outline" onClick={() => setAwardModalOpen(false)}>
-                Cancel
-              </Button>
-              <Button type="submit" disabled={submitting}>
-                {submitting ? "Claiming..." : "Award Points"}
-              </Button>
-            </div>
-          </form>
-        </DialogContent>
-      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

`POST /api/reputation/award` authenticated the caller and then used that identity for exactly one
thing: as the default target. It took the recipient, the action and the number of points as
given, with no authorization and no bounds.

```python
target_user_id = payload.user_id or current_user.id
```

---

## Related Issue

Fixes #1392

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [ ] UI/UX enhancement
- [x] Tests
- [ ] Other

---

## Changes Made

**Administrators only.** The endpoint now depends on `require_roles(SystemRole.ADMIN)`.

**`user_id` is required.** It was optional and defaulted to the caller. "Omit the target and it
means me" is the shape of a self-service score, which is not what this endpoint is for.

**`action` is an enum, not a free string.** The `examples=[...]` list on the field was
documentation, not validation, and `ACTION_POINTS.get(action.lower(), 10)` then silently awarded
ten points for a typo or an invented name. Unknown actions are a 422 now, and an import-time check
raises if a `ReputationAction` member has no entry in `ACTION_POINTS` — so the ten-point fallback
cannot come back by accident. `MANUAL_ADJUSTMENT` is added, worth zero on its own, so an explicit
`points` override has an action to travel under rather than being smuggled in under
`merged_pull_request`.

**`points` is bounded** to ±500, in the schema *and* in the service. The service repeats the check
because `award_reputation` is callable from places that never see the schema, and a bound that
only exists at the edge is one refactor away from being gone.

**Every adjustment is attributable.** `ReputationLog` recorded who *received* points and had no
column for who granted them. It gains `granted_by_id` — nullable, because entries the platform
awards itself have no human actor and neither does any row that already exists — and the route
also writes an audit log entry naming both parties.

**The leaderboard filtered nothing.** Neither the count nor the page had a predicate, so it
ranked deactivated and soft-deleted accounts alongside live ones — publishing their `username`,
`full_name` and `avatar_url` — and `total` was `count(User.id)` over every row in `users`, which
disagreed with the set being listed and made the client's page count wrong. Both statements now
share one predicate, so they cannot drift.

**Frontend client updated** to match: `user_id` required, `action` typed against the same set,
`granted_by_id` on the log, and `MAX_POINTS_PER_AWARD` exported.

---

## Testing

- [x] Tested locally
- [x] Existing tests pass
- [x] Added new tests

**All four faults were reproduced against `main`** with a throwaway test in a clean worktree:

```
[REP 1] self-award 999999 as a plain user -> 201
[REP 1] my score -> 999999 | tier -> Legend 👑
[REP 2] zeroing a rival -> 201
[REP 2] rival score -> 0
[REP 3] unknown action -> 201 points: 10
[REP 4] deactivated account still ranked -> True
```

Note REP 2: deduction was the *cheaper* attack. Since the service floors the score at 0, zeroing
out everyone above you was one request each — no arms race of inflation required.

`tests/test_reputation_award_authz.py` is new (21 tests):

- **Who may call it** — anonymous 401; an ordinary user cannot award themselves, cannot award
  someone else, and cannot deduct from a rival (with the rival's score asserted intact
  afterwards); an admin can, and gets the table's value.
- **Target required** — omitting `user_id` is a 422 rather than meaning "me"; an unknown user is a
  404.
- **Validation** — unknown action 422 with the score unchanged; points above the ceiling and below
  the floor both 422; an override exactly at the ceiling accepted; an admin deduction still floors
  at zero.
- **`resolve_points` directly** — every enum member has a point value (the guard against the
  ten-point fallback), unknown action raises 422, an over-large override raises 422.
- **Attribution** — the response and the stored row both carry `granted_by_id`; a service-level
  award with no actor leaves it null.
- **Leaderboard** — deactivated accounts drop out, soft-deleted accounts drop out, `total` equals
  the number of entries before and after a deactivation, and ranking is still by score descending.

Full backend suite compared against `main` in a clean worktree: **89 failures before, 89 after,
no regressions.**

---

## Checklist

- [x] My code follows the project's coding standards.
- [x] I have tested my changes locally.
- [x] I have updated the documentation where necessary.
- [x] My changes do not introduce new warnings or errors.
- [x] I have reviewed my own code.
- [x] This pull request focuses on a single feature or fix.
- [x] I have linked the related issue.

---

## Additional Notes

**Breaking API change, deliberately.** `user_id` becomes required and `action` becomes a closed
set. Any client sending an ad-hoc action string now gets a 422 — which is the point.

**The vulnerability had a button.** `routes/_app.leaderboard.tsx` carried a "Claim Reputation
Points" dialog that posted to `/api/reputation/award` with no `user_id`, which the API resolved to
the caller. `typecheck` caught it after my first push. I removed the control rather than retyping
it: awarding is administrative now, and `/api/users/me` returns `is_superuser` but not
`system_role`, so the client cannot honestly gate the affordance — a button that 403s for almost
everyone is worse than no button. The "How to Earn Reputation Points" card stays.

**Nothing awards reputation automatically.** `award_reputation` has no callers anywhere in the
backend; the HTTP endpoint is the only way a score has ever changed. That is the deeper problem
underneath this issue: reputation is meant to be *derived* from merged PRs, completed projects and
endorsements, and none of that is wired up. This PR makes the manual path safe and auditable; it
does not build the derived one. Worth its own issue.

**The migration also creates the table.** `reputation_logs` is one of the models #1235 flags as
declared in the ORM and never created by any migration, so `alembic upgrade head` produces a
database without it and an unconditional `ALTER TABLE` fails outright — which is exactly what CI
reported. The migration creates the table in the shape the model declares when it is absent, and
adds only the column when it is already there. Since no earlier revision knows about the table,
`downgrade` drops it; leaving it behind breaks `alembic downgrade base`, because its foreign key
to `users` blocks `DROP TABLE users` further down the chain. That is slightly more than the title
promises, but a migration that cannot run against a migrated database is not a migration.

Verified against Postgres 16 locally, running the same three steps the workflow does — upgrade to
head (46 tables, `reputation_logs` present with both foreign keys and all three indexes, and
`created_at` as `timestamp with time zone`), the schema assertions, and downgrade to base.

**Migration ordering.** `down_revision` is `1c63e6c28cf8`, the current single head. #1393 also
adds a migration off that head; whichever lands second will need a one-line rebase of its
`down_revision`, since the conflict is semantic (two alembic heads) rather than textual and git
will not flag it.

ECSoc 2026