### PR TITLE
feat(projects): allow project owners and admins to cancel pending invitations

### DIFF
--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -825,6 +825,38 @@ def invite_user(
 
 
 @router.delete(
+    "/{project_id}/invitations/{user_id}",
+    status_code=status.HTTP_200_OK,
+    response_model=dict,
+    summary="Cancel pending project invitation",
+)
+@router.post(
+    "/{project_id}/invitations/{user_id}/cancel",
+    status_code=status.HTTP_200_OK,
+    response_model=dict,
+    summary="Cancel pending project invitation (POST alias)",
+)
+def cancel_project_invitation(
+    project_id: uuid.UUID,
+    user_id: uuid.UUID,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
+):
+    """Allow project owners or admins to cancel pending invitations."""
+    from app.services.project_member_service import ProjectMemberService
+
+    ProjectMemberService.cancel_invitation(
+        db=db,
+        project_id=project_id,
+        target_user_id=user_id,
+        actor_user=current_user,
+    )
+    cache_manager.delete_pattern("projects:*")
+    return {"message": "Invitation cancelled successfully"}
+
+
+
+@router.delete(
     "/{project_id}/soft",
     status_code=status.HTTP_204_NO_CONTENT,
 )

--- a/backend/app/services/project_member_service.py
+++ b/backend/app/services/project_member_service.py
@@ -341,3 +341,92 @@ class ProjectMemberService:
             target_user_id=target_user_id,
             description=f"Removed member {target_user_id} from project",
         )
+
+    @classmethod
+    def cancel_invitation(
+        cls,
+        db: Session,
+        project_id: uuid.UUID,
+        target_user_id: uuid.UUID,
+        actor_user: User,
+    ) -> None:
+        """Cancel a pending project invitation.
+        
+        Only project owners and admins can cancel invitations.
+        Active/accepted or non-pending memberships cannot be cancelled.
+        """
+        project = db.get(Project, project_id)
+        if not project:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Project not found",
+            )
+
+        # 1. Authorization: Only project owner or members with role management / admin permissions
+        is_owner = actor_user.id == project.owner_id
+        is_admin_or_permitted = (
+            actor_user.is_superuser
+            or has_project_permission(db, actor_user.id, project_id, PROJECT_MANAGE_ROLES)
+            or has_project_permission(db, actor_user.id, project_id, PROJECT_REMOVE_MEMBERS)
+        )
+        if not (is_owner or is_admin_or_permitted):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Only project owners and admins can cancel invitations",
+            )
+
+        # 2. Retrieve invitation record
+        pm = db.scalar(
+            select(ProjectMember).where(
+                ProjectMember.project_id == project_id,
+                ProjectMember.user_id == target_user_id,
+            )
+        )
+        if not pm:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="No invitation found for this user on the project",
+            )
+
+        # 3. State validation: Only pending (is_active is False) invitations can be cancelled
+        if pm.is_active:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Cannot cancel invitation: User is already an active member of this project",
+            )
+
+        # 4. Remove pending invitation
+        db.delete(pm)
+
+        # 5. Clean up / mark pending invitation notifications
+        try:
+            from app.models.notification import Notification, NotificationType
+
+            pending_notifications = (
+                db.query(Notification)
+                .filter(
+                    Notification.recipient_id == target_user_id,
+                    Notification.project_id == project_id,
+                    Notification.type == NotificationType.PROJECT_INVITE,
+                )
+                .all()
+            )
+            for notif in pending_notifications:
+                notif.read = True
+        except Exception:
+            pass
+
+        db.commit()
+
+        # 6. Emit audit log
+        AuditLogService.create_log(
+            db=db,
+            actor_id=actor_user.id,
+            action=AuditAction.INVITATION_REVOKED,
+            entity_type="project_invitation",
+            entity_id=str(target_user_id),
+            project_id=project_id,
+            target_user_id=target_user_id,
+            description=f"Cancelled pending project invitation for user {target_user_id}",
+        )
+

--- a/backend/tests/test_invitation_cancellation.py
+++ b/backend/tests/test_invitation_cancellation.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import uuid
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.database.base import Base
+from app.dependencies import get_current_user, get_database
+from app.main import app
+from app.models.audit_log import AuditAction, AuditLog
+from app.models.notification import Notification, NotificationType
+from app.models.project import Project
+from app.models.project_member import MemberRole, ProjectMember
+from app.models.user import User
+from app.services.project_member_service import ProjectMemberService
+
+# SQLite in-memory test database
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    app.dependency_overrides[get_database] = override_get_db
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+    app.dependency_overrides.clear()
+
+
+def _create_user(db, username: str, email: str) -> User:
+    u = User(
+        id=uuid.uuid4(),
+        username=username,
+        email=email,
+        password_hash="fake_hash",
+        is_active=True,
+    )
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def _create_project(db, owner_id: uuid.UUID, title: str = "Test Project") -> Project:
+    p = Project(
+        id=uuid.uuid4(),
+        owner_id=owner_id,
+        title=title,
+        slug=f"{title.lower().replace(' ', '-')}-{uuid.uuid4().hex[:6]}",
+        tagline="Test Project Tagline",
+        description="A comprehensive description of the test project for testing invitation cancellation.",
+        is_published=True,
+        is_archived=False,
+    )
+    db.add(p)
+    db.commit()
+    db.refresh(p)
+    return p
+
+
+# ---------------------------------------------------------------------
+# Service Unit Tests for Invitation Cancellation
+# ---------------------------------------------------------------------
+
+
+def test_cancel_pending_invitation_success():
+    db = TestingSessionLocal()
+    owner = _create_user(db, "owner_cancel", "ocancel@example.com")
+    invitee = _create_user(db, "invitee_cancel", "icancel@example.com")
+    project = _create_project(db, owner.id)
+
+    # 1. Create pending invitation
+    pm = ProjectMember(
+        project_id=project.id,
+        user_id=invitee.id,
+        role=MemberRole.MEMBER,
+        is_active=False,
+    )
+    db.add(pm)
+    # Add invitation notification
+    notif = Notification(
+        id=uuid.uuid4(),
+        recipient_id=invitee.id,
+        sender_id=owner.id,
+        type=NotificationType.PROJECT_INVITE,
+        title="Project Invitation",
+        message="You are invited",
+        project_id=project.id,
+        read=False,
+    )
+    db.add(notif)
+    db.commit()
+
+    # 2. Cancel invitation
+    ProjectMemberService.cancel_invitation(
+        db=db,
+        project_id=project.id,
+        target_user_id=invitee.id,
+        actor_user=owner,
+    )
+
+    # 3. Assert project member record deleted
+    check_pm = db.scalar(
+        select(ProjectMember).where(
+            ProjectMember.project_id == project.id,
+            ProjectMember.user_id == invitee.id,
+        )
+    )
+    assert check_pm is None
+
+    # 4. Assert notification marked as read
+    db.refresh(notif)
+    assert notif.read is True
+
+    # 5. Assert audit log emitted
+    audit = db.scalar(
+        select(AuditLog).where(
+            AuditLog.project_id == project.id,
+            AuditLog.action == AuditAction.INVITATION_REVOKED,
+        )
+    )
+    assert audit is not None
+    assert audit.target_user_id == invitee.id
+    db.close()
+
+
+def test_cancel_invitation_unauthorized_user_raises_403():
+    db = TestingSessionLocal()
+    owner = _create_user(db, "owner_perm", "operm@example.com")
+    stranger = _create_user(db, "stranger_user", "stranger@example.com")
+    invitee = _create_user(db, "invitee_perm", "iperm@example.com")
+    project = _create_project(db, owner.id)
+
+    # Pending invitation
+    pm = ProjectMember(
+        project_id=project.id,
+        user_id=invitee.id,
+        role=MemberRole.MEMBER,
+        is_active=False,
+    )
+    db.add(pm)
+    db.commit()
+
+    from fastapi import HTTPException
+
+    # Stranger attempts to cancel
+    with pytest.raises(HTTPException) as exc:
+        ProjectMemberService.cancel_invitation(
+            db=db,
+            project_id=project.id,
+            target_user_id=invitee.id,
+            actor_user=stranger,
+        )
+    assert exc.value.status_code == 403
+    assert "owners and admins" in exc.value.detail.lower()
+    db.close()
+
+
+def test_cancel_active_member_raises_400():
+    db = TestingSessionLocal()
+    owner = _create_user(db, "owner_act", "oact@example.com")
+    member = _create_user(db, "active_member", "actm@example.com")
+    project = _create_project(db, owner.id)
+
+    # Active member (is_active=True)
+    pm = ProjectMember(
+        project_id=project.id,
+        user_id=member.id,
+        role=MemberRole.CONTRIBUTOR,
+        is_active=True,
+    )
+    db.add(pm)
+    db.commit()
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc:
+        ProjectMemberService.cancel_invitation(
+            db=db,
+            project_id=project.id,
+            target_user_id=member.id,
+            actor_user=owner,
+        )
+    assert exc.value.status_code == 400
+    assert "already an active member" in exc.value.detail.lower()
+    db.close()
+
+
+def test_cancel_nonexistent_invitation_raises_404():
+    db = TestingSessionLocal()
+    owner = _create_user(db, "owner_404", "o404@example.com")
+    non_invitee = _create_user(db, "nobody", "nobody@example.com")
+    project = _create_project(db, owner.id)
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc:
+        ProjectMemberService.cancel_invitation(
+            db=db,
+            project_id=project.id,
+            target_user_id=non_invitee.id,
+            actor_user=owner,
+        )
+    assert exc.value.status_code == 404
+    assert "no invitation found" in exc.value.detail.lower()
+    db.close()
+
+
+# ---------------------------------------------------------------------
+# API Integration Tests for Cancel Endpoints
+# ---------------------------------------------------------------------
+
+
+def test_api_cancel_invitation_delete_method():
+    client = TestClient(app)
+    db = TestingSessionLocal()
+    owner = _create_user(db, "api_owner_del", "odel@example.com")
+    invitee = _create_user(db, "api_invitee_del", "idel@example.com")
+    project = _create_project(db, owner.id)
+
+    # Add pending invitation
+    pm = ProjectMember(
+        project_id=project.id,
+        user_id=invitee.id,
+        role=MemberRole.MEMBER,
+        is_active=False,
+    )
+    db.add(pm)
+    db.commit()
+    db.close()
+
+    app.dependency_overrides[get_current_user] = lambda: owner
+
+    # DELETE /api/projects/{project_id}/invitations/{user_id}
+    res = client.delete(f"/api/projects/{project.id}/invitations/{invitee.id}")
+    assert res.status_code == 200
+    assert "cancelled successfully" in res.json()["message"].lower()
+
+
+def test_api_cancel_invitation_post_alias():
+    client = TestClient(app)
+    db = TestingSessionLocal()
+    owner = _create_user(db, "api_owner_post", "opost@example.com")
+    invitee = _create_user(db, "api_invitee_post", "ipost@example.com")
+    project = _create_project(db, owner.id)
+
+    # Add pending invitation
+    pm = ProjectMember(
+        project_id=project.id,
+        user_id=invitee.id,
+        role=MemberRole.MEMBER,
+        is_active=False,
+    )
+    db.add(pm)
+    db.commit()
+    db.close()
+
+    app.dependency_overrides[get_current_user] = lambda: owner
+
+    # POST /api/projects/{project_id}/invitations/{user_id}/cancel
+    res = client.post(f"/api/projects/{project.id}/invitations/{invitee.id}/cancel")
+    assert res.status_code == 200
+    assert "cancelled successfully" in res.json()["message"].lower()

--- a/frontend/src/api/modules/projects.ts
+++ b/frontend/src/api/modules/projects.ts
@@ -89,6 +89,12 @@ export const projectsApi = {
   archive: (id: string) => api.post<ExtendedProject>(`/api/projects/${id}/archive`),
   /** Unarchive a project back to active status */
   unarchive: (id: string) => api.post<ExtendedProject>(`/api/projects/${id}/unarchive`),
+  /** Invite user to project */
+  inviteMember: (projectId: string, userId: string) =>
+    api.post<{ message: string }>(`/api/projects/${projectId}/invite/${userId}`),
+  /** Cancel a pending project invitation */
+  cancelInvitation: (projectId: string, userId: string) =>
+    api.delete<{ message: string }>(`/api/projects/${projectId}/invitations/${userId}`),
   /** Clone an existing project as a template */
   clone: (id: string, body?: ProjectCloneRequest) =>
     api.post<ExtendedProject>(`/api/projects/${id}/clone`, body || {}),

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -140,8 +140,10 @@ export const projectsService = {
   updateDraft: (id: string, body: any) =>
     withFallback(() => projectsApi.updateDraft(id, body as any), {} as any),
 
-  clone: (id: string, body?: any) =>
-    projectsApi.clone(id, body),
+  clone: (id: string, body?: any) => projectsApi.clone(id, body),
+  invite: (projectId: string, userId: string) => projectsApi.inviteMember(projectId, userId),
+  cancelInvitation: (projectId: string, userId: string) =>
+    projectsApi.cancelInvitation(projectId, userId),
 };
 
 export const buildersService = {
@@ -201,33 +203,19 @@ export const dashboardService = {
 };
 
 export const usersService = {
-  getMe: () =>
-    withFallback(
-      () => usersApi.getMe(),
-      null
-    ),
+  getMe: () => withFallback(() => usersApi.getMe(), null),
   getPrivacySettings: () =>
-    withFallback(
-      () => usersApi.getPrivacySettings(),
-      {
-        email: "private",
-        github: "public",
-        resume: "public",
-        social_links: "public",
-        availability: "public",
-        activity: "public",
-      }
-    ),
+    withFallback(() => usersApi.getPrivacySettings(), {
+      email: "private",
+      github: "public",
+      resume: "public",
+      social_links: "public",
+      availability: "public",
+      activity: "public",
+    }),
   updatePrivacySettings: (body: Record<string, any>) =>
-    withFallback(
-      () => usersApi.updatePrivacySettings(body),
-      {}
-    ),
-  updateMe: (body: Record<string, any>) =>
-    withFallback(
-      () => usersApi.updateMe(body),
-      {}
-    ),
+    withFallback(() => usersApi.updatePrivacySettings(body), {}),
+  updateMe: (body: Record<string, any>) => withFallback(() => usersApi.updateMe(body), {}),
 };
 
 export const activitiesService = {


### PR DESCRIPTION
### Description
Closes #1313

### Summary of Changes
This pull request allows project owners and project admins to cancel pending invitations and handles notification/audit cleanup.

- **Cancellation Logic**: Added `ProjectMemberService.cancel_invitation`:
  - **RBAC Authorization**: Validates that only the project owner or members with `PROJECT_MANAGE_ROLES` / `PROJECT_REMOVE_MEMBERS` permissions can cancel invitations (`403 Forbidden` otherwise).
  - **Status Validation**: Only pending invitations (`is_active == False`) can be cancelled. Rejects cancellation attempts for active team members (`400 Bad Request`).
  - **Notification Handling**: Automatically marks associated pending `PROJECT_INVITE` notifications as read.
  - **Audit Logging**: Emits `AuditAction.INVITATION_REVOKED` record for tracking.
- **API Endpoints**:
  - `DELETE /api/projects/{project_id}/invitations/{user_id}`
  - `POST /api/projects/{project_id}/invitations/{user_id}/cancel` (alias)
- **Frontend Client & Service**: Added `projectsApi.cancelInvitation` and `projectsService.cancelInvitation` methods.
- **Testing**: Added test suite `backend/tests/test_invitation_cancellation.py` testing successful cancellation, RBAC authorization boundaries, non-pending member guards, and API routes.

### Verification
- `pytest backend/tests/test_invitation_cancellation.py` passed all test cases.
