### PR TITLE
feat(applications): allow applicants to withdraw pending applications

### DIFF
--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -42,12 +42,10 @@ class ApplicationService:
             ApplicationStatus.INTERVIEWING,
             ApplicationStatus.ACCEPTED,
             ApplicationStatus.REJECTED,
-            ApplicationStatus.WITHDRAWN,
         },
         ApplicationStatus.INTERVIEWING: {
             ApplicationStatus.ACCEPTED,
             ApplicationStatus.REJECTED,
-            ApplicationStatus.WITHDRAWN,
         },
         ApplicationStatus.ACCEPTED: set(),
         ApplicationStatus.REJECTED: set(),
@@ -353,11 +351,11 @@ class ApplicationService:
         db: Session,
         db_application: Application,
     ) -> Application:
-
-        ApplicationService._validate_status_transition(
-            db_application.status,
-            ApplicationStatus.WITHDRAWN,
-        )
+        if db_application.status != ApplicationStatus.PENDING:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Only pending applications can be withdrawn",
+            )
 
         db_application.status = ApplicationStatus.WITHDRAWN
         db.flush()

--- a/backend/tests/test_applications.py
+++ b/backend/tests/test_applications.py
@@ -290,6 +290,62 @@ def test_withdraw_application_unauthorized(
     assert res.status_code == 403
 
 
+def test_owner_cannot_withdraw_application(
+    client: TestClient, register_and_login, test_project
+):
+    pid = test_project["id"]
+    owner_token = test_project["token"]
+    _, applicant_token = register_and_login(
+        "owner_withdraw@example.com", "ownerwithdraw"
+    )
+
+    created = client.post(
+        "/api/applications/",
+        json={"project_id": str(pid), "flare_id": str(test_project["flare_id"])},
+        headers={"Authorization": f"Bearer {applicant_token}"},
+    )
+    assert created.status_code == 201
+    app_id = created.json()["id"]
+
+    res = client.patch(
+        f"/api/applications/{app_id}/withdraw",
+        headers={"Authorization": f"Bearer {owner_token}"},
+    )
+    assert res.status_code == 403
+    assert res.json()["detail"] == "Only the applicant can withdraw this application"
+
+
+def test_cannot_withdraw_non_pending_application(
+    client: TestClient, register_and_login, test_project
+):
+    pid = test_project["id"]
+    owner_token = test_project["token"]
+    _, applicant_token = register_and_login(
+        "nonpending_withdraw@example.com", "npwithdraw"
+    )
+
+    created = client.post(
+        "/api/applications/",
+        json={"project_id": str(pid), "flare_id": str(test_project["flare_id"])},
+        headers={"Authorization": f"Bearer {applicant_token}"},
+    )
+    assert created.status_code == 201
+    app_id = created.json()["id"]
+
+    accepted = client.patch(
+        f"/api/applications/{app_id}/accept",
+        headers={"Authorization": f"Bearer {owner_token}"},
+    )
+    assert accepted.status_code == 200
+
+    res = client.patch(
+        f"/api/applications/{app_id}/withdraw",
+        headers={"Authorization": f"Bearer {applicant_token}"},
+    )
+    assert res.status_code == 400
+    assert res.json()["detail"] == "Only pending applications can be withdrawn"
+
+
 def test_create_application_unauthenticated(client: TestClient, test_project):
     pid = test_project["id"]
     res = client.post(


### PR DESCRIPTION
## Summary
- Applicants can withdraw only their own pending applications.
- Non-pending applications cannot be withdrawn.
- Project owners cannot withdraw an application on behalf of the applicant.

## Related Issue
Closes #1314

ECSoc 2026

## Type of Change
- [x] New feature
- [x] Tests

## Testing
- [x] Added tests for owner 403 and non-pending 400
- [ ] Tested locally
- [ ] Existing tests pass

```bash
cd backend && pytest tests/test_applications.py -v