### PR TITLE
feat: implement comment threading and nested structures for #1428

### DIFF
--- a/backend/alembic/versions/c3a9f18d5e72_create_post_likes_and_post_comments.py
+++ b/backend/alembic/versions/c3a9f18d5e72_create_post_likes_and_post_comments.py
@@ -136,6 +136,12 @@ def upgrade() -> None:
         ),
         sa.Column("content", sa.Text(), nullable=False),
         sa.Column(
+            "parent_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("post_comments.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column(
             "created_at",
             sa.DateTime(timezone=True),
             server_default=sa.func.now(),

--- a/backend/app/models/post_comment.py
+++ b/backend/app/models/post_comment.py
@@ -48,6 +48,13 @@ class PostComment(Base):
         nullable=False,
     )
 
+    parent_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("post_comments.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+    )
+
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),
@@ -68,6 +75,13 @@ class PostComment(Base):
         backref=backref("comments", cascade="all, delete-orphan", passive_deletes=True),
     )
     author = relationship("User")
+    
+    replies = relationship(
+        "PostComment",
+        backref=backref("parent", remote_side=[id]),
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
 
     def __repr__(self) -> str:
         return (

--- a/backend/app/routers/posts.py
+++ b/backend/app/routers/posts.py
@@ -85,11 +85,13 @@ def _map_comment(comment: PostComment) -> PostCommentResponse:
     return PostCommentResponse(
         id=comment.id,
         post_id=comment.post_id,
+        parent_id=comment.parent_id,
         author=_author_response(comment.author),
         content=comment.content,
         ago=get_ago_string(comment.created_at),
         created_at=comment.created_at,
         updated_at=comment.updated_at,
+        replies=[_map_comment(reply) for reply in getattr(comment, 'replies', [])]
     )
 
 
@@ -400,13 +402,15 @@ def list_comments(
     page: int = Query(1, ge=1),
     limit: int = Query(DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
 ):
-    """Read a post's comments. There was previously no way to."""
+    """Read a post's comments. Returns top-level comments and their nested replies."""
     _get_post_or_404(db, post_id)
 
     comments = (
         db.query(PostComment)
-        .options(joinedload(PostComment.author))
-        .filter(PostComment.post_id == post_id)
+        .options(
+            joinedload(PostComment.author),
+        )
+        .filter(PostComment.post_id == post_id, PostComment.parent_id.is_(None))
         .order_by(PostComment.created_at.asc())
         .offset((page - 1) * limit)
         .limit(limit)
@@ -434,11 +438,19 @@ def comment_post(
     returned so the client can render it without a refetch.
     """
     db_post = _get_post_or_404(db, post_id)
+    
+    if payload.parent_id:
+        parent_comment = db.query(PostComment).filter(PostComment.id == payload.parent_id).first()
+        if not parent_comment:
+            raise HTTPException(status_code=404, detail="Parent comment not found")
+        if parent_comment.post_id != db_post.id:
+            raise HTTPException(status_code=400, detail="Parent comment does not belong to this post")
 
     comment = PostComment(
         post_id=db_post.id,
         author_id=current_user.id,
         content=payload.comment,
+        parent_id=payload.parent_id,
     )
     db.add(comment)
     db.flush()

--- a/backend/app/schemas/post.py
+++ b/backend/app/schemas/post.py
@@ -129,6 +129,7 @@ class PostResponse(BaseModel):
 
 class PostCommentCreate(BaseModel):
     comment: str = Field(..., min_length=1, max_length=MAX_COMMENT_LENGTH)
+    parent_id: Optional[uuid.UUID] = None
 
     @field_validator("comment")
     @classmethod
@@ -144,11 +145,13 @@ class PostCommentResponse(BaseModel):
 
     id: uuid.UUID
     post_id: uuid.UUID
+    parent_id: Optional[uuid.UUID] = None
     author: PostAuthorResponse
     content: str
     ago: str = "just now"
     created_at: datetime
     updated_at: datetime
+    replies: list[PostCommentResponse] = []
 
 
 class PostEngagementResponse(BaseModel):

--- a/backend/tests/test_post_engagement.py
+++ b/backend/tests/test_post_engagement.py
@@ -349,6 +349,67 @@ def test_commenting_on_a_missing_post_is_404(client, author):
 
 
 # --------------------------------------------------------------------------
+# Comment Threading
+# --------------------------------------------------------------------------
+
+def test_can_reply_to_a_comment(client, author, reader):
+    _, author_token = author
+    _, reader_token = reader
+    post_id = _create_post(client, author_token)
+
+    # Top-level comment
+    comment_id = client.post(
+        f"/api/posts/{post_id}/comment",
+        json={"comment": "first"},
+        headers=_auth(reader_token),
+    ).json()["id"]
+
+    # Reply
+    reply_id = client.post(
+        f"/api/posts/{post_id}/comment",
+        json={"comment": "reply", "parent_id": comment_id},
+        headers=_auth(author_token),
+    ).json()["id"]
+
+    comments = client.get(f"/api/posts/{post_id}/comments").json()
+    assert len(comments) == 1
+    assert comments[0]["id"] == comment_id
+    assert len(comments[0]["replies"]) == 1
+    assert comments[0]["replies"][0]["id"] == reply_id
+    assert comments[0]["replies"][0]["parent_id"] == comment_id
+
+def test_replying_to_a_missing_comment_is_404(client, author):
+    _, token = author
+    post_id = _create_post(client, token)
+    missing = "00000000-0000-0000-0000-000000000000"
+
+    response = client.post(
+        f"/api/posts/{post_id}/comment",
+        json={"comment": "reply", "parent_id": missing},
+        headers=_auth(token),
+    )
+    assert response.status_code == 404
+
+def test_replying_to_a_comment_on_another_post_is_400(client, author, reader):
+    _, token = author
+    post_1 = _create_post(client, token)
+    post_2 = _create_post(client, token)
+
+    comment_1 = client.post(
+        f"/api/posts/{post_1}/comment",
+        json={"comment": "first"},
+        headers=_auth(token),
+    ).json()["id"]
+
+    response = client.post(
+        f"/api/posts/{post_2}/comment",
+        json={"comment": "reply", "parent_id": comment_1},
+        headers=_auth(token),
+    )
+    assert response.status_code == 400
+
+
+# --------------------------------------------------------------------------
 # Comment deletion
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description
This PR resolves the final requirements of issue #1428 by implementing comment threading and nested response structures for Post engagements. Although the core endpoints for liking and top-level commenting were previously introduced, the ability to reply directly to existing comments was missing.

## Changes Made
- Added a self-referencing `parent_id` foreign key column to the `post_comments` table migration.
- Updated `PostComment` model with the `parent_id` and a `replies` relationship for eager/lazy loading of nested children.
- Updated `PostCommentCreate` and `PostCommentResponse` Pydantic schemas to validate and expose nested thread hierarchies.
- Refactored `list_comments` in the router to paginate top-level comments and recursively map replies to them.
- Added cross-post threading protections (e.g., throwing a `400` if attempting to reply to a comment that belongs to a different post).
- Added comprehensive threading validation tests to `test_post_engagement.py`.

Fixes #1428

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
