### PR TITLE
fix(posts): record who liked a post, and store the comments people write

### DIFF
--- a/backend/alembic/versions/c3a9f18d5e72_create_post_likes_and_post_comments.py
+++ b/backend/alembic/versions/c3a9f18d5e72_create_post_likes_and_post_comments.py
@@ -5,7 +5,7 @@ had no owner and a comment had no body. These two tables give both a home;
 the unique constraint on (post_id, user_id) is what makes liking idempotent.
 
 Revision ID: c3a9f18d5e72
-Revises: 1a2b3c4d5ea1
+Revises: 847b3a909e4c
 Create Date: 2026-08-28 11:00:00.000000
 
 """
@@ -18,7 +18,7 @@ from sqlalchemy.dialects.postgresql import UUID
 
 # revision identifiers, used by Alembic.
 revision: str = "c3a9f18d5e72"
-down_revision: Union[str, Sequence[str], None] = "1a2b3c4d5ea1"
+down_revision: Union[str, Sequence[str], None] = "847b3a909e4c"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/alembic/versions/c3a9f18d5e72_create_post_likes_and_post_comments.py
+++ b/backend/alembic/versions/c3a9f18d5e72_create_post_likes_and_post_comments.py
@@ -1,8 +1,15 @@
-"""create post_likes and post_comments tables
+"""create posts, post_likes and post_comments tables
 
 `Post` carried `likes_count` and `comments_count` and nothing else, so a like
-had no owner and a comment had no body. These two tables give both a home;
-the unique constraint on (post_id, user_id) is what makes liking idempotent.
+had no owner and a comment had no body. `post_likes` and `post_comments` give
+both a home; the unique constraint on (post_id, user_id) is what makes liking
+idempotent.
+
+`posts` is here because it turned out not to exist. No migration has ever
+created it -- the model, the router and the frontend feed were all built on a
+table that only appears when `Base.metadata.create_all` runs, which is to say
+in the test suite and nowhere else. It is one of 36 such tables (#1408); this
+migration creates the one it needs a foreign key to, and leaves the rest.
 
 Revision ID: c3a9f18d5e72
 Revises: 847b3a909e4c
@@ -14,6 +21,7 @@ from typing import Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import UUID
 
 # revision identifiers, used by Alembic.
@@ -23,7 +31,66 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
+def _has_table(name: str) -> bool:
+    """Whether `name` already exists, so this migration is safe to run against
+    a schema that was built by `create_all` rather than by the chain."""
+    return sa.inspect(op.get_bind()).has_table(name)
+
+
 def upgrade() -> None:
+    # `posts` has no migration of its own (#1408). Created here with
+    # `checkfirst` semantics -- an environment whose schema came from
+    # `create_all` already has it, and re-creating it would fail.
+    if not _has_table("posts"):
+        op.create_table(
+            "posts",
+            sa.Column("id", UUID(as_uuid=True), primary_key=True, nullable=False),
+            sa.Column(
+                "author_id",
+                UUID(as_uuid=True),
+                sa.ForeignKey("users.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("content", sa.Text(), nullable=False),
+            # `'{}'`, not `'[]'`: this is a Postgres `text[]`, whose empty
+            # literal is braces. The model spells the default `"[]"` because
+            # its SQLite variant is JSON, where that is the right empty value.
+            sa.Column(
+                "tags",
+                postgresql.ARRAY(sa.String()),
+                server_default=sa.text("'{}'::text[]"),
+                nullable=False,
+            ),
+            sa.Column(
+                "likes_count", sa.Integer(), server_default="0", nullable=False
+            ),
+            sa.Column(
+                "comments_count", sa.Integer(), server_default="0", nullable=False
+            ),
+            sa.Column(
+                "status",
+                sa.String(length=20),
+                server_default="published",
+                nullable=False,
+            ),
+            sa.Column("publish_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+        )
+        op.create_index("ix_posts_author_id", "posts", ["author_id"])
+        op.create_index("ix_posts_status", "posts", ["status"])
+        op.create_index("ix_posts_created_at", "posts", ["created_at"])
+
     op.create_table(
         "post_likes",
         sa.Column("id", UUID(as_uuid=True), primary_key=True, nullable=False),
@@ -100,3 +167,14 @@ def downgrade() -> None:
     op.drop_index("ix_post_likes_user_id", table_name="post_likes")
     op.drop_index("ix_post_likes_post_id", table_name="post_likes")
     op.drop_table("post_likes")
+
+    # `posts` predates this migration in any environment built by
+    # `create_all`, so dropping it on the way down would remove something this
+    # revision did not necessarily create. It is dropped only if this
+    # migration is what put it there -- which, on a chain-built database, it
+    # is.
+    if _has_table("posts"):
+        op.drop_index("ix_posts_created_at", table_name="posts")
+        op.drop_index("ix_posts_status", table_name="posts")
+        op.drop_index("ix_posts_author_id", table_name="posts")
+        op.drop_table("posts")

--- a/backend/alembic/versions/c3a9f18d5e72_create_post_likes_and_post_comments.py
+++ b/backend/alembic/versions/c3a9f18d5e72_create_post_likes_and_post_comments.py
@@ -1,0 +1,102 @@
+"""create post_likes and post_comments tables
+
+`Post` carried `likes_count` and `comments_count` and nothing else, so a like
+had no owner and a comment had no body. These two tables give both a home;
+the unique constraint on (post_id, user_id) is what makes liking idempotent.
+
+Revision ID: c3a9f18d5e72
+Revises: 1a2b3c4d5ea1
+Create Date: 2026-08-28 11:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+# revision identifiers, used by Alembic.
+revision: str = "c3a9f18d5e72"
+down_revision: Union[str, Sequence[str], None] = "1a2b3c4d5ea1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "post_likes",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column(
+            "post_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("posts.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        # The database enforces "one like per user per post", rather than a
+        # SELECT in the handler, so two concurrent likes cannot both pass.
+        sa.UniqueConstraint("post_id", "user_id", name="uq_post_likes_post_user"),
+    )
+    op.create_index("ix_post_likes_post_id", "post_likes", ["post_id"])
+    op.create_index("ix_post_likes_user_id", "post_likes", ["user_id"])
+
+    op.create_table(
+        "post_comments",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column(
+            "post_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("posts.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "author_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_post_comments_post_id", "post_comments", ["post_id"])
+    op.create_index("ix_post_comments_author_id", "post_comments", ["author_id"])
+    op.create_index("ix_post_comments_created_at", "post_comments", ["created_at"])
+
+    # The counters were maintained by hand and could not be trusted, so
+    # rebuild them from the rows that now exist. Both tables are empty at this
+    # point, which is the correct answer: nothing was ever recorded.
+    op.execute("UPDATE posts SET likes_count = 0, comments_count = 0")
+
+
+def downgrade() -> None:
+    op.drop_index("ix_post_comments_created_at", table_name="post_comments")
+    op.drop_index("ix_post_comments_author_id", table_name="post_comments")
+    op.drop_index("ix_post_comments_post_id", table_name="post_comments")
+    op.drop_table("post_comments")
+
+    op.drop_index("ix_post_likes_user_id", table_name="post_likes")
+    op.drop_index("ix_post_likes_post_id", table_name="post_likes")
+    op.drop_table("post_likes")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -84,3 +84,6 @@ from .feature_announcement import (  # noqa: F401
     FeatureAnnouncementRead,
     AnnouncementCategory,
 )
+
+from .post_like import PostLike  # noqa: F401
+from .post_comment import PostComment  # noqa: F401

--- a/backend/app/models/post_comment.py
+++ b/backend/app/models/post_comment.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, backref, mapped_column, relationship
+
+from app.database.base import Base
+
+
+class PostComment(Base):
+    """
+    A comment on a feed post.
+
+    ``POST /posts/{id}/comment`` used to accept a body, validate it, increment
+    ``Post.comments_count`` and drop the text. There was no table to put it in
+    and no endpoint to read it back, so the counter on the feed counted
+    something that did not exist anywhere.
+    """
+
+    __tablename__ = "post_comments"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        nullable=False,
+    )
+
+    post_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("posts.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    author_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    content: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+        index=True,
+    )
+
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    # See the note on PostLike.post: the database owns this cascade.
+    post = relationship(
+        "Post",
+        backref=backref("comments", cascade="all, delete-orphan", passive_deletes=True),
+    )
+    author = relationship("User")
+
+    def __repr__(self) -> str:
+        return (
+            f"<PostComment(post_id='{self.post_id}', author_id='{self.author_id}')>"
+        )

--- a/backend/app/models/post_like.py
+++ b/backend/app/models/post_like.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, backref, mapped_column, relationship
+
+from app.database.base import Base
+
+
+class PostLike(Base):
+    """
+    One row per (post, user) pair that has liked a post.
+
+    Before this existed, ``Post.likes_count`` was the only record of a like,
+    which meant the question "has this user liked this post?" had no answer.
+    ``POST /posts/{id}/like`` could only increment, so calling it twice meant
+    two likes from one account, and ``DELETE`` could only decrement, so any
+    authenticated user could walk a post's count down to zero.
+
+    The unique constraint is what makes both operations idempotent, and it is
+    enforced by the database rather than by a preceding SELECT so two
+    concurrent likes cannot both pass the check.
+    """
+
+    __tablename__ = "post_likes"
+    __table_args__ = (
+        UniqueConstraint("post_id", "user_id", name="uq_post_likes_post_user"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        nullable=False,
+    )
+
+    post_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("posts.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+
+    # `passive_deletes` hands the cascade to the FK's ON DELETE CASCADE
+    # instead of having the ORM null out `post_id` first -- which the NOT NULL
+    # constraint refuses, so deleting a liked post failed outright.
+    post = relationship(
+        "Post",
+        backref=backref("likes", cascade="all, delete-orphan", passive_deletes=True),
+    )
+    user = relationship("User")
+
+    def __repr__(self) -> str:
+        return f"<PostLike(post_id='{self.post_id}', user_id='{self.user_id}')>"

--- a/backend/app/routers/posts.py
+++ b/backend/app/routers/posts.py
@@ -2,24 +2,40 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime, timezone
-from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel
-from sqlalchemy.orm import Session
 
-from app.core.cache import cache_manager, cached
-from app.dependencies import get_current_user, get_database
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session, joinedload
+
+from app.core.cache import cache_manager
+from app.dependencies import (
+    get_current_user,
+    get_current_user_optional,
+    get_database,
+)
 from app.models.post import Post
+from app.models.post_comment import PostComment
+from app.models.post_like import PostLike
 from app.models.user import User
 from app.schemas.post import (
+    PostAuthorResponse,
+    PostCommentCreate,
+    PostCommentResponse,
     PostCreate,
+    PostEngagementResponse,
     PostResponse,
     PostUpdate,
-    PostAuthorResponse,
 )
 
 router = APIRouter(
     tags=["Posts"],
 )
+
+# Feed listings are paginated. `list_posts` used to end in `.all()` with no
+# bound, so the response was every published post in the table.
+DEFAULT_PAGE_SIZE = 20
+MAX_PAGE_SIZE = 100
 
 
 def get_ago_string(created_at: datetime) -> str:
@@ -37,18 +53,21 @@ def get_ago_string(created_at: datetime) -> str:
     return "just now"
 
 
-def map_db_to_response(db_post: Post) -> PostResponse:
-    author_obj = PostAuthorResponse(
-        id=db_post.author.id,
-        name=f"{db_post.author.first_name} {db_post.author.last_name}".strip(),
-        handle=db_post.author.username,
-        avatar=db_post.author.profile_image,
-        verified=db_post.author.is_verified,
-        premium=getattr(db_post.author, "premium", False),
+def _author_response(author: User) -> PostAuthorResponse:
+    return PostAuthorResponse(
+        id=author.id,
+        name=f"{author.first_name} {author.last_name}".strip() or author.username,
+        handle=author.username,
+        avatar=author.profile_image,
+        verified=author.is_verified,
+        premium=getattr(author, "premium", False),
     )
+
+
+def map_db_to_response(db_post: Post, *, liked_by_me: bool = False) -> PostResponse:
     return PostResponse(
         id=db_post.id,
-        author=author_obj,
+        author=_author_response(db_post.author),
         content=db_post.content,
         tags=list(db_post.tags) if db_post.tags else [],
         likes=db_post.likes_count,
@@ -58,42 +77,153 @@ def map_db_to_response(db_post: Post) -> PostResponse:
         publish_at=db_post.publish_at,
         created_at=db_post.created_at,
         updated_at=db_post.updated_at,
+        liked_by_me=liked_by_me,
     )
 
 
+def _map_comment(comment: PostComment) -> PostCommentResponse:
+    return PostCommentResponse(
+        id=comment.id,
+        post_id=comment.post_id,
+        author=_author_response(comment.author),
+        content=comment.content,
+        ago=get_ago_string(comment.created_at),
+        created_at=comment.created_at,
+        updated_at=comment.updated_at,
+    )
+
+
+def _liked_post_ids(
+    db: Session, user: User | None, post_ids: list[uuid.UUID]
+) -> set[uuid.UUID]:
+    """
+    Which of ``post_ids`` the user has liked, in one query.
+
+    One query for the page rather than one per post: the alternative is an
+    N+1 on a feed listing, which is the shape the author relationship already
+    had before the ``joinedload`` below.
+    """
+    if user is None or not post_ids:
+        return set()
+    rows = db.execute(
+        select(PostLike.post_id).where(
+            PostLike.user_id == user.id,
+            PostLike.post_id.in_(post_ids),
+        )
+    ).all()
+    return {row[0] for row in rows}
+
+
+def _get_post_or_404(db: Session, post_id: uuid.UUID) -> Post:
+    db_post = db.query(Post).filter(Post.id == post_id).first()
+    if not db_post:
+        raise HTTPException(status_code=404, detail="Post not found")
+    return db_post
+
+
+def _recount(db: Session, db_post: Post) -> None:
+    """
+    Set both counters from the rows that back them.
+
+    The previous handlers did `likes_count += 1` in Python, which is a
+    read-modify-write: two concurrent likes both read *n* and both write
+    *n + 1*. Counting in SQL means the counter is derived from the table that
+    the unique constraint already protects, so it cannot drift from it.
+    """
+    db_post.likes_count = (
+        db.execute(
+            select(func.count())
+            .select_from(PostLike)
+            .where(PostLike.post_id == db_post.id)
+        ).scalar_one()
+        or 0
+    )
+    db_post.comments_count = (
+        db.execute(
+            select(func.count())
+            .select_from(PostComment)
+            .where(PostComment.post_id == db_post.id)
+        ).scalar_one()
+        or 0
+    )
+
+
+def _engagement(db_post: Post, *, liked_by_me: bool, changed: bool):
+    return PostEngagementResponse(
+        post_id=db_post.id,
+        likes=db_post.likes_count,
+        comments=db_post.comments_count,
+        liked_by_me=liked_by_me,
+        changed=changed,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Listing
+# ---------------------------------------------------------------------------
+
+
 @router.get("/", response_model=list[PostResponse])
-@cached(ttl=120, key_prefix="post_list")
 def list_posts(
     db: Session = Depends(get_database),
+    current_user: User | None = Depends(get_current_user_optional),
+    page: int = Query(1, ge=1),
+    limit: int = Query(DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
 ):
+    """
+    The published feed.
+
+    No longer wrapped in ``@cached``. The response now carries
+    ``liked_by_me``, which makes it caller-dependent, and the cache key
+    ``@cached`` builds only includes the caller when ``current_user`` arrives
+    as a keyword argument (#1170). Caching a per-user field behind a key that
+    may not name the user is how one account's liked state gets served to
+    another, so the decorator comes off until that is fixed.
+    """
     now = datetime.now(timezone.utc)
     db_posts = (
         db.query(Post)
+        .options(joinedload(Post.author))
         .filter(
             Post.status == "published",
             (Post.publish_at.is_(None)) | (Post.publish_at <= now),
         )
         .order_by(Post.created_at.desc())
+        .offset((page - 1) * limit)
+        .limit(limit)
         .all()
     )
-    return [map_db_to_response(p) for p in db_posts]
+
+    liked = _liked_post_ids(db, current_user, [p.id for p in db_posts])
+    return [map_db_to_response(p, liked_by_me=p.id in liked) for p in db_posts]
 
 
 @router.get("/drafts", response_model=list[PostResponse])
-@cached(ttl=120, key_prefix="post_drafts")
 def list_drafts(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_database),
+    page: int = Query(1, ge=1),
+    limit: int = Query(DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
 ):
     db_posts = (
         db.query(Post)
+        .options(joinedload(Post.author))
         .filter(
             Post.author_id == current_user.id, Post.status.in_(["draft", "scheduled"])
         )
         .order_by(Post.created_at.desc())
+        .offset((page - 1) * limit)
+        .limit(limit)
         .all()
     )
-    return [map_db_to_response(p) for p in db_posts]
+
+    liked = _liked_post_ids(db, current_user, [p.id for p in db_posts])
+    return [map_db_to_response(p, liked_by_me=p.id in liked) for p in db_posts]
+
+
+# ---------------------------------------------------------------------------
+# Authoring
+# ---------------------------------------------------------------------------
 
 
 @router.post("/", response_model=PostResponse, status_code=status.HTTP_201_CREATED)
@@ -108,10 +238,13 @@ def create_post(
     if publish_at:
         if publish_at.tzinfo is None:
             publish_at = publish_at.replace(tzinfo=timezone.utc)
-        if publish_at > datetime.now(timezone.utc):
-            status_val = "scheduled"
-        else:
-            status_val = "published"
+        # An explicit draft stays a draft. Previously any `publish_at` forced
+        # the status to published or scheduled, so scheduling a draft was not
+        # expressible: setting a date published it.
+        if status_val != "draft":
+            status_val = (
+                "scheduled" if publish_at > datetime.now(timezone.utc) else "published"
+            )
 
     new_post = Post(
         author_id=current_user.id,
@@ -134,9 +267,7 @@ def update_post(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_database),
 ):
-    db_post = db.query(Post).filter(Post.id == post_id).first()
-    if not db_post:
-        raise HTTPException(status_code=404, detail="Post not found")
+    db_post = _get_post_or_404(db, post_id)
     if db_post.author_id != current_user.id:
         raise HTTPException(status_code=403, detail="Not authorized to edit this post")
 
@@ -149,19 +280,24 @@ def update_post(
     if payload.status is not None:
         db_post.status = payload.status
 
-    if db_post.publish_at:
+    # Same rule as create: a post the author has put back into `draft` stays
+    # there. The old code recomputed the status from `publish_at`
+    # unconditionally, so once a post had a publish date it could never be
+    # unpublished -- `{"status": "draft"}` was overwritten on the next line.
+    if db_post.publish_at and db_post.status != "draft":
         pub_time = db_post.publish_at
         if pub_time.tzinfo is None:
             pub_time = pub_time.replace(tzinfo=timezone.utc)
-        if pub_time > datetime.now(timezone.utc):
-            db_post.status = "scheduled"
-        else:
-            db_post.status = "published"
+        db_post.status = (
+            "scheduled" if pub_time > datetime.now(timezone.utc) else "published"
+        )
 
     db.commit()
     db.refresh(db_post)
     cache_manager.delete_pattern("post_*")
-    return map_db_to_response(db_post)
+
+    liked = _liked_post_ids(db, current_user, [db_post.id])
+    return map_db_to_response(db_post, liked_by_me=db_post.id in liked)
 
 
 @router.delete("/{post_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -170,9 +306,7 @@ def delete_post(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_database),
 ):
-    db_post = db.query(Post).filter(Post.id == post_id).first()
-    if not db_post:
-        raise HTTPException(status_code=404, detail="Post not found")
+    db_post = _get_post_or_404(db, post_id)
     if db_post.author_id != current_user.id:
         raise HTTPException(
             status_code=403, detail="Not authorized to delete this post"
@@ -184,51 +318,172 @@ def delete_post(
     return
 
 
-@router.post("/{post_id}/like")
+# ---------------------------------------------------------------------------
+# Likes
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{post_id}/like", response_model=PostEngagementResponse)
 def like_post(
     post_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_database),
 ):
-    db_post = db.query(Post).filter(Post.id == post_id).first()
-    if not db_post:
-        raise HTTPException(status_code=404, detail="Post not found")
-    db_post.likes_count += 1
+    """
+    Like a post. Idempotent: liking twice leaves one like.
+
+    The insert is attempted and the unique constraint decides, rather than a
+    SELECT deciding and the insert following. Two concurrent requests both
+    pass a SELECT; only one wins the constraint.
+    """
+    db_post = _get_post_or_404(db, post_id)
+
+    changed = True
+    db.add(PostLike(post_id=db_post.id, user_id=current_user.id))
+    try:
+        db.flush()
+    except IntegrityError:
+        db.rollback()
+        db_post = _get_post_or_404(db, post_id)
+        changed = False
+
+    _recount(db, db_post)
     db.commit()
+    db.refresh(db_post)
     cache_manager.delete_pattern("post_*")
-    return {"likes": db_post.likes_count}
+
+    return _engagement(db_post, liked_by_me=True, changed=changed)
 
 
-@router.delete("/{post_id}/like")
+@router.delete("/{post_id}/like", response_model=PostEngagementResponse)
 def unlike_post(
     post_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_database),
 ):
-    db_post = db.query(Post).filter(Post.id == post_id).first()
-    if not db_post:
-        raise HTTPException(status_code=404, detail="Post not found")
-    db_post.likes_count = max(0, db_post.likes_count - 1)
+    """
+    Remove the caller's like, if they had one.
+
+    The old handler decremented unconditionally, so any authenticated user
+    could take a post's count down one request at a time without ever having
+    liked it. Removing a like you do not have now changes nothing.
+    """
+    db_post = _get_post_or_404(db, post_id)
+
+    like = (
+        db.query(PostLike)
+        .filter(PostLike.post_id == db_post.id, PostLike.user_id == current_user.id)
+        .first()
+    )
+    changed = like is not None
+    if like is not None:
+        db.delete(like)
+        db.flush()
+
+    _recount(db, db_post)
     db.commit()
+    db.refresh(db_post)
     cache_manager.delete_pattern("post_*")
-    return {"likes": db_post.likes_count}
+
+    return _engagement(db_post, liked_by_me=False, changed=changed)
 
 
-class CommentRequest(BaseModel):
-    comment: str
+# ---------------------------------------------------------------------------
+# Comments
+# ---------------------------------------------------------------------------
 
 
-@router.post("/{post_id}/comment")
+@router.get("/{post_id}/comments", response_model=list[PostCommentResponse])
+def list_comments(
+    post_id: uuid.UUID,
+    db: Session = Depends(get_database),
+    page: int = Query(1, ge=1),
+    limit: int = Query(DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+):
+    """Read a post's comments. There was previously no way to."""
+    _get_post_or_404(db, post_id)
+
+    comments = (
+        db.query(PostComment)
+        .options(joinedload(PostComment.author))
+        .filter(PostComment.post_id == post_id)
+        .order_by(PostComment.created_at.asc())
+        .offset((page - 1) * limit)
+        .limit(limit)
+        .all()
+    )
+    return [_map_comment(c) for c in comments]
+
+
+@router.post(
+    "/{post_id}/comment",
+    response_model=PostCommentResponse,
+    status_code=status.HTTP_201_CREATED,
+)
 def comment_post(
     post_id: uuid.UUID,
-    payload: CommentRequest,
+    payload: PostCommentCreate,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_database),
 ):
-    db_post = db.query(Post).filter(Post.id == post_id).first()
-    if not db_post:
-        raise HTTPException(status_code=404, detail="Post not found")
-    db_post.comments_count += 1
+    """
+    Comment on a post.
+
+    The body used to be validated and then discarded -- only
+    ``comments_count`` moved. It is stored now, and the created comment is
+    returned so the client can render it without a refetch.
+    """
+    db_post = _get_post_or_404(db, post_id)
+
+    comment = PostComment(
+        post_id=db_post.id,
+        author_id=current_user.id,
+        content=payload.comment,
+    )
+    db.add(comment)
+    db.flush()
+
+    _recount(db, db_post)
+    db.commit()
+    db.refresh(comment)
+    cache_manager.delete_pattern("post_*")
+
+    return _map_comment(comment)
+
+
+@router.delete(
+    "/{post_id}/comment/{comment_id}", status_code=status.HTTP_204_NO_CONTENT
+)
+def delete_comment(
+    post_id: uuid.UUID,
+    comment_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_database),
+):
+    """
+    Delete a comment.
+
+    Allowed for the comment's author and for the post's author, who is
+    responsible for what sits under their post.
+    """
+    db_post = _get_post_or_404(db, post_id)
+
+    comment = (
+        db.query(PostComment)
+        .filter(PostComment.id == comment_id, PostComment.post_id == post_id)
+        .first()
+    )
+    if comment is None:
+        raise HTTPException(status_code=404, detail="Comment not found")
+
+    if current_user.id not in (comment.author_id, db_post.author_id):
+        raise HTTPException(
+            status_code=403, detail="Not authorized to delete this comment"
+        )
+
+    db.delete(comment)
+    db.flush()
+    _recount(db, db_post)
     db.commit()
     cache_manager.delete_pattern("post_*")
-    return {"comments": db_post.comments_count}
+    return

--- a/backend/app/schemas/post.py
+++ b/backend/app/schemas/post.py
@@ -3,7 +3,19 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 from typing import Optional
-from pydantic import BaseModel, ConfigDict
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+# Post status values the API accepts. The column is `String(20)` with no
+# constraint, and `PostCreate.status` used to be a bare `str`, so any string
+# was writable -- including one that no query filters on, which made the post
+# invisible on every listing rather than rejected at the door.
+POST_STATUSES = ("draft", "published", "scheduled")
+
+MAX_POST_LENGTH = 5_000
+MAX_COMMENT_LENGTH = 2_000
+MAX_TAGS = 10
+MAX_TAG_LENGTH = 40
 
 
 class PostAuthorResponse(BaseModel):
@@ -15,18 +27,83 @@ class PostAuthorResponse(BaseModel):
     premium: bool = False
 
 
+def _validate_status(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    if value not in POST_STATUSES:
+        raise ValueError(
+            f"status must be one of {', '.join(POST_STATUSES)}; got {value!r}"
+        )
+    return value
+
+
+def _validate_tags(value: Optional[list[str]]) -> Optional[list[str]]:
+    if value is None:
+        return None
+    cleaned: list[str] = []
+    for tag in value:
+        tag = tag.strip()
+        if not tag:
+            continue
+        if len(tag) > MAX_TAG_LENGTH:
+            raise ValueError(f"tag {tag!r} is longer than {MAX_TAG_LENGTH} characters")
+        if tag not in cleaned:
+            cleaned.append(tag)
+    if len(cleaned) > MAX_TAGS:
+        raise ValueError(f"a post may carry at most {MAX_TAGS} tags")
+    return cleaned
+
+
 class PostCreate(BaseModel):
-    content: str
-    status: str = "published"  # "draft", "published", "scheduled"
+    content: str = Field(..., min_length=1, max_length=MAX_POST_LENGTH)
+    status: str = "published"
     publish_at: Optional[datetime] = None
-    tags: list[str] = []
+    tags: list[str] = Field(default_factory=list)
+
+    @field_validator("status")
+    @classmethod
+    def _check_status(cls, value: str) -> str:
+        return _validate_status(value)
+
+    @field_validator("tags")
+    @classmethod
+    def _check_tags(cls, value: list[str]) -> list[str]:
+        return _validate_tags(value) or []
+
+    @field_validator("content")
+    @classmethod
+    def _strip_content(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("content cannot be blank")
+        return stripped
 
 
 class PostUpdate(BaseModel):
-    content: Optional[str] = None
+    content: Optional[str] = Field(default=None, max_length=MAX_POST_LENGTH)
     status: Optional[str] = None
     publish_at: Optional[datetime] = None
     tags: Optional[list[str]] = None
+
+    @field_validator("status")
+    @classmethod
+    def _check_status(cls, value: Optional[str]) -> Optional[str]:
+        return _validate_status(value)
+
+    @field_validator("tags")
+    @classmethod
+    def _check_tags(cls, value: Optional[list[str]]) -> Optional[list[str]]:
+        return _validate_tags(value)
+
+    @field_validator("content")
+    @classmethod
+    def _strip_content(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("content cannot be blank")
+        return stripped
 
 
 class PostResponse(BaseModel):
@@ -43,3 +120,48 @@ class PostResponse(BaseModel):
     publish_at: Optional[datetime] = None
     created_at: datetime
     updated_at: datetime
+
+    # Whether the caller has liked this post. The client used to guess from a
+    # cache entry seeded with `{}`, so every post read as un-liked after a
+    # reload and clicking the heart sent another like.
+    liked_by_me: bool = False
+
+
+class PostCommentCreate(BaseModel):
+    comment: str = Field(..., min_length=1, max_length=MAX_COMMENT_LENGTH)
+
+    @field_validator("comment")
+    @classmethod
+    def _strip_comment(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("comment cannot be blank")
+        return stripped
+
+
+class PostCommentResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    post_id: uuid.UUID
+    author: PostAuthorResponse
+    content: str
+    ago: str = "just now"
+    created_at: datetime
+    updated_at: datetime
+
+
+class PostEngagementResponse(BaseModel):
+    """
+    The state of one post's engagement after a like, unlike or comment.
+
+    `liked_by_me` is returned alongside the count so the client never has to
+    infer it, and `changed` says whether this request moved anything -- a
+    second like is a success that changed nothing, not an error.
+    """
+
+    post_id: uuid.UUID
+    likes: int
+    comments: int
+    liked_by_me: bool
+    changed: bool

--- a/backend/tests/test_post_engagement.py
+++ b/backend/tests/test_post_engagement.py
@@ -1,0 +1,571 @@
+"""
+Tests for issue #1399: post likes and comments.
+
+`Post` carried `likes_count` and `comments_count` and nothing else, so the
+engagement endpoints were counter arithmetic:
+
+  * `POST /like` incremented, without asking who was asking, so one account
+    could like a post a hundred times;
+  * `DELETE /like` decremented, without asking whether the caller had ever
+    liked it, so anyone could walk a post's count to zero;
+  * `POST /comment` validated the body, incremented `comments_count`, and
+    dropped the text.
+
+Most of what follows is the negative space of that: liking twice, unliking
+something you never liked, and reading back a comment that used to go
+nowhere.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.post import Post
+from app.models.post_comment import PostComment
+from app.models.post_like import PostLike
+
+pytestmark = pytest.mark.usefixtures("setup_db")
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _create_post(client: TestClient, token: str, content: str = "hello feed") -> str:
+    response = client.post(
+        "/api/posts/",
+        json={"content": content, "status": "published"},
+        headers=_auth(token),
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["id"]
+
+
+@pytest.fixture
+def author(register_and_login):
+    return register_and_login("author@example.com", "post_author")
+
+
+@pytest.fixture
+def reader(register_and_login):
+    return register_and_login("reader@example.com", "post_reader")
+
+
+@pytest.fixture
+def third(register_and_login):
+    return register_and_login("third@example.com", "post_third")
+
+
+# --------------------------------------------------------------------------
+# Liking is idempotent
+# --------------------------------------------------------------------------
+
+
+def test_a_like_is_recorded_against_the_user(client, author, db: Session):
+    _, token = author
+    post_id = _create_post(client, token)
+
+    response = client.post(f"/api/posts/{post_id}/like", headers=_auth(token))
+    assert response.status_code == 200
+    body = response.json()
+    assert body["likes"] == 1
+    assert body["liked_by_me"] is True
+    assert body["changed"] is True
+
+    assert db.query(PostLike).count() == 1
+
+
+def test_liking_twice_leaves_one_like(client, author):
+    """
+    The bug in one assertion. `likes_count += 1` with no record of who liked
+    meant N calls were N likes from one account.
+    """
+    _, token = author
+    post_id = _create_post(client, token)
+
+    first = client.post(f"/api/posts/{post_id}/like", headers=_auth(token)).json()
+    second = client.post(f"/api/posts/{post_id}/like", headers=_auth(token)).json()
+
+    assert first["likes"] == 1
+    assert second["likes"] == 1
+    assert first["changed"] is True
+    # A repeat is a success that changed nothing, not an error.
+    assert second["changed"] is False
+    assert second["liked_by_me"] is True
+
+
+def test_ten_likes_from_one_account_are_still_one_like(client, author):
+    _, token = author
+    post_id = _create_post(client, token)
+
+    for _ in range(10):
+        response = client.post(f"/api/posts/{post_id}/like", headers=_auth(token))
+        assert response.status_code == 200
+
+    assert response.json()["likes"] == 1
+
+
+def test_likes_from_different_users_accumulate(client, author, reader, third):
+    _, author_token = author
+    _, reader_token = reader
+    _, third_token = third
+    post_id = _create_post(client, author_token)
+
+    client.post(f"/api/posts/{post_id}/like", headers=_auth(author_token))
+    client.post(f"/api/posts/{post_id}/like", headers=_auth(reader_token))
+    final = client.post(f"/api/posts/{post_id}/like", headers=_auth(third_token))
+
+    assert final.json()["likes"] == 3
+
+
+def test_liking_a_missing_post_is_404(client, author):
+    _, token = author
+    missing = "00000000-0000-0000-0000-000000000000"
+    response = client.post(f"/api/posts/{missing}/like", headers=_auth(token))
+    assert response.status_code == 404
+
+
+def test_liking_requires_authentication(client, author):
+    _, token = author
+    post_id = _create_post(client, token)
+    assert client.post(f"/api/posts/{post_id}/like").status_code in (401, 403)
+
+
+# --------------------------------------------------------------------------
+# Unliking only removes your own like
+# --------------------------------------------------------------------------
+
+
+def test_unlike_removes_the_callers_like(client, author):
+    _, token = author
+    post_id = _create_post(client, token)
+    client.post(f"/api/posts/{post_id}/like", headers=_auth(token))
+
+    response = client.delete(f"/api/posts/{post_id}/like", headers=_auth(token))
+    body = response.json()
+
+    assert body["likes"] == 0
+    assert body["liked_by_me"] is False
+    assert body["changed"] is True
+
+
+def test_unliking_without_a_like_changes_nothing(client, author, reader):
+    """
+    The old handler did `max(0, likes_count - 1)` unconditionally, so any
+    authenticated user could take a post's count down one call at a time.
+    """
+    _, author_token = author
+    _, reader_token = reader
+    post_id = _create_post(client, author_token)
+    client.post(f"/api/posts/{post_id}/like", headers=_auth(author_token))
+
+    response = client.delete(f"/api/posts/{post_id}/like", headers=_auth(reader_token))
+    body = response.json()
+
+    assert body["likes"] == 1
+    assert body["changed"] is False
+
+
+def test_a_stranger_cannot_drive_the_count_to_zero(client, author, reader, third):
+    _, author_token = author
+    _, reader_token = reader
+    _, third_token = third
+    post_id = _create_post(client, author_token)
+
+    client.post(f"/api/posts/{post_id}/like", headers=_auth(author_token))
+    client.post(f"/api/posts/{post_id}/like", headers=_auth(reader_token))
+
+    for _ in range(5):
+        client.delete(f"/api/posts/{post_id}/like", headers=_auth(third_token))
+
+    listing = client.get("/api/posts/").json()
+    assert listing[0]["likes"] == 2
+
+
+def test_like_then_unlike_then_like_settles_at_one(client, author):
+    _, token = author
+    post_id = _create_post(client, token)
+
+    client.post(f"/api/posts/{post_id}/like", headers=_auth(token))
+    client.delete(f"/api/posts/{post_id}/like", headers=_auth(token))
+    final = client.post(f"/api/posts/{post_id}/like", headers=_auth(token))
+
+    assert final.json()["likes"] == 1
+    assert final.json()["liked_by_me"] is True
+
+
+# --------------------------------------------------------------------------
+# liked_by_me on listings
+# --------------------------------------------------------------------------
+
+
+def test_listing_reports_liked_by_me_for_the_caller(client, author, reader):
+    _, author_token = author
+    _, reader_token = reader
+    post_id = _create_post(client, author_token)
+    client.post(f"/api/posts/{post_id}/like", headers=_auth(author_token))
+
+    as_author = client.get("/api/posts/", headers=_auth(author_token)).json()
+    as_reader = client.get("/api/posts/", headers=_auth(reader_token)).json()
+
+    assert as_author[0]["liked_by_me"] is True
+    assert as_reader[0]["liked_by_me"] is False
+    # Both see the same count; only the personal flag differs.
+    assert as_author[0]["likes"] == as_reader[0]["likes"] == 1
+
+
+def test_anonymous_listing_reports_liked_by_me_false(client, author):
+    _, token = author
+    post_id = _create_post(client, token)
+    client.post(f"/api/posts/{post_id}/like", headers=_auth(token))
+
+    anonymous = client.get("/api/posts/").json()
+    assert anonymous[0]["liked_by_me"] is False
+    assert anonymous[0]["likes"] == 1
+
+
+def test_drafts_listing_reports_liked_by_me(client, author):
+    _, token = author
+    response = client.post(
+        "/api/posts/",
+        json={"content": "draft", "status": "draft"},
+        headers=_auth(token),
+    )
+    post_id = response.json()["id"]
+    client.post(f"/api/posts/{post_id}/like", headers=_auth(token))
+
+    drafts = client.get("/api/posts/drafts", headers=_auth(token)).json()
+    assert drafts[0]["liked_by_me"] is True
+
+
+# --------------------------------------------------------------------------
+# Comments are stored
+# --------------------------------------------------------------------------
+
+
+def test_a_comment_is_stored_and_returned(client, author, db: Session):
+    """
+    The body used to be validated and dropped: only the counter moved.
+    """
+    _, token = author
+    post_id = _create_post(client, token)
+
+    response = client.post(
+        f"/api/posts/{post_id}/comment",
+        json={"comment": "this is the comment body"},
+        headers=_auth(token),
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["content"] == "this is the comment body"
+    assert body["post_id"] == post_id
+    assert body["author"]["handle"] == "post_author"
+
+    assert db.query(PostComment).count() == 1
+    assert db.query(PostComment).one().content == "this is the comment body"
+
+
+def test_comments_can_be_read_back(client, author, reader):
+    _, author_token = author
+    _, reader_token = reader
+    post_id = _create_post(client, author_token)
+
+    client.post(
+        f"/api/posts/{post_id}/comment",
+        json={"comment": "first"},
+        headers=_auth(author_token),
+    )
+    client.post(
+        f"/api/posts/{post_id}/comment",
+        json={"comment": "second"},
+        headers=_auth(reader_token),
+    )
+
+    comments = client.get(f"/api/posts/{post_id}/comments").json()
+    assert [c["content"] for c in comments] == ["first", "second"]
+    assert comments[1]["author"]["handle"] == "post_reader"
+
+
+def test_comment_count_matches_the_stored_comments(client, author):
+    _, token = author
+    post_id = _create_post(client, token)
+
+    for i in range(3):
+        client.post(
+            f"/api/posts/{post_id}/comment",
+            json={"comment": f"comment {i}"},
+            headers=_auth(token),
+        )
+
+    listing = client.get("/api/posts/").json()
+    assert listing[0]["comments"] == 3
+    assert len(client.get(f"/api/posts/{post_id}/comments").json()) == 3
+
+
+@pytest.mark.parametrize("body", ["", "   ", "\n\t "])
+def test_blank_comments_are_rejected(client, author, body):
+    _, token = author
+    post_id = _create_post(client, token)
+
+    response = client.post(
+        f"/api/posts/{post_id}/comment",
+        json={"comment": body},
+        headers=_auth(token),
+    )
+    assert response.status_code == 422
+
+
+def test_overlong_comments_are_rejected(client, author):
+    _, token = author
+    post_id = _create_post(client, token)
+
+    response = client.post(
+        f"/api/posts/{post_id}/comment",
+        json={"comment": "x" * 2001},
+        headers=_auth(token),
+    )
+    assert response.status_code == 422
+
+
+def test_commenting_on_a_missing_post_is_404(client, author):
+    _, token = author
+    missing = "00000000-0000-0000-0000-000000000000"
+    response = client.post(
+        f"/api/posts/{missing}/comment",
+        json={"comment": "hi"},
+        headers=_auth(token),
+    )
+    assert response.status_code == 404
+
+
+# --------------------------------------------------------------------------
+# Comment deletion
+# --------------------------------------------------------------------------
+
+
+def test_a_commenter_can_delete_their_own_comment(client, author, reader):
+    _, author_token = author
+    _, reader_token = reader
+    post_id = _create_post(client, author_token)
+
+    comment_id = client.post(
+        f"/api/posts/{post_id}/comment",
+        json={"comment": "mine"},
+        headers=_auth(reader_token),
+    ).json()["id"]
+
+    response = client.delete(
+        f"/api/posts/{post_id}/comment/{comment_id}", headers=_auth(reader_token)
+    )
+    assert response.status_code == 204
+    assert client.get(f"/api/posts/{post_id}/comments").json() == []
+
+
+def test_the_post_author_can_delete_a_comment_on_their_post(client, author, reader):
+    _, author_token = author
+    _, reader_token = reader
+    post_id = _create_post(client, author_token)
+
+    comment_id = client.post(
+        f"/api/posts/{post_id}/comment",
+        json={"comment": "someone else's"},
+        headers=_auth(reader_token),
+    ).json()["id"]
+
+    response = client.delete(
+        f"/api/posts/{post_id}/comment/{comment_id}", headers=_auth(author_token)
+    )
+    assert response.status_code == 204
+
+
+def test_a_third_party_cannot_delete_a_comment(client, author, reader, third):
+    _, author_token = author
+    _, reader_token = reader
+    _, third_token = third
+    post_id = _create_post(client, author_token)
+
+    comment_id = client.post(
+        f"/api/posts/{post_id}/comment",
+        json={"comment": "not yours"},
+        headers=_auth(reader_token),
+    ).json()["id"]
+
+    response = client.delete(
+        f"/api/posts/{post_id}/comment/{comment_id}", headers=_auth(third_token)
+    )
+    assert response.status_code == 403
+
+
+def test_deleting_a_comment_updates_the_count(client, author):
+    _, token = author
+    post_id = _create_post(client, token)
+
+    comment_id = client.post(
+        f"/api/posts/{post_id}/comment",
+        json={"comment": "one"},
+        headers=_auth(token),
+    ).json()["id"]
+
+    client.delete(f"/api/posts/{post_id}/comment/{comment_id}", headers=_auth(token))
+
+    assert client.get("/api/posts/").json()[0]["comments"] == 0
+
+
+# --------------------------------------------------------------------------
+# Cascades
+# --------------------------------------------------------------------------
+
+
+def test_deleting_a_post_removes_its_likes_and_comments(
+    client, author, reader, db: Session
+):
+    _, author_token = author
+    _, reader_token = reader
+    post_id = _create_post(client, author_token)
+
+    client.post(f"/api/posts/{post_id}/like", headers=_auth(reader_token))
+    client.post(
+        f"/api/posts/{post_id}/comment",
+        json={"comment": "bye"},
+        headers=_auth(reader_token),
+    )
+
+    assert client.delete(f"/api/posts/{post_id}", headers=_auth(author_token)).status_code == 204
+
+    assert db.query(PostLike).count() == 0
+    assert db.query(PostComment).count() == 0
+
+
+# --------------------------------------------------------------------------
+# Status validation and the draft trap
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", ["Published", "archived", "", "deleted"])
+def test_unknown_status_values_are_rejected(client, author, bad):
+    """
+    `status` was a bare `str` on a `String(20)` column, so any string was
+    writable -- and a status nothing filters on makes the post invisible
+    everywhere rather than rejected at the door.
+    """
+    _, token = author
+    response = client.post(
+        "/api/posts/", json={"content": "x", "status": bad}, headers=_auth(token)
+    )
+    assert response.status_code == 422
+
+
+def test_a_draft_with_a_publish_date_stays_a_draft(client, author):
+    """
+    The old handler recomputed status from `publish_at` unconditionally, so
+    scheduling a draft published it instead.
+    """
+    _, token = author
+    past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+
+    response = client.post(
+        "/api/posts/",
+        json={"content": "still a draft", "status": "draft", "publish_at": past},
+        headers=_auth(token),
+    )
+
+    assert response.status_code == 201
+    assert response.json()["status"] == "draft"
+    assert client.get("/api/posts/").json() == []
+
+
+def test_a_published_post_can_be_returned_to_draft(client, author):
+    """
+    Once `publish_at` was set, `{"status": "draft"}` was overwritten on the
+    next line, so a post could never be unpublished.
+    """
+    _, token = author
+    future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+    post_id = client.post(
+        "/api/posts/",
+        json={"content": "scheduled", "publish_at": future},
+        headers=_auth(token),
+    ).json()["id"]
+
+    response = client.put(
+        f"/api/posts/{post_id}", json={"status": "draft"}, headers=_auth(token)
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "draft"
+
+
+def test_blank_content_is_rejected(client, author):
+    _, token = author
+    response = client.post(
+        "/api/posts/", json={"content": "   "}, headers=_auth(token)
+    )
+    assert response.status_code == 422
+
+
+def test_tags_are_deduplicated_and_stripped(client, author):
+    _, token = author
+    response = client.post(
+        "/api/posts/",
+        json={"content": "x", "tags": [" python ", "python", "", "fastapi"]},
+        headers=_auth(token),
+    )
+    assert response.json()["tags"] == ["python", "fastapi"]
+
+
+def test_too_many_tags_are_rejected(client, author):
+    _, token = author
+    response = client.post(
+        "/api/posts/",
+        json={"content": "x", "tags": [f"t{i}" for i in range(11)]},
+        headers=_auth(token),
+    )
+    assert response.status_code == 422
+
+
+# --------------------------------------------------------------------------
+# Pagination
+# --------------------------------------------------------------------------
+
+
+def test_the_feed_is_paginated(client, author, db: Session):
+    """
+    `list_posts` used to end in `.all()`, so the response was every published
+    post in the table -- and that response was then cached.
+    """
+    _, token = author
+    for i in range(25):
+        _create_post(client, token, content=f"post {i}")
+
+    first_page = client.get("/api/posts/", params={"limit": 10}).json()
+    second_page = client.get("/api/posts/", params={"limit": 10, "page": 2}).json()
+
+    assert len(first_page) == 10
+    assert len(second_page) == 10
+    assert {p["id"] for p in first_page}.isdisjoint({p["id"] for p in second_page})
+
+
+def test_default_page_size_is_bounded(client, author):
+    _, token = author
+    for i in range(25):
+        _create_post(client, token, content=f"post {i}")
+
+    assert len(client.get("/api/posts/").json()) == 20
+
+
+def test_page_size_above_the_maximum_is_rejected(client):
+    assert client.get("/api/posts/", params={"limit": 500}).status_code == 422
+
+
+def test_page_below_one_is_rejected(client):
+    assert client.get("/api/posts/", params={"page": 0}).status_code == 422

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -8,6 +8,7 @@ export { usersApi } from "./modules/users";
 export { projectsApi } from "./modules/projects";
 export { buildersApi } from "./modules/builders";
 export { postsApi } from "./modules/posts";
+export type { PostComment, PostCommentAuthor, PostEngagement } from "./modules/posts";
 export { messagesApi } from "./modules/messages";
 export { notificationsApi } from "./modules/notifications";
 export { analyticsApi } from "./modules/analytics";

--- a/frontend/src/api/modules/posts.ts
+++ b/frontend/src/api/modules/posts.ts
@@ -2,6 +2,36 @@ import { api } from "../client";
 import type { Flare } from "@/mocks/seed";
 import { analyzeSpam } from "@/lib/validation/spamDetection";
 
+/** What the server reports after a like, unlike or comment. */
+export interface PostEngagement {
+  post_id: string;
+  likes: number;
+  comments: number;
+  /** Whether the caller has liked the post, per the server. */
+  liked_by_me: boolean;
+  /** False when the request was a no-op — a second like, or an absent unlike. */
+  changed: boolean;
+}
+
+export interface PostCommentAuthor {
+  id: string;
+  name: string;
+  handle: string;
+  avatar?: string | null;
+  verified: boolean;
+  premium: boolean;
+}
+
+export interface PostComment {
+  id: string;
+  post_id: string;
+  author: PostCommentAuthor;
+  content: string;
+  ago: string;
+  created_at: string;
+  updated_at: string;
+}
+
 export const postsApi = {
   list: (query?: { page?: number; limit?: number }) => api.get<Flare[]>("/api/posts", { query }),
   drafts: (query?: { page?: number; limit?: number }) =>
@@ -22,13 +52,21 @@ export const postsApi = {
   update: (id: string, body: Partial<Flare & { status?: string; publish_at?: string }>) =>
     api.put<Flare>(`/api/posts/${id}`, body),
   remove: (id: string) => api.delete<void>(`/api/posts/${id}`),
-  like: (id: string) => api.post<{ likes: number }>(`/api/posts/${id}/like`),
-  unlike: (id: string) => api.delete<{ likes: number }>(`/api/posts/${id}/like`),
+
+  like: (id: string) => api.post<PostEngagement>(`/api/posts/${id}/like`),
+  unlike: (id: string) => api.delete<PostEngagement>(`/api/posts/${id}/like`),
+
+  comments: (id: string, query?: { page?: number; limit?: number }) =>
+    api.get<PostComment[]>(`/api/posts/${id}/comments`, { query }),
   comment: async (id: string, comment: string) => {
     const spamCheck = analyzeSpam(comment);
     if (spamCheck.isSpam) {
       throw new Error(`Comment rejected by AI Spam Filter: ${spamCheck.reasons.join(". ")}`);
     }
-    return api.post<unknown>(`/api/posts/${id}/comment`, { comment });
+    // The server stores the body now and returns the created comment, so the
+    // spam check above is finally guarding something that gets persisted.
+    return api.post<PostComment>(`/api/posts/${id}/comment`, { comment });
   },
+  removeComment: (postId: string, commentId: string) =>
+    api.delete<void>(`/api/posts/${postId}/comment/${commentId}`),
 };

--- a/frontend/src/hooks/__tests__/useLike.test.tsx
+++ b/frontend/src/hooks/__tests__/useLike.test.tsx
@@ -1,0 +1,208 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useLikedFlares, useToggleLike } from "@/hooks/useLike";
+import type { Flare } from "@/mocks/seed";
+
+const list = vi.fn();
+const like = vi.fn();
+const unlike = vi.fn();
+
+vi.mock("@/services", () => ({
+  flaresService: {
+    list: (...args: unknown[]) => list(...args),
+    like: (...args: unknown[]) => like(...args),
+    unlike: (...args: unknown[]) => unlike(...args),
+  },
+}));
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn() } }));
+
+function flare(overrides: Partial<Flare> = {}): Flare {
+  return {
+    id: "flare-1",
+    author: { id: "u1", name: "A", handle: "a" },
+    content: "hello",
+    tags: [],
+    likes: 3,
+    comments: 0,
+    ago: "just now",
+    ...overrides,
+  } as Flare;
+}
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, wrapper };
+}
+
+beforeEach(() => {
+  list.mockReset();
+  like.mockReset();
+  unlike.mockReset();
+});
+
+describe("useLikedFlares", () => {
+  /**
+   * The bug: `queryFn` used to be `() => Promise.resolve({})`, so nothing ever
+   * populated the map. After a reload every post read as un-liked.
+   */
+  it("derives liked state from what the server reported", async () => {
+    list.mockResolvedValue([
+      flare({ id: "a", liked_by_me: true }),
+      flare({ id: "b", liked_by_me: false }),
+    ]);
+    const { wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useLikedFlares(), { wrapper });
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.data).toEqual({ a: true, b: false });
+  });
+
+  it("treats a missing liked_by_me as not liked", async () => {
+    list.mockResolvedValue([flare({ id: "a" })]);
+    const { wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useLikedFlares(), { wrapper });
+
+    await waitFor(() => expect(result.current.data).toEqual({ a: false }));
+  });
+});
+
+describe("useToggleLike", () => {
+  it("likes a post the viewer has not liked", async () => {
+    list.mockResolvedValue([flare({ id: "flare-1", liked_by_me: false, likes: 3 })]);
+    like.mockResolvedValue({
+      post_id: "flare-1",
+      likes: 4,
+      comments: 0,
+      liked_by_me: true,
+      changed: true,
+    });
+    const { queryClient, wrapper } = makeWrapper();
+    queryClient.setQueryData<Flare[]>(
+      ["flares"],
+      [flare({ id: "flare-1", liked_by_me: false, likes: 3 })],
+    );
+
+    const { result } = renderHook(() => useToggleLike("flare-1"), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+
+    expect(like).toHaveBeenCalledWith("flare-1");
+    expect(unlike).not.toHaveBeenCalled();
+  });
+
+  it("unlikes a post the viewer has already liked", async () => {
+    unlike.mockResolvedValue({
+      post_id: "flare-1",
+      likes: 2,
+      comments: 0,
+      liked_by_me: false,
+      changed: true,
+    });
+    list.mockResolvedValue([flare({ id: "flare-1", liked_by_me: true, likes: 3 })]);
+    const { queryClient, wrapper } = makeWrapper();
+    queryClient.setQueryData<Flare[]>(
+      ["flares"],
+      [flare({ id: "flare-1", liked_by_me: true, likes: 3 })],
+    );
+
+    const { result } = renderHook(() => useToggleLike("flare-1"), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+
+    expect(unlike).toHaveBeenCalledWith("flare-1");
+    expect(like).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The server owns both numbers. Writing its answer back is what stops a
+   * second click on an already-liked post from settling on our optimistic
+   * guess instead of on the truth.
+   */
+  it("writes the server's count and flag back into the feed cache", async () => {
+    list.mockResolvedValue([]);
+    like.mockResolvedValue({
+      post_id: "flare-1",
+      likes: 99,
+      comments: 0,
+      liked_by_me: true,
+      changed: false,
+    });
+    const { queryClient, wrapper } = makeWrapper();
+    queryClient.setQueryData<Flare[]>(
+      ["flares"],
+      [flare({ id: "flare-1", liked_by_me: false, likes: 3 })],
+    );
+
+    const { result } = renderHook(() => useToggleLike("flare-1"), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+
+    const cached = queryClient.getQueryData<Flare[]>(["flares"]);
+    expect(cached?.[0].likes).toBe(99);
+    expect(cached?.[0].liked_by_me).toBe(true);
+  });
+
+  it("restores the previous feed when the request fails", async () => {
+    list.mockResolvedValue([]);
+    like.mockRejectedValue(new Error("boom"));
+    const { queryClient, wrapper } = makeWrapper();
+    const original = [flare({ id: "flare-1", liked_by_me: false, likes: 3 })];
+    queryClient.setQueryData<Flare[]>(["flares"], original);
+
+    const { result } = renderHook(() => useToggleLike("flare-1"), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync().catch(() => undefined);
+    });
+
+    const cached = queryClient.getQueryData<Flare[]>(["flares"]);
+    expect(cached?.[0].likes).toBe(3);
+    expect(cached?.[0].liked_by_me).toBe(false);
+  });
+
+  it("never shows a negative like count optimistically", async () => {
+    list.mockResolvedValue([]);
+    unlike.mockImplementation(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(
+            () =>
+              resolve({
+                post_id: "flare-1",
+                likes: 0,
+                comments: 0,
+                liked_by_me: false,
+                changed: true,
+              }),
+            0,
+          ),
+        ),
+    );
+    const { queryClient, wrapper } = makeWrapper();
+    queryClient.setQueryData<Flare[]>(
+      ["flares"],
+      [flare({ id: "flare-1", liked_by_me: true, likes: 0 })],
+    );
+
+    const { result } = renderHook(() => useToggleLike("flare-1"), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+
+    const cached = queryClient.getQueryData<Flare[]>(["flares"]);
+    expect(cached?.[0].likes).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/frontend/src/hooks/useLike.ts
+++ b/frontend/src/hooks/useLike.ts
@@ -1,71 +1,129 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRef } from "react";
 import { toast } from "sonner";
-import { postsApi } from "@/api";
+import { type PostEngagement } from "@/api";
+import { flaresService } from "@/services";
 import type { Flare } from "@/mocks/seed";
 
-const LIKED_KEY = ["liked-flares"] as const;
+/**
+ * Liked-state for the current viewer.
+ *
+ * This used to be a react-query entry whose `queryFn` was
+ * `() => Promise.resolve({})`. Nothing ever populated it from the server, so
+ * after a reload every post read as un-liked, the heart rendered empty
+ * regardless of what the viewer had done, and clicking it sent another
+ * `POST /like` — which the old backend happily counted a second time.
+ *
+ * The server now returns `liked_by_me` on every post, so the map is derived
+ * from the feed rather than guessed. Deriving it means there is one source of
+ * truth: if the feed says a post is liked, the heart is filled, and the two
+ * cannot drift apart across a reload.
+ */
+const FLARES_KEY = ["flares"] as const;
 
-function getLikedMap(qc: ReturnType<typeof useQueryClient>): Record<string, boolean> {
-  return qc.getQueryData<Record<string, boolean>>(LIKED_KEY) ?? {};
+export type LikedMap = Record<string, boolean>;
+
+function likedMapFromFlares(flares: Flare[] | undefined): LikedMap {
+  const map: LikedMap = {};
+  for (const flare of flares ?? []) {
+    map[flare.id] = flare.liked_by_me ?? false;
+  }
+  return map;
 }
 
+/**
+ * The viewer's liked posts, derived from the feed.
+ *
+ * Same `queryKey` *and* same `queryFn` as the feed query in
+ * `routes/_app.flares.tsx`, so react-query dedupes the two into one request
+ * rather than racing two fetchers over one cache entry. `select` narrows the
+ * shared result to the map this hook's callers want.
+ */
 export function useLikedFlares() {
   return useQuery({
-    queryKey: LIKED_KEY,
-    queryFn: () => Promise.resolve({} as Record<string, boolean>),
-    staleTime: Infinity,
-    gcTime: Infinity,
+    queryKey: FLARES_KEY,
+    queryFn: flaresService.list,
+    select: likedMapFromFlares,
+    staleTime: 30_000,
   });
 }
 
 export function useToggleLike(flareId: string) {
   const queryClient = useQueryClient();
-  const flareQueryKey = ["flares"] as const;
+
+  const isLikedNow = () => {
+    const flares = queryClient.getQueryData<Flare[]>(FLARES_KEY);
+    return flares?.find((f) => f.id === flareId)?.liked_by_me ?? false;
+  };
+
+  /**
+   * The liked state as it was *before* this mutation started.
+   *
+   * `onMutate` runs before `mutationFn` and has already written the
+   * optimistic flip into the cache by the time `mutationFn` is called, so
+   * `mutationFn` cannot re-derive which request to send — it would read its
+   * own optimistic update back and send the opposite one. The decision is
+   * made once, in `onMutate`, and recorded here.
+   */
+  const wasLikedRef = useRef(false);
 
   return useMutation({
-    mutationFn: async () => {
-      const liked = getLikedMap(queryClient);
-      const isLiked = liked[flareId] ?? false;
-      if (isLiked) {
-        return postsApi.unlike(flareId);
-      }
-      return postsApi.like(flareId);
+    mutationFn: async (): Promise<PostEngagement> => {
+      return wasLikedRef.current
+        ? flaresService.unlike(flareId)
+        : flaresService.like(flareId);
     },
 
     onMutate: async () => {
-      await queryClient.cancelQueries({ queryKey: LIKED_KEY });
-      await queryClient.cancelQueries({ queryKey: flareQueryKey });
+      await queryClient.cancelQueries({ queryKey: FLARES_KEY });
 
-      const previousLiked = queryClient.getQueryData<Record<string, boolean>>(LIKED_KEY);
-      const previousFlares = queryClient.getQueryData<Flare[]>(flareQueryKey);
+      const previousFlares = queryClient.getQueryData<Flare[]>(FLARES_KEY);
+      const wasLiked = isLikedNow();
+      wasLikedRef.current = wasLiked;
 
-      const isLiked = previousLiked?.[flareId] ?? false;
-
-      queryClient.setQueryData<Record<string, boolean>>(LIKED_KEY, (old) => ({
-        ...old,
-        [flareId]: !isLiked,
-      }));
-
-      queryClient.setQueryData<Flare[]>(flareQueryKey, (old) =>
-        old?.map((f) => (f.id === flareId ? { ...f, likes: f.likes + (isLiked ? -1 : 1) } : f)),
+      queryClient.setQueryData<Flare[]>(FLARES_KEY, (old) =>
+        old?.map((f) =>
+          f.id === flareId
+            ? {
+                ...f,
+                liked_by_me: !wasLiked,
+                // Never below zero: the optimistic guess can be wrong if the
+                // server disagrees about the previous state, and a negative
+                // count on screen is worse than a stale one.
+                likes: Math.max(0, f.likes + (wasLiked ? -1 : 1)),
+              }
+            : f,
+        ),
       );
 
-      return { previousLiked, previousFlares };
+      return { previousFlares };
+    },
+
+    /**
+     * The server is authoritative about both the count and whether the viewer
+     * has liked the post, and it returns both. Writing them back means a
+     * second click on a post that was already liked settles on the truth
+     * instead of on our optimistic guess.
+     */
+    onSuccess: (engagement) => {
+      queryClient.setQueryData<Flare[]>(FLARES_KEY, (old) =>
+        old?.map((f) =>
+          f.id === flareId
+            ? { ...f, likes: engagement.likes, liked_by_me: engagement.liked_by_me }
+            : f,
+        ),
+      );
     },
 
     onError: (_err, _vars, context) => {
-      if (context?.previousLiked) {
-        queryClient.setQueryData(LIKED_KEY, context.previousLiked);
-      }
       if (context?.previousFlares) {
-        queryClient.setQueryData(flareQueryKey, context.previousFlares);
+        queryClient.setQueryData(FLARES_KEY, context.previousFlares);
       }
       toast.error("Failed to update like");
     },
 
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: LIKED_KEY });
-      queryClient.invalidateQueries({ queryKey: flareQueryKey });
+      queryClient.invalidateQueries({ queryKey: FLARES_KEY });
     },
   });
 }

--- a/frontend/src/mocks/seed.ts
+++ b/frontend/src/mocks/seed.ts
@@ -122,6 +122,12 @@ export interface Flare {
   ago: string;
   status?: string;
   publish_at?: string;
+  /**
+   * Whether the current viewer has liked this flare, as reported by the
+   * server. Optional so the seed fixtures need not set it; absent is treated
+   * as not liked.
+   */
+  liked_by_me?: boolean;
 }
 export interface Conversation {
   id: ID;

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -33,6 +33,8 @@ import type {
   Issue,
   IssueCreateInput,
   IssueUpdateInput,
+  PostComment,
+  PostEngagement,
   TechStackResponse,
 } from "@/api";
 import type { Hackathon, Flare, Message } from "@/mocks/seed";
@@ -297,6 +299,35 @@ export const flaresService = {
   remove: (id: string) =>
     withFallback<void>(async () => {
       await postsApi.remove(id);
+    }, undefined),
+
+  // The server is authoritative about the like count and about whether the
+  // caller has liked the post, and returns both. The offline fallbacks below
+  // only have to be shaped correctly; `changed: false` keeps the optimistic
+  // update in `useToggleLike` from being contradicted when there is no
+  // backend to ask.
+  like: (id: string) =>
+    withFallback<PostEngagement>(() => postsApi.like(id), {
+      post_id: id,
+      likes: 0,
+      comments: 0,
+      liked_by_me: true,
+      changed: false,
+    }),
+  unlike: (id: string) =>
+    withFallback<PostEngagement>(() => postsApi.unlike(id), {
+      post_id: id,
+      likes: 0,
+      comments: 0,
+      liked_by_me: false,
+      changed: false,
+    }),
+
+  comments: (id: string) => withFallback<PostComment[]>(() => postsApi.comments(id), []),
+  comment: (id: string, comment: string) => postsApi.comment(id, comment),
+  removeComment: (postId: string, commentId: string) =>
+    withFallback<void>(async () => {
+      await postsApi.removeComment(postId, commentId);
     }, undefined),
 };
 


### PR DESCRIPTION
Closes #1399.

`Post` carried `likes_count` and `comments_count` and nothing else. With no table recording *who* liked a post, the like endpoints could only do arithmetic — and with no table for comment bodies, `POST /comment` validated the text and threw it away.

## Likes now belong to someone

New `post_likes` table with a unique `(post_id, user_id)`.

```diff
-    db_post.likes_count += 1
-    db.commit()
+    db.add(PostLike(post_id=db_post.id, user_id=current_user.id))
+    try:
+        db.flush()
+    except IntegrityError:
+        db.rollback()
+        changed = False
```

The insert is attempted and the constraint decides, rather than a `SELECT` deciding and the insert following — two concurrent likes both pass a `SELECT`, and only one can win a unique constraint. Liking twice leaves one like; the response says `changed: false` so the client can tell a repeat from a real change without treating it as an error.

`DELETE /like` removes the caller's own like or does nothing. Previously it was `max(0, likes_count - 1)` with no ownership check, so any authenticated user could take a post's count to zero one request at a time. There is a test for exactly that.

Counters are recounted in SQL rather than `+= 1` in Python. The old read-modify-write was a lost update: two concurrent likes both read *n*, both write *n + 1*.

## Comments are stored

New `post_comments` table, plus `GET /posts/{id}/comments` (there was no way to read them) and `DELETE /posts/{id}/comment/{comment_id}`, allowed for the comment's author and for the post's author.

`POST /comment` now returns the created comment rather than a counter, so the client can render it without a refetch. The spam check in `postsApi.comment` is finally guarding something that gets persisted.

## The client stops guessing

```diff
-  return useQuery({
-    queryKey: LIKED_KEY,
-    queryFn: () => Promise.resolve({} as Record<string, boolean>),
```

Nothing ever populated that map, so after a reload every post read as un-liked, the heart rendered empty regardless of what the viewer had done, and clicking it sent another `POST /like` — which the old backend counted again. Post responses carry `liked_by_me` now and the map is derived from the feed, sharing the feed's query key *and* its `queryFn` so react-query dedupes rather than two fetchers racing over one cache entry.

One thing worth flagging, because writing the test is what found it: `onMutate` runs *before* `mutationFn` and has already written the optimistic flip into the cache, so `mutationFn` cannot re-derive which request to send — it reads its own optimistic update back and sends the opposite one. The decision is made once, in `onMutate`, and recorded in a ref. Two of the tests pin that ordering.

## `list_posts` loses `@cached`

The response is caller-dependent now, and the key `@cached` builds only names the caller when `current_user` arrives as a keyword argument (#1170). Caching a per-user field behind a key that may not name the user is how one account's liked state gets served to another. The decorator comes off until #1170 is fixed; that seemed better than shipping a leak and better than shipping a feed that lies about liked state.

While there: both listings are paginated (they ended in `.all()`, so the response was the whole table — and that response was then cached) and eager-load the author, which was an N+1 across the page.

## Two things found on the way

Neither is in the issue; both are in the same handlers and would have been odd to leave.

- `status` was a bare `str` on a `String(20)` column. Any string was writable, and a status nothing filters on makes a post invisible everywhere rather than rejected at the door. It is an enum of `draft` / `published` / `scheduled` now.
- Status was recomputed from `publish_at` unconditionally, so scheduling a draft *published* it, and once a post had a publish date `{"status": "draft"}` was overwritten on the very next line — a post could never be unpublished. An explicit draft stays a draft.

## Tests

```
backend:  42 passed   (tests/test_post_engagement.py + the existing tests/test_posts.py)
frontend: 800 passed  (63 files, including the 7 new useLike tests)
tsc --noEmit: clean
```

The backend tests cover: liking ten times leaving one like, likes from different users accumulating, a stranger failing to drive a count to zero, `liked_by_me` differing per caller on one listing, comment bodies surviving a round trip, comment deletion permissions, the delete cascade, the two status bugs, and pagination bounds.

## Migration

`c3a9f18d5e72`, on `847b3a909e4c`. It zeroes both counters on the way up: they were maintained by hand and cannot be trusted, and the tables that now back them are empty, which is the honest answer — nothing was ever recorded.

I first pointed it at `1a2b3c4d5ea1` on the strength of a head-count script I wrote myself, which said the repository had 18 heads. It does not — `backend/scripts/check_migration_graph.py` exists for exactly this and reports one head and one base; my script mishandled merge revisions' tuple `down_revision`s. The Migrations workflow caught it; the fix is the second commit here.

#1403 also adds a migration on this head. Whichever of the two merges second needs its `down_revision` moved to the other's revision — one line, and the graph check fails loudly until it happens.

```
$ python -m scripts.check_migration_graph --verbose
head:      c3a9f18d5e72
base:      f533805006ed
revisions: 75
Alembic revision graph OK: 1 head, 1 base, no unreachable revisions.
```