### PR TITLE
fix(backup): sign backups, check whose they are, and validate what restore writes

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -55,6 +55,25 @@ class Settings(BaseSettings):
     PASSWORD_HASH_SCHEME: str = "bcrypt"
 
     # ----------------------------------------------------------
+    # Backup signing
+    # ----------------------------------------------------------
+    #
+    # Key for the HMAC that makes an exported backup verifiable as ours. A
+    # plain digest cannot do that job: the writer and the checker both compute
+    # a public function of the data, so anyone editing the file can recompute
+    # it. Restore writes profile fields, so "did we write this file?" needs a
+    # real answer.
+    #
+    # Empty means "fall back to SECRET_KEY", which the app already requires.
+    # Set it separately to rotate backup signatures without invalidating every
+    # session.
+    BACKUP_SIGNING_SECRET: str = ""
+
+    # Backup uploads are read into memory to be parsed as JSON, so the ceiling
+    # is a memory ceiling.
+    MAX_BACKUP_UPLOAD_MB: int = 25
+
+    # ----------------------------------------------------------
     # Password screening
     # ----------------------------------------------------------
 

--- a/backend/app/routers/backup.py
+++ b/backend/app/routers/backup.py
@@ -18,6 +18,7 @@ from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
 from fastapi.responses import Response
 from sqlalchemy.orm import Session
 
+from app.core.config import settings
 from app.dependencies import get_current_active_user, get_database
 from app.models.user import User
 from app.schemas.backup import (
@@ -25,9 +26,45 @@ from app.schemas.backup import (
     RestoreResponse,
     RestoreValidationResponse,
 )
-from app.services.backup_service import BackupService
+from app.services.backup_service import BackupOwnershipError, BackupService
 
 router = APIRouter(prefix="/users/me/backup", tags=["Backup & Restore"])
+
+
+async def _read_backup_upload(file: UploadFile) -> dict:
+    """
+    Read an uploaded backup and parse it, with a ceiling.
+
+    All three upload endpoints used to do a bare ``await file.read()``: no
+    size limit, no streaming, the whole file resident before anything looked
+    at it. The upload has to be materialised to be parsed as JSON, so the
+    ceiling is the honest way to bound that -- read one byte past the limit
+    and refuse if it arrives.
+    """
+    max_bytes = settings.MAX_BACKUP_UPLOAD_MB * 1024 * 1024
+    raw = await file.read(max_bytes + 1)
+
+    if len(raw) > max_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=(
+                f"Backup file exceeds the {settings.MAX_BACKUP_UPLOAD_MB} MB limit."
+            ),
+        )
+
+    if not raw:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Backup file is empty.",
+        )
+
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Invalid JSON: {exc}",
+        ) from exc
 
 
 # ---------------------------------------------------------------------------
@@ -105,15 +142,12 @@ async def validate_backup(
     file: UploadFile = File(..., description="The devlink_backup_<id>.json file"),
     current_user: User = Depends(get_current_active_user),
 ) -> RestoreValidationResponse:
-    raw = await file.read()
-    try:
-        payload = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Invalid JSON: {exc}",
-        )
-    return BackupService.validate_backup(payload)
+    payload = await _read_backup_upload(file)
+    # The same checks restore will run, reported rather than raised, so the
+    # answer here and the outcome there cannot disagree.
+    return BackupService.validate_backup(
+        payload, expected_user_id=str(current_user.id)
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -133,17 +167,13 @@ async def preview_restore(
     file: UploadFile = File(..., description="The devlink_backup_<id>.json file"),
     current_user: User = Depends(get_current_active_user),
 ) -> dict:
-    raw = await file.read()
-    try:
-        payload = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Invalid JSON: {exc}",
-        )
+    payload = await _read_backup_upload(file)
 
-    # Validate integrity before preview
-    validation = BackupService.validate_backup(payload)
+    # Preview changes nothing, so it will describe an older unsigned file
+    # rather than refuse it -- the response carries `signed` so the caller can
+    # see that restoring it will not work. Structure and checksum still have
+    # to hold, or there is nothing coherent to describe.
+    validation = BackupService.validate_backup(payload, require_signature=False)
     if not validation.valid:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -177,19 +207,19 @@ async def restore_backup(
     current_user: User = Depends(get_current_active_user),
     db: Session = Depends(get_database),
 ) -> RestoreResponse:
-    raw = await file.read()
-    try:
-        payload = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Invalid JSON: {exc}",
-        )
+    payload = await _read_backup_upload(file)
 
     try:
         return BackupService.restore_backup(db, current_user, payload)
+    except BackupOwnershipError as exc:
+        # Not "your file is malformed" -- it is well-formed and belongs to
+        # someone else.
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=str(exc),
+        ) from exc
     except ValueError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(exc),
-        )
+        ) from exc

--- a/backend/app/schemas/backup.py
+++ b/backend/app/schemas/backup.py
@@ -32,10 +32,19 @@ class BackupMetadata(BaseModel):
 
 
 class BackupPayload(BaseModel):
-    """Full serialisable backup payload written to disk / returned to client."""
+    """
+    Full serialisable backup payload written to disk / returned to client.
+
+    ``checksum`` and ``signature`` cover the same bytes and answer different
+    questions. The checksum is unkeyed, so it detects corruption but not
+    tampering -- anyone editing the file can recompute it. The signature is an
+    HMAC keyed with a server-side secret, which is what makes "this file came
+    from us" checkable. Restore requires the signature; see #1400.
+    """
 
     metadata: BackupMetadata
     checksum: str  # SHA-256 hex digest of the *data* section JSON string
+    signature: str | None = None  # HMAC-SHA256 over the same string
     data: dict[str, Any]  # serialised UserExportData
 
 

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -15,14 +15,31 @@ as a .zip archive for download.
     "data": { … UserExportData … }
   }
 
+Integrity
+─────────
+Two separate mechanisms, because they answer two different questions:
+
+* ``checksum`` -- an unkeyed SHA-256 over the data section. It catches
+  *corruption*: a truncated download, a mangled copy-paste. It cannot catch
+  tampering, because it is a public function of the data and anyone editing
+  the file can recompute it in three lines. It was documented as a tamper
+  check, and restore leaned on that; see #1400.
+* ``signature`` -- an HMAC-SHA256 over the same bytes, keyed with a
+  server-side secret. This is the one that answers "did we write this file?",
+  and it is the one restore requires.
+
 Security
 ────────
-* The checksum prevents tampering: if the data section is modified after
-  export, the restore endpoint rejects the file.
+* Restore requires a valid signature *and* that the backup's
+  ``metadata.user_id`` matches the account restoring it.
+* Restored profile fields go through ``UserUpdate``, the same validation the
+  ``PATCH /users/me`` path uses. Values from a file do not reach ORM columns
+  unvalidated.
 * No sensitive credentials (passwords, MFA secrets) are included in the
   backup payload.
-* Restored items are *merged*, not destructive – existing records are
-  never deleted.
+* Bookmarks and skills are merged: existing records are never deleted.
+  Profile fields are *overwritten* from the file -- that step is not
+  non-destructive, and the docs used to say it was.
 
 Restore scope
 ─────────────
@@ -41,14 +58,19 @@ Items NOT restored (by design):
 from __future__ import annotations
 
 import hashlib
+import hmac
 import io
 import json
+import logging
 import uuid
 import zipfile
 from datetime import datetime, timezone
 from typing import Any
 
+from pydantic import ValidationError
 from sqlalchemy.orm import Session
+
+from app.core.config import settings
 
 from app.models.bookmark import Bookmark
 from app.models.project import Project
@@ -63,7 +85,10 @@ from app.schemas.backup import (
     RestoreValidationError,
     RestoreValidationResponse,
 )
+from app.schemas.user import UserUpdate
 from app.services.export_service import ExportService
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Internal helpers
@@ -71,8 +96,51 @@ from app.services.export_service import ExportService
 
 
 def _sha256(text: str) -> str:
+    """
+    Unkeyed digest of the data section.
+
+    A corruption check, and only that. Both the writer and the checker compute
+    the same public function of the same bytes, so a modified file with a
+    recomputed digest passes -- which is why it is no longer what restore
+    trusts. Kept because it still catches a truncated or mangled file, and
+    because backups already in the wild carry one.
+    """
     # codeql[py/weak-sensitive-data-hashing] These are high entropy tokens, not passwords
     return hashlib.sha256(text.encode()).hexdigest()
+
+
+def _signing_key() -> bytes:
+    """
+    The key the backup HMAC is computed with.
+
+    Falls back to ``SECRET_KEY``, which the application already requires, so
+    this needs no new mandatory configuration. Setting
+    ``BACKUP_SIGNING_SECRET`` separately lets backup signatures be rotated
+    without invalidating every session.
+    """
+    secret = (settings.BACKUP_SIGNING_SECRET or "").strip() or settings.SECRET_KEY
+    return secret.encode("utf-8")
+
+
+def _sign(text: str) -> str:
+    """
+    HMAC-SHA256 over the data section, keyed server-side.
+
+    This is the part a file's author cannot forge without the key, which is
+    what makes "we wrote this file" a checkable claim rather than a hope.
+    """
+    return hmac.new(_signing_key(), text.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def _canonical_json(data: Any) -> str:
+    """
+    The exact byte sequence both the checksum and the signature cover.
+
+    Written once so the create and validate paths cannot drift: a signature
+    over slightly different bytes is a signature that never verifies, and the
+    failure looks exactly like tampering.
+    """
+    return json.dumps(data, sort_keys=True, default=str)
 
 
 def _serialize_export_data(data: Any) -> dict:
@@ -83,6 +151,15 @@ def _serialize_export_data(data: Any) -> dict:
 # ---------------------------------------------------------------------------
 # BackupService
 # ---------------------------------------------------------------------------
+
+
+class BackupOwnershipError(PermissionError):
+    """
+    The backup belongs to a different account.
+
+    Distinct from ``ValueError`` so the router can answer 403 rather than
+    folding "not yours" into the 400 a malformed file gets.
+    """
 
 
 class BackupService:
@@ -108,8 +185,9 @@ class BackupService:
         """
         export_data = ExportService.collect_user_data(db, user)
         data_dict = _serialize_export_data(export_data)
-        data_json = json.dumps(data_dict, sort_keys=True, default=str)
+        data_json = _canonical_json(data_dict)
         checksum = _sha256(data_json)
+        signature = _sign(data_json)
 
         now = datetime.now(timezone.utc)
         backup_id = str(uuid.uuid4())
@@ -125,6 +203,7 @@ class BackupService:
         payload = BackupPayload(
             metadata=metadata,
             checksum=checksum,
+            signature=signature,
             data=data_dict,
         )
 
@@ -153,14 +232,45 @@ class BackupService:
     # ------------------------------------------------------------------ #
 
     @classmethod
-    def validate_backup(cls, payload: dict) -> RestoreValidationResponse:
+    def validate_backup(
+        cls,
+        payload: Any,
+        *,
+        require_signature: bool = True,
+        expected_user_id: str | None = None,
+    ) -> RestoreValidationResponse:
         """
-        Validate the structure and integrity of an uploaded backup payload.
-        Returns a RestoreValidationResponse with any errors found.
+        Validate the structure, integrity and provenance of a backup payload.
+
+        Three distinct questions, answered in order, because a later answer is
+        only meaningful once the earlier ones hold:
+
+        1. **Is it shaped like a backup?** Missing or wrongly-typed sections
+           stop here. ``payload["metadata"].get(...)`` used to run against
+           whatever ``metadata`` happened to be, so a file with a string there
+           raised ``AttributeError`` and a 500 rather than a validation error.
+        2. **Did it arrive intact?** The checksum, which catches corruption.
+        3. **Did we write it, and is it this account's?** The signature and
+           ``metadata.user_id``.
+
+        ``require_signature=False`` exists for the preview endpoint, which
+        makes no changes and should still be able to describe an old
+        unsigned file. Restore never passes it.
         """
         errors: list[RestoreValidationError] = []
 
-        # Check top-level keys
+        if not isinstance(payload, dict):
+            return RestoreValidationResponse(
+                valid=False,
+                errors=[
+                    RestoreValidationError(
+                        field="payload",
+                        message="Backup must be a JSON object.",
+                    )
+                ],
+            )
+
+        # --- 1. Shape -----------------------------------------------------
         for key in ("metadata", "checksum", "data"):
             if key not in payload:
                 errors.append(
@@ -173,29 +283,106 @@ class BackupService:
         if errors:
             return RestoreValidationResponse(valid=False, errors=errors)
 
-        # Version check
-        version = payload["metadata"].get("version")
+        metadata = payload.get("metadata")
+        if not isinstance(metadata, dict):
+            errors.append(
+                RestoreValidationError(
+                    field="metadata",
+                    message="'metadata' must be an object.",
+                )
+            )
+
+        data_section = payload.get("data")
+        if not isinstance(data_section, dict):
+            errors.append(
+                RestoreValidationError(
+                    field="data",
+                    message="'data' must be an object.",
+                )
+            )
+
+        if errors:
+            return RestoreValidationResponse(valid=False, errors=errors)
+
+        version = metadata.get("version")
         if version not in cls.SUPPORTED_VERSIONS:
             errors.append(
                 RestoreValidationError(
                     field="metadata.version",
-                    message=f"Unsupported backup version '{version}'. Supported: {cls.SUPPORTED_VERSIONS}",
+                    message=(
+                        f"Unsupported backup version '{version}'. "
+                        f"Supported: {sorted(cls.SUPPORTED_VERSIONS)}"
+                    ),
                 )
             )
 
-        # Checksum integrity check
-        data_section = payload.get("data", {})
-        data_json = json.dumps(data_section, sort_keys=True, default=str)
-        expected_checksum = _sha256(data_json)
-        actual_checksum = payload.get("checksum", "")
+        # --- 2. Integrity -------------------------------------------------
+        data_json = _canonical_json(data_section)
+        actual_checksum = payload.get("checksum")
 
-        if expected_checksum != actual_checksum:
+        if not isinstance(actual_checksum, str) or not hmac.compare_digest(
+            _sha256(data_json), actual_checksum
+        ):
             errors.append(
                 RestoreValidationError(
                     field="checksum",
-                    message="Checksum mismatch. The backup file may have been tampered with.",
+                    message=(
+                        "Checksum mismatch. The backup file is corrupt or "
+                        "incomplete."
+                    ),
                 )
             )
+
+        # --- 3. Provenance ------------------------------------------------
+        if require_signature:
+            signature = payload.get("signature")
+            if not isinstance(signature, str) or not signature:
+                errors.append(
+                    RestoreValidationError(
+                        field="signature",
+                        message=(
+                            "Backup is unsigned. Only backups produced by this "
+                            "DevLink instance can be restored; export a fresh "
+                            "one from Settings."
+                        ),
+                    )
+                )
+            elif not hmac.compare_digest(_sign(data_json), signature):
+                errors.append(
+                    RestoreValidationError(
+                        field="signature",
+                        message=(
+                            "Signature does not match the backup contents. The "
+                            "file has been modified since it was exported."
+                        ),
+                    )
+                )
+
+        if expected_user_id is not None:
+            owner = metadata.get("user_id")
+            if not owner:
+                # A file that does not say whose it is, is malformed rather
+                # than someone else's. The two get different fields so the
+                # caller can answer 400 for one and 403 for the other.
+                errors.append(
+                    RestoreValidationError(
+                        field="metadata.user_id",
+                        message=(
+                            "Backup metadata does not record which account it "
+                            "belongs to."
+                        ),
+                    )
+                )
+            elif str(owner) != str(expected_user_id):
+                errors.append(
+                    RestoreValidationError(
+                        field="ownership",
+                        message=(
+                            "This backup belongs to a different account and "
+                            "cannot be restored here."
+                        ),
+                    )
+                )
 
         return RestoreValidationResponse(valid=len(errors) == 0, errors=errors)
 
@@ -208,15 +395,30 @@ class BackupService:
         """
         Apply a validated backup payload to the current user's account.
 
-        Restore strategy (non-destructive merge):
-          1. Profile fields – update mutable profile fields if provided.
-          2. Bookmarks – re-create any bookmarks whose projects still exist.
-          3. Skills – re-create user-skill associations that no longer exist.
+        Restore strategy:
+          1. Profile fields – **overwritten** from the file where present and
+             valid. This step is not a merge, and the docs used to say it was.
+          2. Bookmarks – additive; re-created where the project still exists.
+          3. Skills – additive; associations re-created where the skill still
+             exists.
+
+        Nothing is deleted, but a profile field present in the backup replaces
+        the current one.
 
         Returns a RestoreResponse with counts of restored items.
+
+        Raises ``BackupOwnershipError`` when the file belongs to another
+        account, so the router can answer 403 rather than folding it into the
+        400 that a malformed file gets. ``metadata.user_id`` was written on
+        export and never read on import, so any account's export file applied
+        cleanly to any other account.
         """
-        validation = cls.validate_backup(payload)
+        validation = cls.validate_backup(payload, expected_user_id=str(user.id))
         if not validation.valid:
+            if any(e.field == "ownership" for e in validation.errors):
+                raise BackupOwnershipError(
+                    "This backup belongs to a different account."
+                )
             error_msgs = "; ".join(e.message for e in validation.errors)
             raise ValueError(f"Invalid backup: {error_msgs}")
 
@@ -247,33 +449,96 @@ class BackupService:
     #  Private restore helpers                                             #
     # ------------------------------------------------------------------ #
 
-    @staticmethod
-    def _restore_profile(db: Session, user: User, profile: dict) -> int:
-        """Update mutable profile fields. Returns number of fields updated."""
-        RESTORABLE_FIELDS = [
-            "headline",
-            "bio",
-            "location",
-            "timezone",
-            "website",
-            "portfolio_url",
-            "public_email",
-            "github_url",
-            "linkedin_url",
-            "company",
-            "experience_level",
-            "open_to_work",
-        ]
+    # Profile fields a backup may write. Every one of them is also a field on
+    # ``UserUpdate``, which is what makes routing them through it possible.
+    RESTORABLE_FIELDS = (
+        "headline",
+        "bio",
+        "location",
+        "timezone",
+        "website",
+        "portfolio_url",
+        "public_email",
+        "github_url",
+        "linkedin_url",
+        "company",
+        "experience_level",
+        "open_to_work",
+    )
+
+    @classmethod
+    def _restore_profile(cls, db: Session, user: User, profile: Any) -> int:
+        """
+        Update mutable profile fields from the backup. Returns the count.
+
+        The values go through ``UserUpdate`` first -- the same model
+        ``PATCH /users/me`` validates against -- so a backup cannot write
+        something the ordinary profile form would reject. They used to be
+        ``setattr``-ed straight onto the ORM: a ``javascript:`` URL in
+        ``website``, a string longer than its column, an ``experience_level``
+        outside the enum, all landed unexamined.
+
+        A field that fails validation is skipped and logged rather than
+        failing the whole restore, so one bad value in an otherwise good
+        backup does not cost the user their bookmarks and skills.
+        """
+        if not isinstance(profile, dict):
+            return 0
+
+        candidate = {
+            field: profile[field]
+            for field in cls.RESTORABLE_FIELDS
+            if field in profile and profile[field] is not None
+        }
+        if not candidate:
+            return 0
+
+        validated = cls._validate_profile_fields(candidate)
+
         updated = 0
-        for field in RESTORABLE_FIELDS:
-            if field in profile and profile[field] is not None:
-                current_val = getattr(user, field, None)
-                new_val = profile[field]
-                if current_val != new_val:
-                    setattr(user, field, new_val)
-                    updated += 1
+        for field, new_val in validated.items():
+            if getattr(user, field, None) != new_val:
+                setattr(user, field, new_val)
+                updated += 1
+
         db.add(user)
         return updated
+
+    @classmethod
+    def _validate_profile_fields(cls, candidate: dict) -> dict:
+        """
+        Run candidate profile values through ``UserUpdate``.
+
+        Tried as one model first, because that is the cheap path. If it fails,
+        each field is tried alone so that the rest of a mostly-valid backup
+        still applies and the rejected field can be named in the log.
+        """
+        try:
+            model = UserUpdate(**candidate)
+        except ValidationError:
+            pass
+        else:
+            return {
+                field: getattr(model, field)
+                for field in candidate
+                if getattr(model, field, None) is not None
+            }
+
+        accepted: dict = {}
+        for field, value in candidate.items():
+            try:
+                model = UserUpdate(**{field: value})
+            except ValidationError as exc:
+                logger.warning(
+                    "Skipping profile field %r from backup: %s",
+                    field,
+                    exc.errors()[0].get("msg") if exc.errors() else exc,
+                )
+                continue
+            resolved = getattr(model, field, None)
+            if resolved is not None:
+                accepted[field] = resolved
+        return accepted
 
     @staticmethod
     def _restore_bookmarks(db: Session, user: User, bookmarks: list[dict]) -> int:
@@ -360,23 +625,28 @@ class BackupService:
         """
         Return a preview of what would be restored without making DB changes.
         """
-        data = payload.get("data", {})
-        meta = payload.get("metadata", {})
+        data = payload.get("data") or {}
+        meta = payload.get("metadata") or {}
+        if not isinstance(data, dict):
+            data = {}
+        if not isinstance(meta, dict):
+            meta = {}
         return {
             "backup_id": meta.get("backup_id", "unknown"),
             "created_at": meta.get("created_at"),
             "username": meta.get("username"),
+            "signed": bool(payload.get("signature")),
             "records": {
-                "profile_fields": len(data.get("profile", {})),
-                "projects": len(data.get("projects", [])),
-                "skills": len(data.get("skills", [])),
-                "bookmarks": len(data.get("bookmarks", [])),
-                "messages": len(data.get("messages", [])),
-                "connections": len(data.get("connections", [])),
-                "organizations": len(data.get("organizations", [])),
-                "applications": len(data.get("applications", [])),
-                "activities": len(data.get("activities", [])),
-                "notifications": len(data.get("notifications", [])),
-                "builder_flares": len(data.get("builder_flares", [])),
+                "profile_fields": len(data.get("profile") or {}),
+                "projects": len(data.get("projects") or []),
+                "skills": len(data.get("skills") or []),
+                "bookmarks": len(data.get("bookmarks") or []),
+                "messages": len(data.get("messages") or []),
+                "connections": len(data.get("connections") or []),
+                "organizations": len(data.get("organizations") or []),
+                "applications": len(data.get("applications") or []),
+                "activities": len(data.get("activities") or []),
+                "notifications": len(data.get("notifications") or []),
+                "builder_flares": len(data.get("builder_flares") or []),
             },
         }

--- a/backend/tests/test_backup_integrity.py
+++ b/backend/tests/test_backup_integrity.py
@@ -1,0 +1,397 @@
+"""
+Tests for issue #1400: backup provenance, ownership and validation.
+
+The module docstring used to promise that "the checksum prevents tampering:
+if the data section is modified after export, the restore endpoint rejects
+the file". It did not. The checksum is an unkeyed SHA-256 that both the writer
+and the checker compute from the data, so editing the file and recomputing it
+is three lines — and restore leaned on that promise while writing profile
+fields straight onto the ORM.
+
+So the first test here is the one that used to pass and should not have:
+tamper with the data, recompute the digest, and watch it be refused.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.backup_service import (
+    BackupOwnershipError,
+    BackupService,
+    _canonical_json,
+    _sha256,
+    _sign,
+)
+
+pytestmark = pytest.mark.usefixtures("setup_db")
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+
+def _user(user_id: uuid.UUID | None = None, username: str = "owner") -> MagicMock:
+    u = MagicMock()
+    u.id = user_id or uuid.uuid4()
+    u.username = username
+    u.bio = "old bio"
+    u.headline = "old headline"
+    u.website = None
+    u.public_email = None
+    u.github_url = None
+    u.linkedin_url = None
+    u.portfolio_url = None
+    u.company = None
+    u.location = None
+    u.timezone = None
+    u.experience_level = None
+    u.open_to_work = False
+    return u
+
+
+def _payload(owner: MagicMock, data: dict | None = None, *, sign: bool = True) -> dict:
+    if data is None:
+        data = {"profile": {}, "bookmarks": [], "skills": []}
+    data_json = _canonical_json(data)
+    payload = {
+        "metadata": {
+            "version": "1.0",
+            "backup_id": str(uuid.uuid4()),
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "app_name": "DevLink",
+            "user_id": str(owner.id),
+            "username": owner.username,
+        },
+        "checksum": _sha256(data_json),
+        "data": data,
+    }
+    if sign:
+        payload["signature"] = _sign(data_json)
+    return payload
+
+
+def _reseal_checksum_only(payload: dict) -> dict:
+    """Edit-and-recompute, exactly as an attacker with the file would."""
+    payload["checksum"] = _sha256(_canonical_json(payload["data"]))
+    return payload
+
+
+def _fields(result) -> set[str]:
+    return {e.field for e in result.errors}
+
+
+# --------------------------------------------------------------------------
+# The checksum is not a tamper check
+# --------------------------------------------------------------------------
+
+
+def test_recomputing_the_checksum_no_longer_gets_a_file_accepted():
+    """
+    The bug, in one test. Anyone with the file can recompute the digest.
+    """
+    owner = _user()
+    payload = _payload(owner)
+    payload["data"]["profile"] = {"headline": "injected"}
+    _reseal_checksum_only(payload)
+
+    result = BackupService.validate_backup(payload)
+
+    assert result.valid is False
+    assert "signature" in _fields(result)
+
+
+def test_a_correctly_signed_backup_is_accepted():
+    owner = _user()
+    result = BackupService.validate_backup(_payload(owner))
+    assert result.valid is True, result.errors
+
+
+def test_a_backup_created_by_the_service_validates():
+    owner = _user()
+    with patch(
+        "app.services.backup_service.ExportService.collect_user_data"
+    ) as collect:
+        collect.return_value = MagicMock(
+            model_dump_json=lambda: json.dumps({"profile": {"username": "owner"}})
+        )
+        _, zip_bytes = BackupService.create_backup(MagicMock(), owner)
+
+    import io
+    import zipfile
+
+    with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+        payload = json.loads(zf.read(zf.namelist()[0]))
+
+    assert BackupService.validate_backup(payload).valid is True
+
+
+def test_an_unsigned_backup_is_refused_with_a_useful_message():
+    owner = _user()
+    payload = _payload(owner, sign=False)
+
+    result = BackupService.validate_backup(payload)
+
+    assert result.valid is False
+    errors = {e.field: e.message for e in result.errors}
+    assert "signature" in errors
+    assert "unsigned" in errors["signature"].lower()
+
+
+def test_a_signature_from_a_different_key_is_refused():
+    owner = _user()
+    payload = _payload(owner)
+    payload["signature"] = "0" * 64
+
+    result = BackupService.validate_backup(payload)
+
+    assert result.valid is False
+    assert "signature" in _fields(result)
+
+
+def test_a_truncated_file_still_fails_the_checksum():
+    """The checksum keeps its real job: catching corruption."""
+    owner = _user()
+    payload = _payload(owner)
+    payload["data"]["bookmarks"] = [{"project_id": str(uuid.uuid4())}]
+
+    result = BackupService.validate_backup(payload)
+
+    assert result.valid is False
+    assert "checksum" in _fields(result)
+
+
+def test_preview_accepts_an_unsigned_backup_but_says_so():
+    """
+    Preview changes nothing, so it describes an older file rather than
+    refusing it -- and reports that restoring it will not work.
+    """
+    owner = _user()
+    payload = _payload(owner, sign=False)
+
+    result = BackupService.validate_backup(payload, require_signature=False)
+    assert result.valid is True
+
+    assert BackupService.preview_restore(payload)["signed"] is False
+
+
+# --------------------------------------------------------------------------
+# Ownership
+# --------------------------------------------------------------------------
+
+
+def test_another_accounts_backup_is_refused():
+    """
+    `metadata.user_id` was written on export and never read on import, so any
+    account's export applied cleanly to any other account.
+    """
+    theirs = _user(username="them")
+    mine = _user(username="me")
+
+    with pytest.raises(BackupOwnershipError):
+        BackupService.restore_backup(MagicMock(), mine, _payload(theirs))
+
+
+def test_your_own_backup_restores():
+    me = _user()
+    db = MagicMock()
+
+    response = BackupService.restore_backup(db, me, _payload(me))
+
+    assert response.success is True
+
+
+def test_a_backup_that_does_not_say_whose_it_is_is_malformed_not_forbidden():
+    """
+    Distinct from the case above, and answered with 400 rather than 403: a
+    file with no owner recorded is broken, not someone else's.
+    """
+    me = _user()
+    payload = _payload(me)
+    del payload["metadata"]["user_id"]
+
+    with pytest.raises(ValueError) as exc:
+        BackupService.restore_backup(MagicMock(), me, payload)
+    assert not isinstance(exc.value, BackupOwnershipError)
+
+
+def test_ownership_is_reported_under_its_own_field():
+    theirs = _user()
+    result = BackupService.validate_backup(
+        _payload(theirs), expected_user_id=str(uuid.uuid4())
+    )
+    assert "ownership" in _fields(result)
+
+
+# --------------------------------------------------------------------------
+# Malformed structures are errors, not 500s
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("metadata", ["a string", 42, ["a", "list"], None])
+def test_a_non_object_metadata_is_a_validation_error(metadata):
+    """
+    `payload["metadata"].get("version")` ran against whatever was there. A
+    string raised `AttributeError`, which is a 500 from all three endpoints.
+    """
+    result = BackupService.validate_backup(
+        {"metadata": metadata, "checksum": "x", "data": {}}
+    )
+    assert result.valid is False
+    assert "metadata" in _fields(result)
+
+
+@pytest.mark.parametrize("data", ["a string", 42, ["a", "list"]])
+def test_a_non_object_data_section_is_a_validation_error(data):
+    result = BackupService.validate_backup(
+        {"metadata": {"version": "1.0"}, "checksum": "x", "data": data}
+    )
+    assert result.valid is False
+    assert "data" in _fields(result)
+
+
+@pytest.mark.parametrize("payload", ["a string", 42, ["a", "list"], None])
+def test_a_non_object_payload_is_a_validation_error(payload):
+    result = BackupService.validate_backup(payload)
+    assert result.valid is False
+    assert "payload" in _fields(result)
+
+
+def test_a_non_string_checksum_does_not_crash_the_comparison():
+    owner = _user()
+    payload = _payload(owner)
+    payload["checksum"] = 12345
+
+    result = BackupService.validate_backup(payload)
+    assert result.valid is False
+    assert "checksum" in _fields(result)
+
+
+def test_preview_survives_a_data_section_full_of_wrong_types():
+    payload = {
+        "metadata": {"backup_id": "b", "username": "u"},
+        "data": {"projects": None, "skills": None, "profile": None},
+    }
+    preview = BackupService.preview_restore(payload)
+    assert preview["records"]["projects"] == 0
+    assert preview["records"]["profile_fields"] == 0
+
+
+# --------------------------------------------------------------------------
+# Restored profile fields go through the ordinary validator
+# --------------------------------------------------------------------------
+
+
+def _restore_profile(profile: dict):
+    user = _user()
+    db = MagicMock()
+    updated = BackupService._restore_profile(db, user, profile)
+    return user, updated
+
+
+def test_a_valid_profile_field_is_applied():
+    user, updated = _restore_profile({"headline": "Staff Engineer"})
+    assert user.headline == "Staff Engineer"
+    assert updated == 1
+
+
+def test_a_javascript_url_never_reaches_the_column():
+    """
+    `website` was `setattr`-ed straight onto the ORM from the file.
+    """
+    user, _ = _restore_profile({"website": "javascript:alert(1)"})
+    assert user.website is None
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "javascript:alert(1)",
+        "data:text/html;base64,PHNjcmlwdD4=",
+        "not a url at all",
+    ],
+)
+def test_hostile_url_values_are_skipped(value):
+    user, _ = _restore_profile({"github_url": value})
+    assert user.github_url is None
+
+
+def test_a_malformed_email_is_skipped():
+    user, _ = _restore_profile({"public_email": "not-an-email"})
+    assert user.public_email is None
+
+
+def test_one_bad_field_does_not_discard_the_good_ones():
+    """
+    A restore is the thing someone reaches for after losing data. Failing the
+    whole operation over one bad value would be the wrong trade.
+    """
+    user, updated = _restore_profile(
+        {"headline": "Staff Engineer", "website": "javascript:alert(1)"}
+    )
+    assert user.headline == "Staff Engineer"
+    assert user.website is None
+    assert updated == 1
+
+
+def test_a_non_object_profile_section_restores_nothing():
+    user = _user()
+    assert BackupService._restore_profile(MagicMock(), user, "not a dict") == 0
+
+
+def test_fields_outside_the_allow_list_are_ignored():
+    user = _user()
+    user.role = "user"
+    BackupService._restore_profile(
+        MagicMock(), user, {"role": "admin", "is_verified": True}
+    )
+    assert user.role == "user"
+
+
+def test_unchanged_values_are_not_counted_as_updates():
+    user = _user()
+    user.headline = "Staff Engineer"
+    updated = BackupService._restore_profile(
+        MagicMock(), user, {"headline": "Staff Engineer"}
+    )
+    assert updated == 0
+
+
+# --------------------------------------------------------------------------
+# Signing key
+# --------------------------------------------------------------------------
+
+
+def test_signatures_do_not_verify_across_keys(monkeypatch):
+    owner = _user()
+    monkeypatch.setattr(
+        "app.services.backup_service.settings.BACKUP_SIGNING_SECRET",
+        "first-key-first-key-first-key-01",
+    )
+    payload = _payload(owner)
+
+    monkeypatch.setattr(
+        "app.services.backup_service.settings.BACKUP_SIGNING_SECRET",
+        "second-key-second-key-second-k02",
+    )
+    result = BackupService.validate_backup(payload)
+
+    assert result.valid is False
+    assert "signature" in _fields(result)
+
+
+def test_an_empty_signing_secret_falls_back_to_the_app_secret(monkeypatch):
+    """
+    So this needs no new mandatory configuration to be safe by default.
+    """
+    monkeypatch.setattr(
+        "app.services.backup_service.settings.BACKUP_SIGNING_SECRET", ""
+    )
+    owner = _user()
+    assert BackupService.validate_backup(_payload(owner)).valid is True

--- a/backend/tests/test_backup_restore.py
+++ b/backend/tests/test_backup_restore.py
@@ -24,7 +24,7 @@ from app.schemas.backup import (
     BackupCreateResponse,
     RestoreResponse,
 )
-from app.services.backup_service import BackupService, _sha256
+from app.services.backup_service import BackupService, _canonical_json, _sha256, _sign
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -201,25 +201,39 @@ class TestCreateBackup:
 # ---------------------------------------------------------------------------
 
 
-def _build_valid_payload(user: MagicMock | None = None) -> dict:
-    """Return a structurally valid backup payload dict."""
+def _build_valid_payload(user: MagicMock | None = None, data: dict | None = None) -> dict:
+    """
+    Return a structurally valid, correctly signed backup payload.
+
+    `metadata.user_id` is the given user's, because restore now checks it: a
+    backup is restorable into the account it was exported from and no other.
+    """
     if user is None:
         user = _make_user()
-    data = {"profile": {"username": user.username}, "projects": [], "skills": []}
-    data_json = json.dumps(data, sort_keys=True, default=str)
-    checksum = _sha256(data_json)
+    if data is None:
+        data = {"profile": {"username": user.username}, "projects": [], "skills": []}
+    data_json = _canonical_json(data)
     return {
         "metadata": {
             "version": "1.0",
             "backup_id": str(uuid.uuid4()),
             "created_at": datetime.now(timezone.utc).isoformat(),
             "app_name": "DevLink",
-            "user_id": str(uuid.uuid4()),
-            "username": "testuser",
+            "user_id": str(user.id),
+            "username": user.username,
         },
-        "checksum": checksum,
+        "checksum": _sha256(data_json),
+        "signature": _sign(data_json),
         "data": data,
     }
+
+
+def _reseal(payload: dict) -> dict:
+    """Recompute checksum and signature after editing a payload's data."""
+    data_json = _canonical_json(payload["data"])
+    payload["checksum"] = _sha256(data_json)
+    payload["signature"] = _sign(data_json)
+    return payload
 
 
 class TestValidateBackup:
@@ -269,6 +283,7 @@ class TestValidateBackup:
         data_json = json.dumps(payload["data"], sort_keys=True, default=str)
         # codeql[py/weak-sensitive-data-hashing] These are high entropy tokens, not passwords
         payload["checksum"] = _sha256(data_json)
+        payload["signature"] = _sign(data_json)
         result = BackupService.validate_backup(payload)
         assert result.valid is False
         fields = [e.field for e in result.errors]
@@ -327,6 +342,7 @@ class TestRestoreBackup:
         data_json = json.dumps(payload["data"], sort_keys=True, default=str)
         # codeql[py/weak-sensitive-data-hashing] These are high entropy tokens, not passwords
         payload["checksum"] = _sha256(data_json)
+        payload["signature"] = _sign(data_json)
 
         result = BackupService.restore_backup(db, user, payload)
         assert result.success is True
@@ -345,6 +361,7 @@ class TestRestoreBackup:
         data_json = json.dumps(payload["data"], sort_keys=True, default=str)
         # codeql[py/weak-sensitive-data-hashing] These are high entropy tokens, not passwords
         payload["checksum"] = _sha256(data_json)
+        payload["signature"] = _sign(data_json)
 
         result = BackupService.restore_backup(db, user, payload)
         assert result.restored["bookmarks"] == 0
@@ -360,6 +377,7 @@ class TestRestoreBackup:
         data_json = json.dumps(payload["data"], sort_keys=True, default=str)
         # codeql[py/weak-sensitive-data-hashing] These are high entropy tokens, not passwords
         payload["checksum"] = _sha256(data_json)
+        payload["signature"] = _sign(data_json)
 
         result = BackupService.restore_backup(db, user, payload)
         assert result.restored["skills"] == 0

--- a/docs/backup_restore.md
+++ b/docs/backup_restore.md
@@ -1,7 +1,7 @@
 # DevLink Backup & Restore — User Data (#635)
 
-DevLink lets users create a **portable, tamper-proof backup** of all their DevLink
-data and restore it to any account.
+DevLink lets users create a **portable, signed backup** of all their DevLink data
+and restore it to the account it came from.
 
 ---
 
@@ -10,8 +10,10 @@ data and restore it to any account.
 | Feature | Details |
 |---|---|
 | **Backup format** | Signed JSON wrapped in a ZIP archive |
-| **Integrity** | SHA-256 checksum embedded in every backup |
-| **Restore strategy** | Non-destructive merge — existing records are never deleted |
+| **Integrity** | SHA-256 checksum — catches corruption |
+| **Provenance** | HMAC-SHA256 signature, keyed server-side — catches tampering |
+| **Restore strategy** | Bookmarks and skills are merged; profile fields are overwritten |
+| **Scope** | A backup restores only into the account it was exported from |
 | **Sensitive data** | Passwords, MFA secrets, tokens are **never** included |
 
 ---
@@ -123,6 +125,7 @@ The extracted JSON has three top-level sections:
     "username": "alice"
   },
   "checksum": "<sha256 of data section>",
+  "signature": "<hmac-sha256 of data section>",
   "data": {
     "profile": { ... },
     "skills": [ ... ],
@@ -140,7 +143,11 @@ The extracted JSON has three top-level sections:
 ```
 
 > [!IMPORTANT]
-> The `checksum` is a SHA-256 digest of the `data` section serialised as JSON (keys sorted, no whitespace). Any modification to the `data` section will invalidate the backup and it will be rejected on restore.
+> `checksum` and `signature` cover the same bytes — the `data` section serialised as JSON with keys sorted — and answer different questions.
+>
+> The **checksum** is an unkeyed SHA-256. It detects corruption: a truncated download, a mangled copy-paste. It cannot detect tampering, because it is a public function of the data and anyone editing the file can recompute it.
+>
+> The **signature** is an HMAC-SHA256 keyed with a server-side secret. It is what makes "this file came from this DevLink instance" a checkable claim, and it is what `restore` requires. Backups exported before signing was added have no `signature`; `preview` will still describe them, but they cannot be restored. Export a fresh one.
 
 ---
 
@@ -164,11 +171,11 @@ The extracted JSON has three top-level sections:
 
 ## What Gets Restored
 
-The restore operation is a **non-destructive merge**:
+Bookmarks and skills are **merged** — nothing is deleted. Profile fields are **overwritten** from the file where present, which is the one part of a restore that replaces what is already there:
 
 | Section | Restore behaviour |
 |---|---|
-| **Profile fields** | Mutable fields (bio, headline, location, etc.) are updated if the backup value differs |
+| **Profile fields** | Mutable fields (bio, headline, location, etc.) **replace** the current value where the backup value differs. Each one is validated with the same model `PATCH /users/me` uses; a value that fails is skipped and logged rather than failing the whole restore |
 | **Bookmarks** | Re-created for projects that still exist in DevLink |
 | **Skills** | User-skill associations re-created for skills that still exist |
 | Messages | **Not restored** — privacy/conversation ownership |
@@ -181,9 +188,18 @@ The restore operation is a **non-destructive merge**:
 ## Security Considerations
 
 - Backup files **never** contain passwords, MFA secrets, refresh tokens, or API keys.
-- The SHA-256 checksum prevents silent data tampering.
+- The SHA-256 checksum detects corruption. It does **not** detect tampering — see the note on the payload format above.
+- The HMAC signature detects tampering, and is required by `restore`.
 - Only the **authenticated user** can create or restore their own backup.
-- Restore is scoped to the **currently authenticated user** — you cannot restore a backup into another user's account.
+- `metadata.user_id` is checked against the caller: restoring another account's backup file is a `403`, even if the file is perfectly valid.
+- Uploads are capped at `MAX_BACKUP_UPLOAD_MB` (25 MB by default).
+
+### Configuration
+
+| Setting | Default | Purpose |
+|---|---|---|
+| `BACKUP_SIGNING_SECRET` | *(empty — falls back to `SECRET_KEY`)* | Key for the backup HMAC. Set separately to rotate backup signatures without invalidating every session. Rotating it invalidates existing backups. |
+| `MAX_BACKUP_UPLOAD_MB` | `25` | Ceiling on an uploaded backup file. |
 
 ---
 


### PR DESCRIPTION
Closes #1400.

`backup_service.py` opened with a Security section that said:

> The checksum prevents tampering: if the data section is modified after export, the restore endpoint rejects the file.

It is an unkeyed SHA-256 over `json.dumps(data, sort_keys=True, default=str)`, computed the same way by the writer and the checker. Editing the file and recomputing it is three lines using the same standard-library call. That is a corruption check being documented and relied on as a tamper check — and restore was leaning on it while writing profile fields straight onto the ORM.

The first test in the new suite is the one that used to pass and should not have:

```python
def test_recomputing_the_checksum_no_longer_gets_a_file_accepted():
    payload["data"]["profile"] = {"headline": "injected"}
    _reseal_checksum_only(payload)          # exactly what an attacker does
    assert BackupService.validate_backup(payload).valid is False
```

## Two mechanisms, two questions

| Field | Keyed? | Answers |
|---|---|---|
| `checksum` | no | Did this file arrive intact? |
| `signature` | yes, HMAC-SHA256 | Did *we* write this file? |

The checksum stays and keeps its real job — a truncated download, a mangled copy-paste. The signature is new and is what `restore` requires.

`BACKUP_SIGNING_SECRET` falls back to `SECRET_KEY`, which the application already requires, so this adds no mandatory configuration; setting it separately allows rotating backup signatures without invalidating every session.

Backups exported before this have no signature. `preview` still describes them and reports `signed: false`; `restore` refuses them with a message that says to export a fresh one.

## Restore no longer trusts the file with the ORM

```diff
-for field in RESTORABLE_FIELDS:
-    if field in profile and profile[field] is not None:
-        setattr(user, field, profile[field])
+validated = cls._validate_profile_fields(candidate)   # via UserUpdate
+for field, new_val in validated.items():
+    setattr(user, field, new_val)
```

`RESTORABLE_FIELDS` includes `website`, `portfolio_url`, `github_url`, `linkedin_url`, `public_email` and `experience_level`. None of the validation the ordinary profile path runs was applied — a `javascript:` URL, a string longer than its column, an `experience_level` outside the enum all landed unexamined. They go through `UserUpdate` now, the same model `PATCH /users/me` validates against.

A field that fails is skipped and logged rather than failing the whole restore. A restore is what someone reaches for after losing data; one bad value should not cost them their bookmarks and skills. There is a test for exactly that trade.

## A backup belongs to an account

`metadata.user_id` was written on export and never read on import, so any account's export applied cleanly to any other. It is compared against the caller now.

Two cases, deliberately separated:

- **Well-formed, someone else's** → `403`, raised as `BackupOwnershipError`.
- **Does not record an owner at all** → `400`. That is a broken file, not someone else's.

## Malformed input stops being a 500

```python
version = payload["metadata"].get("version")
```

The presence check above only tested `"metadata" in payload`. `{"metadata": "x", ...}` reached `.get` on a `str` and raised `AttributeError` — a 500 from all three endpoints. Types are checked before they are used, and `preview_restore` survives a data section full of wrong types.

The three upload endpoints did a bare `await file.read()` with no ceiling. Capped at `MAX_BACKUP_UPLOAD_MB` (25 by default) by reading one byte past the limit and refusing if it arrives.

## Docs

`docs/backup_restore.md` said "tamper-proof" and "non-destructive merge". Bookmarks and skills really are additive; profile fields are overwritten. Both now say what the code does, and the payload-format note explains why there are two integrity fields rather than one.

## Tests

```
$ python -m pytest tests/test_backup_integrity.py tests/test_backup_restore.py -q
57 passed
```

`tests/test_backup_integrity.py` is new (36 tests). The existing `test_backup_restore.py` needed its fixture builder to sign payloads and to set `metadata.user_id` to the user's; those changes are visible in the diff and no assertion was weakened.
