### PR TITLE
feat(projects): validate project membership at the service layer

### DIFF
--- a/backend/app/routers/project_members.py
+++ b/backend/app/routers/project_members.py
@@ -26,10 +26,13 @@ router = APIRouter(
 )
 def get_project_members(
     project_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
     db: Session = Depends(get_database),
 ):
     """Retrieve all team members and their project roles."""
-    return ProjectMemberService.get_project_members(db=db, project_id=project_id)
+    return ProjectMemberService.get_project_members(
+        db=db, project_id=project_id, actor_user=current_user
+    )
 
 
 @router.put(

--- a/backend/app/services/project_member_service.py
+++ b/backend/app/services/project_member_service.py
@@ -18,19 +18,73 @@ from app.core.rbac import (
     has_project_permission,
     PROJECT_MANAGE_ROLES,
     PROJECT_REMOVE_MEMBERS,
+    PROJECT_VIEW,
 )
 
 
 class ProjectMemberService:
     @classmethod
+    def get_membership(
+        cls,
+        db: Session,
+        project_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> ProjectMember | None:
+        """Return the project membership row, or ``None`` if it does not exist."""
+        return db.scalar(
+            select(ProjectMember).where(
+                ProjectMember.project_id == project_id,
+                ProjectMember.user_id == user_id,
+            )
+        )
+
+    @classmethod
+    def require_membership(
+        cls,
+        db: Session,
+        project_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> ProjectMember:
+        """Return the membership row, or 404 if it does not exist (#1310)."""
+        membership = cls.get_membership(db, project_id, user_id)
+        if membership is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Project membership not found",
+            )
+        return membership
+
+    @classmethod
+    def require_project_member_access(
+        cls,
+        db: Session,
+        project: Project,
+        actor_user: User,
+        permission: str = PROJECT_VIEW,
+        *,
+        forbidden_detail: str = "You do not have access to this project's members",
+    ) -> None:
+        """403 unless the actor belongs to the project or holds ``permission``."""
+        if actor_user.is_superuser or actor_user.id == project.owner_id:
+            return
+
+        if not has_project_permission(db, actor_user.id, project.id, permission):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=forbidden_detail,
+            )
+
+    @classmethod
     def get_project_members(
-        cls, db: Session, project_id: uuid.UUID
+        cls, db: Session, project_id: uuid.UUID, actor_user: User
     ) -> List[Dict[str, Any]]:
         project = db.get(Project, project_id)
         if not project:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail="Project not found"
             )
+
+        cls.require_project_member_access(db, project, actor_user)
 
         stmt = (
             select(ProjectMember, User)
@@ -102,15 +156,13 @@ class ProjectMemberService:
                 status_code=status.HTTP_404_NOT_FOUND, detail="Project not found"
             )
 
-        # Authorization check
-        if actor_user.id != project.owner_id and not actor_user.is_superuser:
-            if not has_project_permission(
-                db, actor_user.id, project_id, PROJECT_MANAGE_ROLES
-            ):
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail="Insufficient permissions to manage project roles",
-                )
+        cls.require_project_member_access(
+            db,
+            project,
+            actor_user,
+            PROJECT_MANAGE_ROLES,
+            forbidden_detail="Insufficient permissions to manage project roles",
+        )
 
         # Cannot alter project owner role via normal update
         if target_user_id == project.owner_id:
@@ -119,23 +171,9 @@ class ProjectMemberService:
                 detail="Cannot change project owner role. Use transfer ownership instead.",
             )
 
-        pm = db.scalar(
-            select(ProjectMember).where(
-                ProjectMember.project_id == project_id,
-                ProjectMember.user_id == target_user_id,
-            )
-        )
-        if not pm:
-            pm = ProjectMember(
-                project_id=project_id,
-                user_id=target_user_id,
-                role=new_role,
-                is_active=True,
-            )
-            db.add(pm)
-        else:
-            pm.role = new_role
-            pm.is_active = True
+        pm = cls.require_membership(db, project_id, target_user_id)
+        pm.role = new_role
+        pm.is_active = True
 
         db.commit()
         db.refresh(pm)
@@ -307,28 +345,18 @@ class ProjectMemberService:
             )
 
         # Allow self-removal, otherwise require manage permissions
-        if (
-            actor_user.id != target_user_id
-            and actor_user.id != project.owner_id
-            and not actor_user.is_superuser
-        ):
-            if not has_project_permission(
-                db, actor_user.id, project_id, PROJECT_REMOVE_MEMBERS
-            ):
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail="Insufficient permissions to remove team members",
-                )
-
-        pm = db.scalar(
-            select(ProjectMember).where(
-                ProjectMember.project_id == project_id,
-                ProjectMember.user_id == target_user_id,
+        if actor_user.id != target_user_id:
+            cls.require_project_member_access(
+                db,
+                project,
+                actor_user,
+                PROJECT_REMOVE_MEMBERS,
+                forbidden_detail="Insufficient permissions to remove team members",
             )
-        )
-        if pm:
-            db.delete(pm)
-            db.commit()
+
+        pm = cls.require_membership(db, project_id, target_user_id)
+        db.delete(pm)
+        db.commit()
 
         # Audit log
         AuditLogService.create_log(

--- a/backend/tests/test_project_team_roles.py
+++ b/backend/tests/test_project_team_roles.py
@@ -49,6 +49,23 @@ def member_user(db):
 
 
 @pytest.fixture
+def outsider_user(db):
+    user = User(
+        id=uuid4(),
+        first_name="Out",
+        last_name="Sider",
+        username=f"outsider_{uuid4().hex[:6]}",
+        email=f"outsider_{uuid4().hex[:6]}@example.com",
+        password_hash="secret",
+        is_active=True,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@pytest.fixture
 def test_project(db, owner_user):
     proj = Project(
         id=uuid4(),
@@ -75,20 +92,31 @@ def member_auth_headers(member_user):
     return {"Authorization": f"Bearer {token}"}
 
 
-def test_get_project_members(client, db, test_project, owner_user, member_user):
-    # Add member_user as contributor
+@pytest.fixture
+def outsider_auth_headers(outsider_user):
+    token = create_access_token(user_id=str(outsider_user.id))
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _add_member(db, project, user, role=MemberRole.CONTRIBUTOR):
     pm = ProjectMember(
         id=uuid4(),
-        project_id=test_project.id,
-        user_id=member_user.id,
-        role=MemberRole.CONTRIBUTOR,
+        project_id=project.id,
+        user_id=user.id,
+        role=role,
         is_active=True,
     )
     db.add(pm)
     db.commit()
+    db.refresh(pm)
+    return pm
+
+
+def test_get_project_members(client, db, test_project, owner_user, member_user):
+    _add_member(db, test_project, member_user)
 
     members = ProjectMemberService.get_project_members(
-        db=db, project_id=test_project.id
+        db=db, project_id=test_project.id, actor_user=owner_user
     )
     assert len(members) >= 2
     roles = {m["role"] for m in members}
@@ -96,9 +124,34 @@ def test_get_project_members(client, db, test_project, owner_user, member_user):
     assert MemberRole.CONTRIBUTOR in roles
 
 
+def test_get_project_members_allowed_for_member(
+    client, db, test_project, member_user, member_auth_headers
+):
+    _add_member(db, test_project, member_user)
+
+    res = client.get(
+        f"/api/v1/projects/{test_project.id}/members",
+        headers=member_auth_headers,
+    )
+    assert res.status_code == 200
+    assert len(res.json()) >= 2
+
+
+def test_get_project_members_forbidden_for_non_member(
+    client, db, test_project, outsider_auth_headers
+):
+    res = client.get(
+        f"/api/v1/projects/{test_project.id}/members",
+        headers=outsider_auth_headers,
+    )
+    assert res.status_code == 403
+
+
 def test_update_member_role_success(
     client, db, test_project, owner_user, member_user, owner_auth_headers
 ):
+    _add_member(db, test_project, member_user)
+
     # Update role to MAINTAINER
     res = client.put(
         f"/api/v1/projects/{test_project.id}/members/{member_user.id}/role",
@@ -110,9 +163,23 @@ def test_update_member_role_success(
     assert data["role"] == "maintainer"
 
 
+def test_update_member_role_nonexistent_membership(
+    client, db, test_project, member_user, owner_auth_headers
+):
+    res = client.put(
+        f"/api/v1/projects/{test_project.id}/members/{member_user.id}/role",
+        json={"role": "maintainer"},
+        headers=owner_auth_headers,
+    )
+    assert res.status_code == 404
+    assert res.json()["detail"] == "Project membership not found"
+
+
 def test_update_member_role_unauthorized(
     client, db, test_project, owner_user, member_user, member_auth_headers
 ):
+    _add_member(db, test_project, member_user)
+
     # Viewer/member attempting to change roles should fail with 403
     res = client.put(
         f"/api/v1/projects/{test_project.id}/members/{owner_user.id}/role",
@@ -149,7 +216,7 @@ def test_transfer_project_ownership(
 
     # Verify old owner is now MAINTAINER and new owner is OWNER
     members = ProjectMemberService.get_project_members(
-        db=db, project_id=test_project.id
+        db=db, project_id=test_project.id, actor_user=member_user
     )
     member_roles = {m["user_id"]: m["role"] for m in members}
     assert member_roles[str(member_user.id)] == MemberRole.OWNER
@@ -159,14 +226,7 @@ def test_transfer_project_ownership(
 def test_remove_project_member(
     client, db, test_project, owner_user, member_user, owner_auth_headers
 ):
-    # Add member
-    ProjectMemberService.update_member_role(
-        db=db,
-        project_id=test_project.id,
-        target_user_id=member_user.id,
-        new_role=MemberRole.REVIEWER,
-        actor_user=owner_user,
-    )
+    _add_member(db, test_project, member_user, role=MemberRole.REVIEWER)
 
     res = client.delete(
         f"/api/v1/projects/{test_project.id}/members/{member_user.id}",
@@ -175,9 +235,32 @@ def test_remove_project_member(
     assert res.status_code in [200, 204]
 
     members = ProjectMemberService.get_project_members(
-        db=db, project_id=test_project.id
+        db=db, project_id=test_project.id, actor_user=owner_user
     )
     assert not any(m["user_id"] == str(member_user.id) for m in members)
+
+
+def test_remove_project_member_nonexistent_membership(
+    client, db, test_project, member_user, owner_auth_headers
+):
+    res = client.delete(
+        f"/api/v1/projects/{test_project.id}/members/{member_user.id}",
+        headers=owner_auth_headers,
+    )
+    assert res.status_code == 404
+    assert res.json()["detail"] == "Project membership not found"
+
+
+def test_remove_project_member_forbidden_for_non_member(
+    client, db, test_project, member_user, outsider_auth_headers
+):
+    _add_member(db, test_project, member_user)
+
+    res = client.delete(
+        f"/api/v1/projects/{test_project.id}/members/{member_user.id}",
+        headers=outsider_auth_headers,
+    )
+    assert res.status_code == 403
 
 
 def test_cannot_remove_project_owner(
@@ -203,14 +286,7 @@ def test_rbac_permission_checks(db, test_project, owner_user, member_user):
         is True
     )
 
-    # Set member_user as CONTRIBUTOR
-    ProjectMemberService.update_member_role(
-        db=db,
-        project_id=test_project.id,
-        target_user_id=member_user.id,
-        new_role=MemberRole.CONTRIBUTOR,
-        actor_user=owner_user,
-    )
+    _add_member(db, test_project, member_user, role=MemberRole.CONTRIBUTOR)
 
     assert (
         has_project_permission(

--- a/docs/project_roles.md
+++ b/docs/project_roles.md
@@ -39,7 +39,7 @@ Project members can be assigned one of five distinct roles:
 
 | Method | Endpoint | Description | Permission Required |
 |--------|----------|-------------|---------------------|
-| `GET` | `/api/v1/projects/{project_id}/members` | Lists all team members and their roles. | Public / Project Member |
+| `GET` | `/api/v1/projects/{project_id}/members` | Lists all team members and their roles. | Project Member (`project:view`) |
 | `PUT` | `/api/v1/projects/{project_id}/members/{user_id}/role` | Assigns or changes a member's role (`owner`, `maintainer`, `contributor`, `reviewer`, `viewer`). | Owner / Maintainer (`project:manage_roles`) |
 | `POST` | `/api/v1/projects/{project_id}/transfer-ownership` | Transfers project ownership to another team member. | Owner Only (`project:transfer_ownership`) |
 | `DELETE` | `/api/v1/projects/{project_id}/members/{user_id}` | Removes a member from the project. | Owner / Maintainer (`project:remove_members`) or Self-Removal |


### PR DESCRIPTION
## Summary
- Check project membership at the service layer before listing, updating, or removing members.
- Return 403 when the caller is not a member and has no matching permission.
- Return 404 when the target membership does not exist.

## Related Issue
Closes #1310

ECSoc 2026

## Type of Change
- [x] New feature
- [x] Tests

## Testing
- [x] Added tests for 403 (non-member) and 404 (missing membership)
- [ ] Tested locally
- [ ] Existing tests pass

```bash
cd backend && pytest tests/test_project_team_roles.py tests/test_project_audit_trail.py -v