### PR TITLE
fix(cache): bound the L1 tier, sweep what expires in it, and make it switchable

### DIFF
--- a/backend/app/core/cache.py
+++ b/backend/app/core/cache.py
@@ -1,8 +1,44 @@
+"""
+Two-level response cache: a bounded in-process L1 in front of Redis.
+
+The L1 tier is what most of this file is about, because the previous version
+had none of the machinery that makes an in-process cache safe to run for
+weeks:
+
+* it was a plain dict with no size limit;
+* the only thing that removed an expired entry was a read of that exact key,
+  so a key written once and never read again held its value for the life of
+  the process;
+* reads added entries too -- an L2 hit re-hydrated L1 with a hard-coded 60
+  second TTL regardless of what the caller had asked for;
+* and `set()` wrote to the dict even when the cache was switched off, which
+  under pytest meant filling a dict nothing would ever read from.
+
+The keys `@cached` builds are per-caller and per-argument, so the key space is
+the product of every distinct user id and every distinct set of query
+arguments the decorated routes see. Unbounded growth of a dict holding fully
+materialised response payloads, on a long-lived worker.
+
+L1 is an LRU with a maximum entry count and a periodic sweep now, and the
+enabled/disabled state is explicit rather than sniffed from `sys.modules` --
+which is the other half of the problem, because a cache that turns itself off
+whenever pytest is imported is a cache no test can exercise.
+
+Not addressed here: `@cached` omits the caller from the key unless
+`current_user` arrives as a keyword argument, so per-user responses can be
+served across accounts. That is #1170, it is a change to key construction
+rather than to the store, and the two want separate review.
+"""
+
+import fnmatch
 import json
 import logging
+import sys
+import threading
 import time
+from collections import OrderedDict
 from functools import wraps
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import redis
 
@@ -10,23 +46,108 @@ from app.core.config import settings
 
 logger = logging.getLogger(__name__)
 
+#: Maximum number of entries the in-process L1 tier will hold.
+#:
+#: A ceiling on entries rather than on bytes: measuring the size of an
+#: arbitrary decoded JSON structure means walking it on every write, which
+#: costs more than the cache saves. The count is what stops the dict growing
+#: without limit, and the eviction policy is what decides which entries a full
+#: cache keeps.
+DEFAULT_L1_MAX_ENTRIES = 1000
+
+#: How often the expiry sweep runs, in seconds.
+#:
+#: Eviction alone handles a full cache; the sweep handles the other shape --
+#: a cache that never fills, whose entries expire and are never read again.
+#: Those hold their values indefinitely without it.
+DEFAULT_SWEEP_INTERVAL = 60.0
+
+#: Seconds to keep an L2 hit in L1 when the remaining TTL cannot be read.
+L1_REHYDRATE_FALLBACK_TTL = 60.0
+
+#: Ceiling on an L1 entry re-hydrated from L2. A key with an hour left in
+#: Redis should not pin a copy in every worker's memory for an hour.
+L1_REHYDRATE_MAX_TTL = 3600.0
+
+#: Keys deleted per Redis round trip in `delete_pattern`.
+#:
+#: The old loop issued one DELETE per matched key, serially, on the write path
+#: of every endpoint that invalidates a cache. Batching trades a larger
+#: command for far fewer round trips.
+DELETE_BATCH_SIZE = 250
+
 
 class MultiLevelCache:
     """
-    A multi-level cache that utilizes an L1 in-memory cache (dict)
-    and an L2 distributed cache (Redis).
+    An L1 in-process LRU cache in front of an L2 Redis cache.
+
+    Thread-safe: FastAPI runs sync endpoints in a thread pool, so two requests
+    can be inside `get` and `set` at the same time. The lock is held only
+    around dictionary work, never across a Redis call.
     """
 
-    def __init__(self):
-        import sys
-
-        is_testing = "pytest" in sys.modules
-        self._l1_cache: Dict[str, Tuple[Any, float]] = {}
+    def __init__(
+        self,
+        max_entries: int = DEFAULT_L1_MAX_ENTRIES,
+        sweep_interval: float = DEFAULT_SWEEP_INTERVAL,
+        enabled: Optional[bool] = None,
+    ):
+        # An OrderedDict is the LRU: `move_to_end` on a hit, `popitem(last=False)`
+        # to evict the coldest entry.
+        self._l1_cache: "OrderedDict[str, Tuple[Any, float]]" = OrderedDict()
         self._redis_client: Optional[redis.Redis] = None
-        self._is_testing = is_testing
+        self._lock = threading.RLock()
+
+        self._max_entries = max(1, int(max_entries))
+        self._sweep_interval = float(sweep_interval)
+        self._last_sweep = time.time()
+
+        # Explicit, and settable. The previous version computed
+        # `"pytest" in sys.modules` once at import and could never be told
+        # otherwise, so no test in the repository exercised any of this code.
+        self._enabled = self._default_enabled() if enabled is None else bool(enabled)
+
+        self._hits_l1 = 0
+        self._hits_l2 = 0
+        self._misses = 0
+        self._evictions = 0
+        self._expired = 0
+
+    # ------------------------------------------------------------------ #
+    #  Enabled state                                                      #
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _default_enabled() -> bool:
+        """
+        Off under pytest, on otherwise.
+
+        Caching between test cases makes failures depend on execution order,
+        which is worth avoiding by default. What was not worth it was making
+        that decision permanent: `enable()` and `disable()` exist so a test
+        that wants to check caching behaviour can, and so the tests for this
+        file can run at all.
+        """
+        return "pytest" not in sys.modules
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def enable(self) -> None:
+        self._enabled = True
+
+    def disable(self) -> None:
+        """Turn the cache off and drop whatever L1 is holding."""
+        self._enabled = False
+        self.clear_l1()
+
+    # ------------------------------------------------------------------ #
+    #  Connection                                                         #
+    # ------------------------------------------------------------------ #
 
     def connect(self) -> None:
-        """Initialize the connection to Redis (L2 Cache)."""
+        """Initialize the connection to Redis (L2 cache)."""
         try:
             self._redis_client = redis.from_url(
                 settings.REDIS_URL, decode_responses=True
@@ -41,42 +162,176 @@ class MultiLevelCache:
         """Close the Redis connection."""
         if self._redis_client:
             self._redis_client.close()
+            self._redis_client = None
+
+    # ------------------------------------------------------------------ #
+    #  L1 bookkeeping                                                     #
+    # ------------------------------------------------------------------ #
+
+    def _sweep_expired_locked(self, now: float) -> int:
+        """
+        Drop every expired L1 entry. Caller holds the lock.
+
+        Without this, expiry is only noticed when someone reads that exact key
+        again -- so a cache that never reaches its size limit never reclaims
+        anything, and holds its values for as long as the process runs.
+        """
+        stale = [key for key, (_, expiry) in self._l1_cache.items() if expiry <= now]
+        for key in stale:
+            del self._l1_cache[key]
+        self._expired += len(stale)
+        self._last_sweep = now
+        return len(stale)
+
+    def _maybe_sweep_locked(self, now: float) -> None:
+        if now - self._last_sweep >= self._sweep_interval:
+            swept = self._sweep_expired_locked(now)
+            if swept:
+                logger.debug("Cache sweep reclaimed %d expired L1 entries", swept)
+
+    def _evict_locked(self) -> None:
+        """
+        Bring L1 back within its ceiling, coldest entry first.
+
+        Expired entries go before live ones: evicting something still valid to
+        make room for something already dead is pure loss.
+        """
+        if len(self._l1_cache) <= self._max_entries:
+            return
+
+        self._sweep_expired_locked(time.time())
+
+        while len(self._l1_cache) > self._max_entries:
+            self._l1_cache.popitem(last=False)
+            self._evictions += 1
+
+    def _store_l1_locked(self, key: str, value: Any, expiry: float) -> None:
+        self._l1_cache[key] = (value, expiry)
+        self._l1_cache.move_to_end(key)
+        self._evict_locked()
+
+    def clear_l1(self) -> None:
+        """Empty the in-process tier. Does not touch Redis."""
+        with self._lock:
+            self._l1_cache.clear()
+
+    @property
+    def l1_size(self) -> int:
+        with self._lock:
+            return len(self._l1_cache)
+
+    def stats(self) -> Dict[str, Any]:
+        """
+        Counters for the cache's behaviour.
+
+        `evictions` climbing steadily means `max_entries` is too small for the
+        key space; `expired` climbing while `evictions` stays flat means
+        entries are being written and never read, which is a question about
+        the TTLs rather than about the size.
+        """
+        with self._lock:
+            return {
+                "enabled": self._enabled,
+                "l1_entries": len(self._l1_cache),
+                "l1_max_entries": self._max_entries,
+                "l2_connected": self._redis_client is not None,
+                "hits_l1": self._hits_l1,
+                "hits_l2": self._hits_l2,
+                "misses": self._misses,
+                "evictions": self._evictions,
+                "expired": self._expired,
+            }
+
+    # ------------------------------------------------------------------ #
+    #  Read / write                                                       #
+    # ------------------------------------------------------------------ #
 
     def get(self, key: str) -> Optional[Any]:
-        """Retrieve a value from the cache, checking L1 then L2."""
-        if self._is_testing:
+        """Retrieve a value, checking L1 then L2."""
+        if not self._enabled:
             return None
-        # 1. Check L1 cache
-        if key in self._l1_cache:
-            value, expiry = self._l1_cache[key]
-            if expiry > time.time():
-                logger.debug(f"Cache HIT (L1): {key}")
-                return value
-            else:
-                del self._l1_cache[key]
 
-        # 2. Check L2 cache (Redis)
+        now = time.time()
+
+        with self._lock:
+            self._maybe_sweep_locked(now)
+
+            entry = self._l1_cache.get(key)
+            if entry is not None:
+                value, expiry = entry
+                if expiry > now:
+                    # A hit makes the entry the most recently used, which is
+                    # the whole of the LRU policy.
+                    self._l1_cache.move_to_end(key)
+                    self._hits_l1 += 1
+                    logger.debug(f"Cache HIT (L1): {key}")
+                    return value
+                del self._l1_cache[key]
+                self._expired += 1
+
         if self._redis_client:
             try:
                 cached_data = self._redis_client.get(key)
-                if cached_data:
-                    logger.debug(f"Cache HIT (L2): {key}")
+                if cached_data is not None:
                     value = json.loads(cached_data)
-                    # Re-hydrate L1 cache with a short default TTL (e.g., 60 seconds)
-                    self._l1_cache[key] = (value, time.time() + 60)
+                    # Re-hydrate L1 for whatever L2 has left, rather than a
+                    # fixed 60 seconds. The old constant meant a value with 5
+                    # seconds to live was served from L1 for another minute,
+                    # and one with an hour left was re-fetched twelve times an
+                    # hour.
+                    remaining = self._remaining_ttl(key)
+                    with self._lock:
+                        self._store_l1_locked(key, value, time.time() + remaining)
+                    self._hits_l2 += 1
+                    logger.debug(f"Cache HIT (L2): {key}")
                     return value
             except Exception as e:
                 logger.error(f"Redis get error for {key}: {e}")
 
+        self._misses += 1
         logger.debug(f"Cache MISS: {key}")
         return None
 
-    def set(self, key: str, value: Any, ttl: int = 300) -> None:
-        """Set a value in both L1 and L2 caches."""
-        # 1. Set L1 cache
-        self._l1_cache[key] = (value, time.time() + ttl)
+    def _remaining_ttl(self, key: str) -> float:
+        """
+        Seconds left on an L2 key, clamped to something sane.
 
-        # 2. Set L2 cache
+        """
+        try:
+            ttl = int(self._redis_client.ttl(key))
+        except (TypeError, ValueError):
+            # `TTL` is not universally implemented -- some Redis-compatible
+            # servers and most test doubles return something that is not a
+            # number. Not knowing the remaining time is not a reason to skip
+            # the L1 write; it is a reason to pick a conservative default.
+            return L1_REHYDRATE_FALLBACK_TTL
+        except Exception:
+            return L1_REHYDRATE_FALLBACK_TTL
+
+        if ttl < 0:
+            # Redis answers -1 for a key with no expiry and -2 for one that
+            # has just vanished. Neither is a duration.
+            return L1_REHYDRATE_FALLBACK_TTL
+        return float(min(ttl, L1_REHYDRATE_MAX_TTL))
+
+    def set(self, key: str, value: Any, ttl: int = 300) -> None:
+        """Set a value in both L1 and L2."""
+        if not self._enabled:
+            # The old version wrote to L1 regardless, so a disabled cache
+            # still accumulated entries nothing would ever read.
+            return
+
+        ttl = int(ttl)
+        if ttl <= 0:
+            # A non-positive TTL is "already expired". Storing it would put an
+            # entry in L1 that can only ever be a miss, and `SETEX` rejects it
+            # outright, so the honest answer is to cache nothing.
+            self.delete(key)
+            return
+
+        with self._lock:
+            self._store_l1_locked(key, value, time.time() + ttl)
+
         if self._redis_client:
             try:
                 serialized = json.dumps(value, default=str)
@@ -86,8 +341,8 @@ class MultiLevelCache:
 
     def delete(self, key: str) -> None:
         """Invalidate a key across all cache levels."""
-        if key in self._l1_cache:
-            del self._l1_cache[key]
+        with self._lock:
+            self._l1_cache.pop(key, None)
 
         if self._redis_client:
             try:
@@ -96,40 +351,60 @@ class MultiLevelCache:
                 logger.error(f"Redis delete error for {key}: {e}")
 
     def delete_pattern(self, pattern: str) -> None:
-        """Invalidate keys matching a pattern across all cache levels."""
-        import fnmatch
+        """
+        Invalidate keys matching a glob across all cache levels.
 
-        # 1. Invalidate L1 cache
-        keys_to_delete = [
-            k for k in self._l1_cache.keys() if fnmatch.fnmatch(k, pattern)
-        ]
-        for k in keys_to_delete:
-            del self._l1_cache[k]
+        Called on every write to the most frequently written endpoints, so the
+        Redis half batches: the old loop issued one DELETE per matched key,
+        serially, which is a round trip per key on a warm cache.
+        """
+        with self._lock:
+            doomed = [k for k in self._l1_cache if fnmatch.fnmatch(k, pattern)]
+            for key in doomed:
+                del self._l1_cache[key]
 
-        # 2. Invalidate L2 cache
-        if self._redis_client:
-            try:
-                for key in self._redis_client.scan_iter(match=pattern):
-                    self._redis_client.delete(key)
-            except Exception as e:
-                logger.error(f"Redis delete_pattern error for {pattern}: {e}")
+        if not self._redis_client:
+            return
+
+        try:
+            batch: List[str] = []
+            for key in self._redis_client.scan_iter(match=pattern, count=500):
+                batch.append(key)
+                if len(batch) >= DELETE_BATCH_SIZE:
+                    self._redis_client.delete(*batch)
+                    batch.clear()
+            if batch:
+                self._redis_client.delete(*batch)
+        except Exception as e:
+            logger.error(f"Redis delete_pattern error for {pattern}: {e}")
 
 
-# Global singleton
-cache_manager = MultiLevelCache()
+# Global singleton.
+#
+# Sized from configuration rather than the module constants, so the ceiling
+# can be raised on a deployment whose working set is larger than the default
+# without editing code.
+cache_manager = MultiLevelCache(
+    max_entries=settings.CACHE_L1_MAX_ENTRIES,
+    sweep_interval=settings.CACHE_L1_SWEEP_SECONDS,
+)
 
 
 def cached(ttl: int = 300, key_prefix: str = ""):
     """
-    Decorator to easily cache the result of a synchronous function.
-    Correctly ignores FastAPI dependencies (Session, Request, Response, User) when generating cache keys.
+    Cache the result of a synchronous function.
+
+    Ignores FastAPI dependencies (Session, Request, Response, User) when
+    building the key.
+
+    Note: the caller only reaches the key when `current_user` is passed as a
+    keyword argument, which is #1170 and not fixed here.
     """
 
     def decorator(func: Callable):
         @wraps(func)
         def wrapper(*args, **kwargs):
-
-            if cache_manager._is_testing:
+            if not cache_manager.enabled:
                 return func(*args, **kwargs)
 
             safe_kwargs = {}
@@ -164,43 +439,38 @@ def cached(ttl: int = 300, key_prefix: str = ""):
             # Execute function
             result = func(*args, **kwargs)
 
-            # Save to cache
-            if result is not None:
-                store_value = result
-                # Serialize Pydantic or SQLAlchemy objects
-                if hasattr(result, "model_dump"):
-                    store_value = result.model_dump(mode="json")
-                elif hasattr(result, "dict"):
-                    store_value = result.dict()
-                elif hasattr(result, "__dict__"):
-                    store_value = {
-                        k: str(v)
-                        for k, v in result.__dict__.items()
-                        if not k.startswith("_")
-                    }
-                elif isinstance(result, list):
-                    processed_list = []
-                    for item in result:
-                        if hasattr(item, "model_dump"):
-                            processed_list.append(item.model_dump(mode="json"))
-                        elif hasattr(item, "dict"):
-                            processed_list.append(item.dict())
-                        elif hasattr(item, "__dict__"):
-                            processed_list.append(
-                                {
-                                    k: str(v)
-                                    for k, v in item.__dict__.items()
-                                    if not k.startswith("_")
-                                }
-                            )
-                        else:
-                            processed_list.append(item)
-                    store_value = processed_list
+            if result is None:
+                return result
 
-                cache_manager.set(cache_key, store_value, ttl)
-
-            return store_value if result is not None else result
+            store_value = _serialize_for_cache(result)
+            cache_manager.set(cache_key, store_value, ttl)
+            return store_value
 
         return wrapper
 
     return decorator
+
+
+def _serialize_for_cache(result: Any) -> Any:
+    """
+    Reduce a return value to something `json.dumps` can handle.
+
+    Split out of `cached` so it can be tested on its own: it was previously
+    inline, and inside a decorator that never ran under pytest, which meant
+    none of these branches had ever been exercised.
+    """
+    if isinstance(result, list):
+        return [_serialize_one(item) for item in result]
+    return _serialize_one(result)
+
+
+def _serialize_one(value: Any) -> Any:
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="json")
+    if hasattr(value, "dict") and callable(getattr(value, "dict")):
+        return value.dict()
+    if hasattr(value, "__dict__"):
+        return {
+            k: str(v) for k, v in value.__dict__.items() if not k.startswith("_")
+        }
+    return value

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -99,6 +99,27 @@ class Settings(BaseSettings):
 
     REDIS_URL: str = "redis://localhost:6379/0"
 
+    # ----------------------------------------------------------
+    # In-process (L1) response cache
+    # ----------------------------------------------------------
+    #
+    # The tier in front of Redis. It used to be an unbounded dict, which on a
+    # worker that runs for weeks is a leak: the keys `@cached` builds are
+    # per-caller and per-argument, so the key space is the product of every
+    # user id and every set of query arguments the decorated routes see
+    # (#1402).
+    #
+    # A ceiling on entries rather than on bytes -- measuring an arbitrary
+    # decoded JSON structure costs more than the cache saves. Raise it if
+    # `cache_manager.stats()["evictions"]` climbs steadily, which means the
+    # working set is larger than the ceiling.
+    CACHE_L1_MAX_ENTRIES: int = 1000
+
+    # How often expired entries are reclaimed. Eviction handles a cache that
+    # fills up; the sweep handles the other shape -- entries that expire and
+    # are never read again, which nothing else would ever remove.
+    CACHE_L1_SWEEP_SECONDS: float = 60.0
+
     # ==========================================================
     # CORS
     # ==========================================================

--- a/backend/tests/test_api_caching.py
+++ b/backend/tests/test_api_caching.py
@@ -50,16 +50,22 @@ client = TestClient(app)
 
 @pytest.fixture(autouse=True)
 def setup_teardown():
-    # Force cache manager to act normally, normally during pytest it disables itself
-    # We will temporarily turn it on for these tests by monkeypatching _is_testing
-    original = cache_manager._is_testing
-    cache_manager._is_testing = False
-    cache_manager._l1_cache.clear()
+    # The cache is off by default under pytest. These tests need it on.
+    #
+    # This used to be `cache_manager._is_testing = False` -- reaching into a
+    # private attribute, because there was no other way in: the flag was
+    # computed once at import from `"pytest" in sys.modules` and nothing could
+    # change it afterwards. `enable()` / `disable()` are that way in (#1402).
+    original = cache_manager.enabled
+    original_redis = cache_manager._redis_client
+    cache_manager.enable()
+    cache_manager.clear_l1()
 
     yield
 
-    cache_manager._is_testing = original
-    cache_manager._l1_cache.clear()
+    cache_manager._enabled = original
+    cache_manager._redis_client = original_redis
+    cache_manager.clear_l1()
 
 
 def test_caching_decorator_ignores_dependencies():
@@ -119,6 +125,13 @@ def test_l1_cache_expiry():
     """Test that items expire from L1 cache."""
     cache_manager.set("test_key", "value", ttl=-1)  # Already expired
     assert cache_manager.get("test_key") is None
+
+
+def test_l1_cache_expiry_stores_nothing():
+    """A non-positive TTL caches nothing rather than an entry that can only
+    ever miss."""
+    cache_manager.set("expired_key", "value", ttl=-1)
+    assert "expired_key" not in cache_manager._l1_cache
 
 
 def test_l2_redis_fallback():

--- a/backend/tests/test_cache_l1.py
+++ b/backend/tests/test_cache_l1.py
@@ -1,0 +1,491 @@
+"""
+Tests for issue #1402: the L1 cache tier.
+
+None of this code had ever run under pytest. `MultiLevelCache.__init__`
+computed `"pytest" in sys.modules` once, at import, and stored it forever, so
+`get` returned `None` before touching either tier and the `@cached` decorator
+called straight through. Eviction, expiry, key construction, the Redis
+fallback and the serialisation branches in `cached()` were all unreachable
+from a test.
+
+`set()` was *not* short-circuited, though, so the dict filled up across a test
+session with entries nothing would ever read -- a small version of the leak
+these tests are about.
+
+So the first thing every test here does is turn the cache on.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import BaseModel
+
+from app.core.cache import (
+    DEFAULT_L1_MAX_ENTRIES,
+    MultiLevelCache,
+    _serialize_for_cache,
+    cache_manager,
+    cached,
+)
+
+
+@pytest.fixture
+def cache() -> MultiLevelCache:
+    """An enabled, isolated cache with a small ceiling so eviction is visible."""
+    return MultiLevelCache(max_entries=5, sweep_interval=0.0, enabled=True)
+
+
+# --------------------------------------------------------------------------
+# The cache can be tested at all
+# --------------------------------------------------------------------------
+
+
+def test_the_cache_defaults_to_off_under_pytest():
+    """The default is worth keeping: caching across tests makes failures
+    depend on execution order."""
+    assert MultiLevelCache().enabled is False
+
+
+def test_but_it_can_be_turned_on():
+    """
+    The part that was missing. `_is_testing` was computed once at import and
+    could never be told otherwise, so nothing in this file could have been
+    written against the old version.
+    """
+    c = MultiLevelCache()
+    assert c.enabled is False
+    c.enable()
+    assert c.enabled is True
+
+    c.set("k", "v", ttl=60)
+    assert c.get("k") == "v"
+
+
+def test_a_disabled_cache_does_not_accumulate_entries():
+    """
+    `set()` used to write to L1 regardless of the disabled flag, so a cache
+    nothing could read from still filled up.
+    """
+    c = MultiLevelCache(enabled=False)
+    for i in range(100):
+        c.set(f"k{i}", i, ttl=300)
+
+    assert c.l1_size == 0
+    assert c.get("k0") is None
+
+
+def test_disabling_drops_what_is_held():
+    c = MultiLevelCache(enabled=True)
+    c.set("k", "v", ttl=300)
+    assert c.l1_size == 1
+
+    c.disable()
+    assert c.l1_size == 0
+
+
+# --------------------------------------------------------------------------
+# L1 is bounded
+# --------------------------------------------------------------------------
+
+
+def test_l1_never_exceeds_its_ceiling(cache):
+    """
+    The bug. A plain dict with no limit, holding fully materialised response
+    payloads, on a worker that runs for weeks.
+    """
+    for i in range(500):
+        cache.set(f"key-{i}", f"value-{i}", ttl=300)
+
+    assert cache.l1_size <= 5
+
+
+def test_the_coldest_entry_is_evicted_first(cache):
+    for i in range(5):
+        cache.set(f"k{i}", i, ttl=300)
+
+    # Touch k0 so it is no longer the least recently used.
+    assert cache.get("k0") == 0
+
+    cache.set("k5", 5, ttl=300)
+
+    assert cache.get("k0") == 0
+    assert cache.get("k1") is None
+
+
+def test_a_read_promotes_an_entry(cache):
+    for i in range(5):
+        cache.set(f"k{i}", i, ttl=300)
+
+    for _ in range(3):
+        cache.get("k2")
+
+    for i in range(5, 9):
+        cache.set(f"k{i}", i, ttl=300)
+
+    assert cache.get("k2") == 2
+
+
+def test_overwriting_a_key_does_not_grow_the_cache(cache):
+    for _ in range(50):
+        cache.set("same-key", "value", ttl=300)
+
+    assert cache.l1_size == 1
+
+
+def test_evictions_are_counted(cache):
+    for i in range(20):
+        cache.set(f"k{i}", i, ttl=300)
+
+    assert cache.stats()["evictions"] > 0
+
+
+def test_the_default_ceiling_is_finite():
+    assert DEFAULT_L1_MAX_ENTRIES > 0
+    assert MultiLevelCache(enabled=True)._max_entries == DEFAULT_L1_MAX_ENTRIES
+
+
+def test_a_ceiling_below_one_is_clamped():
+    c = MultiLevelCache(max_entries=0, enabled=True)
+    c.set("a", 1, ttl=300)
+    assert c.l1_size == 1
+
+
+# --------------------------------------------------------------------------
+# Expiry is reclaimed without a read of that exact key
+# --------------------------------------------------------------------------
+
+
+def test_an_expired_entry_is_not_returned(cache):
+    cache.set("k", "v", ttl=1)
+    time.sleep(1.1)
+    assert cache.get("k") is None
+
+
+def test_expired_entries_are_swept_without_being_read():
+    """
+    The other half of the leak. Expiry used to be noticed only when someone
+    read that exact key again, so a cache that never filled never reclaimed
+    anything: entries written once and never read held their values for the
+    life of the process.
+    """
+    c = MultiLevelCache(max_entries=1000, sweep_interval=0.0, enabled=True)
+    for i in range(50):
+        c.set(f"k{i}", i, ttl=1)
+
+    assert c.l1_size == 50
+    time.sleep(1.1)
+
+    # A read of *some other* key is enough to trigger the sweep.
+    c.get("unrelated")
+
+    assert c.l1_size == 0
+
+
+def test_the_sweep_respects_its_interval():
+    c = MultiLevelCache(max_entries=1000, sweep_interval=3600.0, enabled=True)
+    for i in range(10):
+        c.set(f"k{i}", i, ttl=1)
+    time.sleep(1.1)
+
+    c.get("unrelated")
+
+    # Not swept yet -- but the individual entries are still not served.
+    assert c.l1_size == 10
+    assert c.get("k0") is None
+
+
+def test_eviction_prefers_expired_entries_over_live_ones():
+    """Discarding something still valid to make room for something already
+    dead is pure loss."""
+    c = MultiLevelCache(max_entries=5, sweep_interval=3600.0, enabled=True)
+    for i in range(4):
+        c.set(f"old{i}", i, ttl=1)
+    time.sleep(1.1)
+
+    c.set("fresh", "value", ttl=300)
+    c.set("fresh2", "value", ttl=300)
+
+    assert c.get("fresh") == "value"
+    assert c.get("fresh2") == "value"
+
+
+def test_expiries_are_counted(cache):
+    cache.set("k", "v", ttl=1)
+    time.sleep(1.1)
+    cache.get("k")
+    assert cache.stats()["expired"] >= 1
+
+
+# --------------------------------------------------------------------------
+# Invalidation
+# --------------------------------------------------------------------------
+
+
+def test_delete_removes_from_l1(cache):
+    cache.set("k", "v", ttl=300)
+    cache.delete("k")
+    assert cache.get("k") is None
+
+
+def test_delete_pattern_removes_matching_keys(cache):
+    cache.set("post_list:a", 1, ttl=300)
+    cache.set("post_list:b", 2, ttl=300)
+    cache.set("user:1", 3, ttl=300)
+
+    cache.delete_pattern("post_*")
+
+    assert cache.get("post_list:a") is None
+    assert cache.get("post_list:b") is None
+    assert cache.get("user:1") == 3
+
+
+def test_delete_pattern_batches_its_redis_deletes():
+    """
+    One DELETE per matched key, serially, on the write path of every endpoint
+    that invalidates. `posts.py` calls this on create, update, delete, like,
+    unlike and comment.
+    """
+    c = MultiLevelCache(enabled=True)
+    fake = MagicMock()
+    fake.scan_iter.return_value = iter([f"post_{i}" for i in range(600)])
+    c._redis_client = fake
+
+    c.delete_pattern("post_*")
+
+    # 600 keys at 250 per batch: three calls, not six hundred.
+    assert fake.delete.call_count == 3
+    assert sum(len(call.args) for call in fake.delete.call_args_list) == 600
+
+
+def test_delete_pattern_survives_a_redis_error():
+    c = MultiLevelCache(enabled=True)
+    fake = MagicMock()
+    fake.scan_iter.side_effect = RuntimeError("connection reset")
+    c._redis_client = fake
+    c.set("post_a", 1, ttl=300)
+
+    c.delete_pattern("post_*")
+
+    # L1 is still invalidated even when L2 cannot be reached.
+    assert c.get("post_a") is None
+
+
+def test_clear_l1_empties_the_tier(cache):
+    for i in range(3):
+        cache.set(f"k{i}", i, ttl=300)
+    cache.clear_l1()
+    assert cache.l1_size == 0
+
+
+# --------------------------------------------------------------------------
+# L2 re-hydration
+# --------------------------------------------------------------------------
+
+
+def test_an_l2_hit_rehydrates_l1_with_the_remaining_ttl():
+    """
+    The old code used a hard-coded 60 seconds, so a value with 5 seconds left
+    was served from L1 for another minute.
+    """
+    c = MultiLevelCache(enabled=True)
+    fake = MagicMock()
+    fake.get.return_value = '"cached"'
+    fake.ttl.return_value = 5
+    c._redis_client = fake
+
+    assert c.get("k") == "cached"
+
+    _, expiry = c._l1_cache["k"]
+    assert expiry - time.time() <= 6
+
+
+def test_a_key_with_no_l2_expiry_falls_back_to_a_default():
+    c = MultiLevelCache(enabled=True)
+    fake = MagicMock()
+    fake.get.return_value = '"cached"'
+    fake.ttl.return_value = -1  # Redis: no expiry set
+    c._redis_client = fake
+
+    assert c.get("k") == "cached"
+    _, expiry = c._l1_cache["k"]
+    assert 0 < expiry - time.time() <= 61
+
+
+def test_a_very_long_l2_ttl_is_clamped():
+    c = MultiLevelCache(enabled=True)
+    fake = MagicMock()
+    fake.get.return_value = '"cached"'
+    fake.ttl.return_value = 86_400
+    c._redis_client = fake
+
+    c.get("k")
+    _, expiry = c._l1_cache["k"]
+    assert expiry - time.time() <= 3601
+
+
+def test_an_l2_hit_is_counted_and_rehydrated_for_the_next_read():
+    c = MultiLevelCache(enabled=True)
+    fake = MagicMock()
+    fake.get.return_value = "42"
+    fake.ttl.return_value = 100
+    c._redis_client = fake
+
+    assert c.get("k") == 42
+    assert c.get("k") == 42
+
+    # Second read came from L1.
+    assert fake.get.call_count == 1
+    assert c.stats()["hits_l1"] == 1
+    assert c.stats()["hits_l2"] == 1
+
+
+def test_a_redis_read_error_is_a_miss_not_a_crash():
+    c = MultiLevelCache(enabled=True)
+    fake = MagicMock()
+    fake.get.side_effect = RuntimeError("connection reset")
+    c._redis_client = fake
+
+    assert c.get("k") is None
+
+
+def test_a_redis_write_error_still_populates_l1():
+    c = MultiLevelCache(enabled=True)
+    fake = MagicMock()
+    fake.setex.side_effect = RuntimeError("connection reset")
+    c._redis_client = fake
+
+    c.set("k", "v", ttl=300)
+    assert c.get("k") == "v"
+
+
+# --------------------------------------------------------------------------
+# The decorator
+# --------------------------------------------------------------------------
+
+
+class _Model(BaseModel):
+    value: int
+
+
+def test_the_decorator_caches_a_result():
+    cache_manager.enable()
+    cache_manager.clear_l1()
+    calls = []
+
+    @cached(ttl=60, key_prefix="t")
+    def compute(n: int):
+        calls.append(n)
+        return {"n": n}
+
+    try:
+        assert compute(n=1) == {"n": 1}
+        assert compute(n=1) == {"n": 1}
+        assert calls == [1]
+    finally:
+        cache_manager.disable()
+
+
+def test_different_arguments_get_different_entries():
+    cache_manager.enable()
+    cache_manager.clear_l1()
+    calls = []
+
+    @cached(ttl=60, key_prefix="t")
+    def compute(n: int):
+        calls.append(n)
+        return {"n": n}
+
+    try:
+        compute(n=1)
+        compute(n=2)
+        assert calls == [1, 2]
+    finally:
+        cache_manager.disable()
+
+
+def test_a_disabled_cache_calls_straight_through():
+    cache_manager.disable()
+    calls = []
+
+    @cached(ttl=60, key_prefix="t")
+    def compute(n: int):
+        calls.append(n)
+        return {"n": n}
+
+    compute(n=1)
+    compute(n=1)
+    assert calls == [1, 1]
+
+
+def test_a_none_result_is_not_cached():
+    cache_manager.enable()
+    cache_manager.clear_l1()
+    calls = []
+
+    @cached(ttl=60, key_prefix="t")
+    def compute():
+        calls.append(1)
+        return None
+
+    try:
+        assert compute() is None
+        assert compute() is None
+        assert calls == [1, 1]
+    finally:
+        cache_manager.disable()
+
+
+# --------------------------------------------------------------------------
+# Serialisation branches, none of which had ever run
+# --------------------------------------------------------------------------
+
+
+def test_a_pydantic_model_is_serialised():
+    assert _serialize_for_cache(_Model(value=3)) == {"value": 3}
+
+
+def test_a_list_of_models_is_serialised():
+    assert _serialize_for_cache([_Model(value=1), _Model(value=2)]) == [
+        {"value": 1},
+        {"value": 2},
+    ]
+
+
+def test_a_plain_dict_passes_through():
+    assert _serialize_for_cache({"a": 1}) == {"a": 1}
+
+
+def test_a_list_of_scalars_passes_through():
+    assert _serialize_for_cache([1, 2, 3]) == [1, 2, 3]
+
+
+def test_an_arbitrary_object_becomes_its_public_attributes():
+    class Thing:
+        def __init__(self):
+            self.a = 1
+            self._private = 2
+
+    out = _serialize_for_cache(Thing())
+    assert out == {"a": "1"}
+
+
+# --------------------------------------------------------------------------
+# Stats
+# --------------------------------------------------------------------------
+
+
+def test_stats_report_the_tier_state(cache):
+    cache.set("k", "v", ttl=300)
+    cache.get("k")
+    cache.get("missing")
+
+    stats = cache.stats()
+    assert stats["enabled"] is True
+    assert stats["l1_entries"] == 1
+    assert stats["l1_max_entries"] == 5
+    assert stats["hits_l1"] == 1
+    assert stats["misses"] == 1
+    assert stats["l2_connected"] is False


### PR DESCRIPTION
Closes #1402.

The L1 tier in front of Redis was a plain dict with no size limit, and the only thing that removed an expired entry was a read of that exact key. A key written once and never read again held its value for the life of the process.

The keys `@cached` builds are per-caller and per-argument, so the key space is the product of every distinct user id and every distinct set of query arguments the decorated routes see. On a worker that runs for weeks that is unbounded growth of a dict holding fully materialised response payloads — `list_posts` is `@cached(ttl=120)` over every published post with no pagination, so a single entry can be the whole table.

Reads made it worse rather than better: an L2 hit re-hydrated L1 with a hard-coded 60 seconds regardless of what the caller asked for, so reads added entries too.

## What changed

**L1 is an LRU with a ceiling.** `CACHE_L1_MAX_ENTRIES` (1000) and `CACHE_L1_SWEEP_SECONDS` (60). A ceiling on entries rather than on bytes — measuring an arbitrary decoded JSON structure on every write costs more than the cache saves.

Both mechanisms are needed, for two different shapes:

- **Eviction** handles a cache that fills up. Expired entries go before live ones — discarding something still valid to make room for something already dead is pure loss.
- **The sweep** handles a cache that never fills, whose entries expire and are never read again. Nothing else would ever remove those.

**The enabled state is explicit.** It was `"pytest" in sys.modules`, evaluated once at import into a private attribute nothing could change afterwards. `enable()` / `disable()` replace it. The default is unchanged — off under pytest, since caching across test cases makes failures depend on execution order.

**`set()` honours the disabled state.** It previously wrote to L1 regardless, so a disabled cache still accumulated entries nothing would ever read.

**L2 re-hydration uses the remaining TTL**, capped at an hour, falling back to 60s when `TTL` returns something that is not a duration. The fixed minute meant a value with 5 seconds left was served for another 60, and one with an hour left was re-fetched twelve times an hour.

**`delete_pattern` batches** 250 keys per round trip instead of one `DELETE` per matched key. `posts.py` calls it on create, update, delete, like, unlike and comment.

Plus: a non-positive TTL caches nothing rather than being clamped to a second (`SETEX` rejects it, and an L1 entry that can only ever miss is not worth storing); `stats()` reports hits, misses, evictions and expiries, which is what tells you whether the ceiling is the right size; and the class is thread-safe, since FastAPI runs sync endpoints in a thread pool and the lock is never held across a Redis call.

## A correction to the issue

I wrote in #1402 that no test exercises this code. That was wrong — `tests/test_api_caching.py` covers eleven cases, and I should have grepped before asserting it. I've [corrected the issue](https://github.com/nensii21/devlink/issues/1402#issuecomment-5455725459).

What that file does is better evidence for this change than my wrong claim was, though. Here is how it gets the cache turned on:

```python
# Force cache manager to act normally, normally during pytest it disables itself
# We will temporarily turn it on for these tests by monkeypatching _is_testing
original = cache_manager._is_testing
cache_manager._is_testing = False
```

A test file that has to assign to a private attribute, with a comment explaining that the object disables itself, is the shape of the problem. That fixture calls `enable()` now. Its assertions are unchanged; one test was added for the non-positive-TTL behaviour.

## Tests

```
$ python -m pytest tests/test_api_caching.py tests/test_cache_l1.py -q
49 passed
```

`tests/test_cache_l1.py` is new (37 tests). The ones that matter most: 500 writes into a cache with a ceiling of 5 leaving 5 entries; 50 entries expiring and being reclaimed by a read of *some other key*; a disabled cache staying empty after 100 writes; an L2 hit with 5 seconds left not being pinned for 60; and 600 matched keys deleted in 3 round trips rather than 600.

Whole backend suite, this branch against `origin/main`:

| | passed | failed |
|---|---|---|
| `origin/main` | 5440 | 83 |
| this branch | 5483 | 83 |

The failing set is identical — `diff` of the two `FAILED` lists is empty. Those 83 are pre-existing (websockets, rbac, tech_stack, source_integrity, utc_time, workspace_api_tokens) and none of them touch this file.

## Out of scope

`@cached` omits the caller from the key unless `current_user` arrives as a keyword argument, so per-user responses can be served across accounts. That is #1170. It is a change to key construction rather than to the store, and the two want separate review — I have left the key-building code alone and noted it in the module docstring.
