### PR TITLE
fix(hooks): clean up chat websocket lifecycle and add backoff reconnection

### DIFF
--- a/frontend/src/hooks/__tests__/useChatWebSocket.test.tsx
+++ b/frontend/src/hooks/__tests__/useChatWebSocket.test.tsx
@@ -1,0 +1,321 @@
+import { renderHook, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useChatWebSocket, getReconnectDelay } from "../useChatWebSocket";
+
+class FakeWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  static instances: FakeWebSocket[] = [];
+  static throwOnNextConstruct = false;
+
+  readyState = FakeWebSocket.CONNECTING;
+  sent: string[] = [];
+  closeCalls = 0;
+
+  onopen: (() => void) | null = null;
+  onmessage: ((e: { data: string }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(public url: string) {
+    if (FakeWebSocket.throwOnNextConstruct) {
+      FakeWebSocket.throwOnNextConstruct = false;
+      throw new Error("cannot construct");
+    }
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.closeCalls += 1;
+    const wasOpen = this.readyState !== FakeWebSocket.CLOSED;
+    this.readyState = FakeWebSocket.CLOSED;
+    if (wasOpen) this.onclose?.();
+  }
+
+  open() {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  drop() {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.onclose?.();
+  }
+
+  deliver(payload: unknown) {
+    this.onmessage?.({ data: JSON.stringify(payload) });
+  }
+
+  get messages(): Array<Record<string, unknown>> {
+    return this.sent.map((raw) => JSON.parse(raw));
+  }
+
+  static get latest(): FakeWebSocket {
+    return FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
+  }
+
+  static reset() {
+    FakeWebSocket.instances = [];
+    FakeWebSocket.throwOnNextConstruct = false;
+  }
+}
+
+describe("useChatWebSocket", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    FakeWebSocket.reset();
+    vi.stubGlobal("WebSocket", FakeWebSocket);
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    localStorage.clear();
+  });
+
+  it("calculates exponential backoff delays with jitter ceiling", () => {
+    vi.spyOn(Math, "random").mockReturnValue(1);
+    expect(getReconnectDelay(0)).toBe(1000);
+    expect(getReconnectDelay(1)).toBe(2000);
+    expect(getReconnectDelay(2)).toBe(4000);
+    expect(getReconnectDelay(10)).toBe(30000); // capped at 30s
+    vi.restoreAllMocks();
+  });
+
+  it("connects and joins the room on open", () => {
+    const onNewMessage = vi.fn();
+    const { result } = renderHook(() => useChatWebSocket("conv-123", "user-1", onNewMessage));
+
+    expect(FakeWebSocket.instances.length).toBe(1);
+    const socket = FakeWebSocket.latest;
+    expect(socket.url).toContain("/api/v1/ws/collab");
+    expect(result.current.isConnected).toBe(false);
+
+    act(() => {
+      socket.open();
+    });
+
+    expect(result.current.isConnected).toBe(true);
+    expect(socket.messages).toEqual([{ type: "chat.join", conversation_id: "conv-123" }]);
+  });
+
+  it("does not connect if conversationId is empty", () => {
+    const onNewMessage = vi.fn();
+    const { result } = renderHook(() => useChatWebSocket("", "user-1", onNewMessage));
+
+    expect(FakeWebSocket.instances.length).toBe(0);
+    expect(result.current.isConnected).toBe(false);
+  });
+
+  it("delivers new chat messages for the active conversation", () => {
+    const onNewMessage = vi.fn();
+    renderHook(() => useChatWebSocket("conv-123", "user-1", onNewMessage));
+
+    const socket = FakeWebSocket.latest;
+    act(() => {
+      socket.open();
+    });
+
+    const msgEvent = {
+      type: "chat.message.new",
+      conversation_id: "conv-123",
+      content: "Hello world",
+    };
+
+    act(() => {
+      socket.deliver(msgEvent);
+    });
+
+    expect(onNewMessage).toHaveBeenCalledTimes(1);
+    expect(onNewMessage).toHaveBeenCalledWith(msgEvent);
+
+    // Message for different conversation is ignored
+    act(() => {
+      socket.deliver({
+        type: "chat.message.new",
+        conversation_id: "other-conv",
+        content: "Wrong room",
+      });
+    });
+
+    expect(onNewMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("tracks typing users and clears after 3 seconds", () => {
+    const onNewMessage = vi.fn();
+    const { result } = renderHook(() => useChatWebSocket("conv-123", "user-1", onNewMessage));
+
+    const socket = FakeWebSocket.latest;
+    act(() => {
+      socket.open();
+    });
+
+    // Typing event from another user
+    act(() => {
+      socket.deliver({
+        type: "chat.typing",
+        conversation_id: "conv-123",
+        user_id: "user-2",
+      });
+    });
+
+    expect(result.current.typingUsers).toEqual(["user-2"]);
+
+    // Own typing event is ignored
+    act(() => {
+      socket.deliver({
+        type: "chat.typing",
+        conversation_id: "conv-123",
+        user_id: "user-1",
+      });
+    });
+
+    expect(result.current.typingUsers).toEqual(["user-2"]);
+
+    // Advance time past 3 seconds
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(result.current.typingUsers).toEqual([]);
+  });
+
+  it("sends leave and closes socket on unmount without triggering reconnect", () => {
+    const onNewMessage = vi.fn();
+    const { unmount } = renderHook(() => useChatWebSocket("conv-123", "user-1", onNewMessage));
+
+    const socket = FakeWebSocket.latest;
+    act(() => {
+      socket.open();
+    });
+
+    unmount();
+
+    expect(socket.messages).toEqual([
+      { type: "chat.join", conversation_id: "conv-123" },
+      { type: "chat.leave", conversation_id: "conv-123" },
+    ]);
+    expect(socket.closeCalls).toBe(1);
+
+    // Advancing timers should not create any new socket
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+
+    expect(FakeWebSocket.instances.length).toBe(1);
+  });
+
+  it("properly tears down previous socket when rapidly switching conversations", () => {
+    const onNewMessage = vi.fn();
+    let convId = "conv-1";
+    const { rerender } = renderHook(() => useChatWebSocket(convId, "user-1", onNewMessage));
+
+    expect(FakeWebSocket.instances.length).toBe(1);
+    const socket1 = FakeWebSocket.instances[0];
+
+    // Switch rapidly to conv-2 before socket1 opens
+    convId = "conv-2";
+    rerender();
+
+    expect(FakeWebSocket.instances.length).toBe(2);
+    const socket2 = FakeWebSocket.instances[1];
+
+    // Stale socket1 now fires open / message -- should be safely ignored and not corrupt state
+    act(() => {
+      socket1.open();
+      socket1.deliver({
+        type: "chat.message.new",
+        conversation_id: "conv-1",
+        content: "Stale message",
+      });
+    });
+
+    expect(onNewMessage).not.toHaveBeenCalled();
+
+    // Now open socket2 and deliver message
+    act(() => {
+      socket2.open();
+      socket2.deliver({
+        type: "chat.message.new",
+        conversation_id: "conv-2",
+        content: "Valid message",
+      });
+    });
+
+    expect(onNewMessage).toHaveBeenCalledTimes(1);
+    expect(onNewMessage).toHaveBeenCalledWith({
+      type: "chat.message.new",
+      conversation_id: "conv-2",
+      content: "Valid message",
+    });
+  });
+
+  it("reconnects with backoff when socket drops unexpectedly", () => {
+    vi.spyOn(Math, "random").mockReturnValue(1); // max delay for deterministic timer
+    const onNewMessage = vi.fn();
+    const { result } = renderHook(() => useChatWebSocket("conv-123", "user-1", onNewMessage));
+
+    const socket1 = FakeWebSocket.latest;
+    act(() => {
+      socket1.open();
+    });
+    expect(result.current.isConnected).toBe(true);
+
+    // Socket drops
+    act(() => {
+      socket1.drop();
+    });
+    expect(result.current.isConnected).toBe(false);
+
+    // Timer expires and triggers reconnect
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(FakeWebSocket.instances.length).toBe(2);
+    const socket2 = FakeWebSocket.latest;
+
+    act(() => {
+      socket2.open();
+    });
+    expect(result.current.isConnected).toBe(true);
+
+    vi.restoreAllMocks();
+  });
+
+  it("broadcasts messages and typing when connected", () => {
+    const onNewMessage = vi.fn();
+    const { result } = renderHook(() => useChatWebSocket("conv-123", "user-1", onNewMessage));
+
+    const socket = FakeWebSocket.latest;
+    act(() => {
+      socket.open();
+    });
+
+    act(() => {
+      result.current.broadcastMessage("Hi all");
+      result.current.broadcastTyping();
+    });
+
+    expect(socket.messages).toEqual([
+      { type: "chat.join", conversation_id: "conv-123" },
+      {
+        type: "chat.message",
+        conversation_id: "conv-123",
+        content: "Hi all",
+      },
+      {
+        type: "chat.typing",
+        conversation_id: "conv-123",
+      },
+    ]);
+  });
+});

--- a/frontend/src/hooks/useChatWebSocket.ts
+++ b/frontend/src/hooks/useChatWebSocket.ts
@@ -1,10 +1,20 @@
 import { useState, useEffect, useRef, useCallback } from "react";
+import { tokenStore } from "@/api/tokens";
 
 export interface ChatWebSocketEvent {
   type: string;
   conversation_id: string;
   user_id: string;
   content?: string;
+}
+
+const BASE_RECONNECT_DELAY_MS = 1_000;
+const MAX_RECONNECT_DELAY_MS = 30_000;
+const MAX_RECONNECT_ATTEMPTS = 10;
+
+export function getReconnectDelay(attempt: number): number {
+  const ceiling = Math.min(BASE_RECONNECT_DELAY_MS * 2 ** attempt, MAX_RECONNECT_DELAY_MS);
+  return Math.round(Math.random() * ceiling);
 }
 
 export function useChatWebSocket(
@@ -15,74 +25,182 @@ export function useChatWebSocket(
   const [isConnected, setIsConnected] = useState(false);
   const [typingUsers, setTypingUsers] = useState<Set<string>>(new Set());
   const wsRef = useRef<WebSocket | null>(null);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reconnectAttemptsRef = useRef(0);
+  const isUnmountedRef = useRef(false);
+  const onNewMessageRef = useRef(onNewMessage);
+  const currentUserIdRef = useRef(currentUserId);
+  const typingTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  // Keep latest callbacks without triggering WebSocket re-instantiation
+  useEffect(() => {
+    onNewMessageRef.current = onNewMessage;
+  }, [onNewMessage]);
 
   useEffect(() => {
-    if (!conversationId) return;
+    currentUserIdRef.current = currentUserId;
+  }, [currentUserId]);
 
-    // Use the existing collab endpoint which handles auth via token
-    const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    // Assuming the token is available or we use a demo token for this prototype.
-    // In a real app we would get the actual token from auth context
-    const token = localStorage.getItem("devlink_access_token") || "demo-token";
-    const wsUrl = `${protocol}//${window.location.host}/api/v1/ws/collab?token=${token}`;
+  useEffect(() => {
+    isUnmountedRef.current = false;
+    const typingTimers = typingTimersRef.current;
 
-    try {
-      const ws = new WebSocket(wsUrl);
-      wsRef.current = ws;
+    // Clear existing timers for previous conversation
+    typingTimers.forEach((timer) => clearTimeout(timer));
+    typingTimers.clear();
 
-      ws.onopen = () => {
-        setIsConnected(true);
-        // Join the conversation room
-        ws.send(JSON.stringify({ type: "chat.join", conversation_id: conversationId }));
-      };
+    // Reset reconnect attempts on conversation change
+    reconnectAttemptsRef.current = 0;
+    if (reconnectTimerRef.current) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
 
-      ws.onmessage = (evt) => {
+    if (!conversationId) {
+      return;
+    }
+
+    function cleanupSocket(socket: WebSocket | null) {
+      if (!socket) return;
+      socket.onopen = null;
+      socket.onmessage = null;
+      socket.onclose = null;
+      socket.onerror = null;
+
+      if (socket.readyState === WebSocket.OPEN) {
         try {
-          const msg = JSON.parse(evt.data);
+          socket.send(JSON.stringify({ type: "chat.leave", conversation_id: conversationId }));
+        } catch {
+          // Ignore send errors during cleanup
+        }
+      }
 
-          if (msg.type === "chat.message.new" && msg.conversation_id === conversationId) {
-            onNewMessage(msg);
-          } else if (msg.type === "chat.typing" && msg.conversation_id === conversationId) {
-            if (msg.user_id !== currentUserId) {
-              setTypingUsers((prev) => {
-                const newSet = new Set(prev);
-                newSet.add(msg.user_id);
-                return newSet;
-              });
+      try {
+        socket.close();
+      } catch {
+        // Ignore close errors
+      }
+    }
 
-              // Clear typing indicator after 3 seconds
-              setTimeout(() => {
+    function connect() {
+      if (isUnmountedRef.current || !conversationId) return;
+
+      const protocol =
+        typeof window !== "undefined" && window.location.protocol === "https:" ? "wss:" : "ws:";
+      const host = typeof window !== "undefined" ? window.location.host : "localhost";
+      const token =
+        tokenStore.getAccess() ||
+        (typeof localStorage !== "undefined"
+          ? localStorage.getItem("devlink_access_token")
+          : null) ||
+        "demo-token";
+      const wsUrl = `${protocol}//${host}/api/v1/ws/collab?token=${encodeURIComponent(token)}`;
+
+      try {
+        const ws = new WebSocket(wsUrl);
+        wsRef.current = ws;
+
+        ws.onopen = () => {
+          if (isUnmountedRef.current || wsRef.current !== ws) {
+            cleanupSocket(ws);
+            return;
+          }
+          reconnectAttemptsRef.current = 0;
+          setIsConnected(true);
+          // Join the conversation room
+          try {
+            ws.send(JSON.stringify({ type: "chat.join", conversation_id: conversationId }));
+          } catch {
+            // Ignore send errors
+          }
+        };
+
+        ws.onmessage = (evt) => {
+          if (isUnmountedRef.current || wsRef.current !== ws) return;
+
+          try {
+            const msg = JSON.parse(evt.data);
+
+            if (msg.type === "chat.message.new" && msg.conversation_id === conversationId) {
+              onNewMessageRef.current?.(msg);
+            } else if (msg.type === "chat.typing" && msg.conversation_id === conversationId) {
+              const userId = msg.user_id;
+              if (userId && userId !== currentUserIdRef.current) {
                 setTypingUsers((prev) => {
                   const newSet = new Set(prev);
-                  newSet.delete(msg.user_id);
+                  newSet.add(userId);
                   return newSet;
                 });
-              }, 3000);
+
+                // Clear any existing typing timer for this user
+                const prevTimer = typingTimers.get(userId);
+                if (prevTimer) clearTimeout(prevTimer);
+
+                // Clear typing indicator after 3 seconds
+                const timer = setTimeout(() => {
+                  typingTimers.delete(userId);
+                  if (isUnmountedRef.current) return;
+                  setTypingUsers((prev) => {
+                    const newSet = new Set(prev);
+                    newSet.delete(userId);
+                    return newSet;
+                  });
+                }, 3000);
+
+                typingTimers.set(userId, timer);
+              }
             }
-          }
-        } catch {
-          // Ignore
-        }
-      };
-
-      ws.onclose = () => {
-        setIsConnected(false);
-      };
-
-      return () => {
-        if (ws.readyState === WebSocket.OPEN) {
-          try {
-            ws.send(JSON.stringify({ type: "chat.leave", conversation_id: conversationId }));
           } catch {
-            // Ignore send errors during cleanup
+            // Ignore parse errors
           }
-        }
-        ws.close();
-      };
-    } catch {
-      setIsConnected(false);
+        };
+
+        ws.onclose = () => {
+          if (isUnmountedRef.current || wsRef.current !== ws) return;
+          setIsConnected(false);
+
+          // Auto-reconnect with exponential backoff if not unmounted
+          if (reconnectAttemptsRef.current < MAX_RECONNECT_ATTEMPTS) {
+            const delay = getReconnectDelay(reconnectAttemptsRef.current);
+            reconnectAttemptsRef.current += 1;
+            reconnectTimerRef.current = setTimeout(() => {
+              reconnectTimerRef.current = null;
+              connect();
+            }, delay);
+          }
+        };
+
+        ws.onerror = () => {
+          if (isUnmountedRef.current || wsRef.current !== ws) return;
+          try {
+            ws.close();
+          } catch {
+            // Ignore
+          }
+        };
+      } catch {
+        setIsConnected(false);
+      }
     }
-  }, [conversationId, currentUserId, onNewMessage]);
+
+    connect();
+
+    return () => {
+      isUnmountedRef.current = true;
+      if (reconnectTimerRef.current) {
+        clearTimeout(reconnectTimerRef.current);
+        reconnectTimerRef.current = null;
+      }
+      typingTimers.forEach((timer) => clearTimeout(timer));
+      typingTimers.clear();
+
+      const ws = wsRef.current;
+      wsRef.current = null;
+      cleanupSocket(ws);
+      setIsConnected(false);
+      setTypingUsers(new Set());
+    };
+  }, [conversationId]);
 
   const broadcastMessage = useCallback(
     (content: string) => {


### PR DESCRIPTION
### ✦ Description

Fixes #1267

This PR resolves the duplicate event listeners, reconnection loop, and state desync issues in `useChatWebSocket`:
- **Clean Lifecycle & Teardown**: Strips and nulls out previous event listeners (`onopen`, `onmessage`, `onclose`, `onerror`) and sends `chat.leave` before closing WebSocket instances on unmount or when `conversationId` changes. Prevents stale connections from firing callbacks after switching conversations.
- **Backoff Reconnection**: Implements jittered exponential backoff for unexpected socket disconnections, capping at 30 seconds and resetting the attempt counter upon successful connection.
- **State and Timer Cleanup**: Cleans up active typing indicator timers and pending reconnect timers upon conversation change/unmount.
- **Stable Callback References**: Uses `useRef` for message and user handlers to prevent unnecessary WebSocket teardown and recreation cycles when callback references change.
- **Unit Tests**: Adds comprehensive unit tests in `frontend/src/hooks/__tests__/useChatWebSocket.test.tsx` covering connection, room join/leave, message delivery, typing indicator timeouts, unexpected disconnect backoff, and rapid conversation switching.

### ⟡ Checklist
- [x] Bug fix verified with unit tests (`vitest`)
- [x] Tested rapid conversation switching and teardown
- [x] ESLint passed with 0 errors