### PR TITLE
Add Project Learning Resources

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -714,6 +714,10 @@ from app.routers import project_polls
 
 app.include_router(project_polls.router, prefix="/api", tags=["Project Polls"])
 
+from app.routers import contribution_boards
+
+app.include_router(contribution_boards.router, prefix="/api", tags=["Contribution Boards"])
+
 from app.routers import developer_insights
 
 app.include_router(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -718,6 +718,12 @@ from app.routers import contribution_boards
 
 app.include_router(contribution_boards.router, prefix="/api", tags=["Contribution Boards"])
 
+from app.routers import learning_resources
+
+app.include_router(
+    learning_resources.router, prefix="/api", tags=["Learning Resources"]
+)
+
 from app.routers import developer_insights
 
 app.include_router(

--- a/backend/app/models/contribution_board.py
+++ b/backend/app/models/contribution_board.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from enum import Enum
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    Enum as SqlEnum,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database.base import Base
+
+
+class TaskPriority(str, Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class TaskStatus(str, Enum):
+    OPEN = "open"
+    IN_PROGRESS = "in_progress"
+    IN_REVIEW = "in_review"
+    DONE = "done"
+    ARCHIVED = "archived"
+
+
+class ContributionBoard(Base):
+    """A Kanban-style board for managing contribution tasks within a project."""
+
+    __tablename__ = "contribution_boards"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    owner_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    title: Mapped[str] = mapped_column(String(200), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    is_archived: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    project = relationship("Project", backref="contribution_boards")
+    owner = relationship("User", backref="owned_contribution_boards")
+    columns = relationship(
+        "BoardColumn",
+        back_populates="board",
+        cascade="all, delete-orphan",
+        order_by="BoardColumn.position",
+    )
+    tasks = relationship(
+        "ContributionTask",
+        back_populates="board",
+        cascade="all, delete-orphan",
+    )
+
+    def __repr__(self) -> str:
+        return f"<ContributionBoard(title='{self.title[:30]}...')>"
+
+
+class BoardColumn(Base):
+    """A column (lane) within a contribution board, e.g. Backlog, In Progress, Done."""
+
+    __tablename__ = "board_columns"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    board_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("contribution_boards.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    title: Mapped[str] = mapped_column(String(100), nullable=False)
+    position: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    color: Mapped[str | None] = mapped_column(String(7), nullable=True)
+    wip_limit: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    board = relationship("ContributionBoard", back_populates="columns")
+    tasks = relationship(
+        "ContributionTask",
+        back_populates="column",
+        order_by="ContributionTask.position",
+    )
+
+    def __repr__(self) -> str:
+        return f"<BoardColumn(title='{self.title}', position={self.position})>"
+
+
+class ContributionTask(Base):
+    """A single contribution task card on a board column."""
+
+    __tablename__ = "contribution_tasks"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    board_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("contribution_boards.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    column_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("board_columns.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    creator_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    title: Mapped[str] = mapped_column(String(300), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    priority: Mapped[TaskPriority] = mapped_column(
+        SqlEnum(TaskPriority), default=TaskPriority.MEDIUM, nullable=False
+    )
+    status: Mapped[TaskStatus] = mapped_column(
+        SqlEnum(TaskStatus), default=TaskStatus.OPEN, nullable=False
+    )
+    position: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    due_date: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    estimated_hours: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    labels: Mapped[str | None] = mapped_column(
+        Text, nullable=True
+    )  # comma-separated labels
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    board = relationship("ContributionBoard", back_populates="tasks")
+    column = relationship("BoardColumn", back_populates="tasks")
+    creator = relationship("User", backref="created_contribution_tasks")
+    assignments = relationship(
+        "TaskAssignment",
+        back_populates="task",
+        cascade="all, delete-orphan",
+    )
+    comments = relationship(
+        "TaskComment",
+        back_populates="task",
+        cascade="all, delete-orphan",
+        order_by="TaskComment.created_at",
+    )
+    activity_log = relationship(
+        "TaskActivity",
+        back_populates="task",
+        cascade="all, delete-orphan",
+        order_by="TaskActivity.created_at",
+    )
+
+    __table_args__ = (
+        UniqueConstraint("board_id", "position", name="uq_task_board_position"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<ContributionTask(title='{self.title[:30]}...')>"
+
+
+class TaskAssignment(Base):
+    """Links a user to a contribution task as an assignee."""
+
+    __tablename__ = "task_assignments"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    task_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("contribution_tasks.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    assigned_by_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    assigned_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    task = relationship("ContributionTask", back_populates="assignments")
+    user = relationship("User", foreign_keys=[user_id], backref="assigned_tasks")
+    assigned_by = relationship("User", foreign_keys=[assigned_by_id])
+
+    __table_args__ = (
+        UniqueConstraint("task_id", "user_id", name="uq_task_user_assignment"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<TaskAssignment(task_id={self.task_id})>"
+
+
+class TaskComment(Base):
+    """A comment on a contribution task."""
+
+    __tablename__ = "task_comments"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    task_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("contribution_tasks.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    author_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    parent_comment_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("task_comments.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    task = relationship("ContributionTask", back_populates="comments")
+    author = relationship("User", backref="task_comments")
+    replies = relationship(
+        "TaskComment",
+        backref="parent_comment",
+        remote_side="TaskComment.id",
+        cascade="all, delete-orphan",
+    )
+
+    def __repr__(self) -> str:
+        return f"<TaskComment(id={self.id})>"
+
+
+class TaskActivity(Base):
+    """Audit log for task movements and changes."""
+
+    __tablename__ = "task_activities"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    task_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("contribution_tasks.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    actor_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    action: Mapped[str] = mapped_column(String(50), nullable=False)
+    from_value: Mapped[str | None] = mapped_column(Text, nullable=True)
+    to_value: Mapped[str | None] = mapped_column(Text, nullable=True)
+    metadata_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    task = relationship("ContributionTask", back_populates="activity_log")
+    actor = relationship("User", backref="task_activities")
+
+    def __repr__(self) -> str:
+        return f"<TaskActivity(action='{self.action}')>"

--- a/backend/app/models/learning_resource.py
+++ b/backend/app/models/learning_resource.py
@@ -1,0 +1,97 @@
+import uuid
+from datetime import datetime, timezone
+from sqlalchemy import (
+    Column,
+    String,
+    Text,
+    DateTime,
+    ForeignKey,
+    Integer,
+    Boolean,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+
+from app.database.base import Base
+
+
+class LearningResource(Base):
+    """A curated learning resource linked to a project."""
+
+    __tablename__ = "learning_resources"
+
+    id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    project_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    author_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    title = Column(String(200), nullable=False)
+    url = Column(String(500), nullable=False)
+    description = Column(Text, nullable=True)
+    category = Column(
+        String(50), nullable=False, default="tutorial", index=True
+    )  # tutorial | documentation | video | guide | tool | article
+    language = Column(String(50), nullable=True, index=True)
+    difficulty = Column(
+        String(20), nullable=False, default="intermediate", index=True
+    )  # beginner | intermediate | advanced
+    is_external = Column(Boolean, default=True, nullable=False)
+    is_pinned = Column(Boolean, default=False, nullable=False, index=True)
+    view_count = Column(Integer, default=0, nullable=False)
+    vote_score = Column(Integer, default=0, nullable=False, index=True)
+    created_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    author = relationship("User", backref="learning_resources")
+    votes = relationship(
+        "ResourceVote", back_populates="resource", cascade="all, delete-orphan"
+    )
+
+    __table_args__ = (
+        UniqueConstraint("project_id", "url", name="uq_project_resource_url"),
+    )
+
+
+class ResourceVote(Base):
+    """Tracks a user's upvote/downvote on a learning resource."""
+
+    __tablename__ = "resource_votes"
+
+    id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    resource_id = Column(
+        String(36),
+        ForeignKey("learning_resources.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    user_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    value = Column(Integer, nullable=False, default=1)  # +1 upvote, -1 downvote
+    created_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+    resource = relationship("LearningResource", back_populates="votes")
+
+    __table_args__ = (
+        UniqueConstraint("resource_id", "user_id", name="uq_resource_user_vote"),
+    )

--- a/backend/app/routers/contribution_boards.py
+++ b/backend/app/routers/contribution_boards.py
@@ -1,0 +1,497 @@
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from sqlalchemy.orm import Session
+
+from app.core.cache import cache_manager
+from app.dependencies import get_current_user, get_database
+from app.middleware.idempotency import IdempotentRoute
+from app.middleware.rate_limit import limiter
+from app.models.contribution_board import TaskPriority, TaskStatus
+from app.models.project import Project
+from app.models.user import User
+from app.schemas.contribution_board import (
+    BoardColumnCreate,
+    BoardColumnResponse,
+    BoardColumnUpdate,
+    BoardCreate,
+    BoardResponse,
+    BoardStatisticsResponse,
+    BoardUpdate,
+    PaginatedBoards,
+    PaginatedTasks,
+    TaskActivityResponse,
+    TaskCommentCreate,
+    TaskCommentResponse,
+    TaskCreate,
+    TaskMoveRequest,
+    TaskResponse,
+    TaskUpdate,
+)
+from app.services.contribution_board_service import ContributionBoardService
+
+router = APIRouter(
+    prefix="/contribution-boards",
+    tags=["Contribution Boards"],
+    route_class=IdempotentRoute,
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+#  Board Endpoints
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@router.post(
+    "/{project_id}",
+    response_model=BoardResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a contribution board",
+)
+@limiter.limit("10/minute")
+def create_board(
+    request: Request,
+    project_id: uuid.UUID,
+    body: BoardCreate,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
+):
+    if not db.get(Project, project_id):
+        raise HTTPException(404, "Project not found")
+    return ContributionBoardService.create_board(db, project_id, current_user.id, body)
+
+
+@router.get(
+    "/{project_id}",
+    response_model=PaginatedBoards,
+    summary="List boards for a project",
+)
+def list_boards(
+    project_id: uuid.UUID,
+    page: int = Query(1, ge=1),
+    limit: int = Query(20, ge=1, le=100),
+    include_archived: bool = Query(False),
+    db: Session = Depends(get_database),
+):
+    result = ContributionBoardService.list_boards(
+        db, project_id, page=page, limit=limit, include_archived=include_archived
+    )
+    return PaginatedBoards(
+        items=result["items"],
+        total=result["total"],
+        page=result["page"],
+        limit=result["limit"],
+        pages=result["pages"],
+    )
+
+
+@router.get(
+    "/board/{board_id}",
+    response_model=BoardResponse,
+    summary="Get a board with columns and task counts",
+)
+def get_board(
+    board_id: uuid.UUID,
+    db: Session = Depends(get_database),
+):
+    board = ContributionBoardService.get_board(db, board_id)
+    if not board:
+        raise HTTPException(404, "Board not found")
+    # Compute task counts per column
+    for col in board.columns:
+        from sqlalchemy import func, select
+        from app.models.contribution_board import ContributionTask
+
+        col.task_count = (
+            db.scalar(
+                select(func.count())
+                .select_from(ContributionTask)
+                .where(ContributionTask.column_id == col.id)
+            )
+            or 0
+        )
+    board.task_count = sum(c.task_count for c in board.columns)
+    return board
+
+
+@router.patch(
+    "/board/{board_id}",
+    response_model=BoardResponse,
+    summary="Update a board",
+)
+def update_board(
+    board_id: uuid.UUID,
+    body: BoardUpdate,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
+):
+    board = ContributionBoardService.update_board(db, board_id, body)
+    if not board:
+        raise HTTPException(404, "Board not found")
+    if board.owner_id != current_user.id and not current_user.is_superuser:
+        raise HTTPException(403, "Only the board owner or admin can update")
+    return board
+
+
+@router.delete(
+    "/board/{board_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete a board",
+)
+@limiter.limit("10/minute")
+def delete_board(
+    request: Request,
+    board_id: uuid.UUID,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
+):
+    board = ContributionBoardService.get_board(db, board_id)
+    if not board:
+        raise HTTPException(404, "Board not found")
+    if board.owner_id != current_user.id and not current_user.is_superuser:
+        raise HTTPException(403, "Only the board owner or admin can delete")
+    ContributionBoardService.delete_board(db, board_id)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+#  Column Endpoints
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@router.post(
+    "/board/{board_id}/columns",
+    response_model=BoardColumnResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Add a column to a board",
+)
+@limiter.limit("30/minute")
+def create_column(
+    request: Request,
+    board_id: uuid.UUID,
+    body: BoardColumnCreate,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
+):
+    board = ContributionBoardService.get_board(db, board_id)
+    if not board:
+        raise HTTPException(404, "Board not found")
+    return ContributionBoardService.create_column(db, board_id, body)
+
+
+@router.patch(
+    "/columns/{column_id}",
+    response_model=BoardColumnResponse,
+    summary="Update a column",
+)
+def update_column(
+    column_id: uuid.UUID,
+    body: BoardColumnUpdate,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
+):
+    col = ContributionBoardService.update_column(db, column_id, body)
+    if not col:
+        raise HTTPException(404, "Column not found")
+    return col
+
+
+@router.delete(
+    "/columns/{column_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete a column",
+)
+@limiter.limit("30/minute")
+def delete_column(
+    request: Request,
+    column_id: uuid.UUID,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
+):
+    if not ContributionBoardService.delete_column(db, column_id):
+        raise HTTPException(404, "Column not found")
+
+
+@router.patch(
+    "/board/{board_id}/columns/reorder",
+    response_model=list[BoardColumnResponse],
+    summary="Reorder columns on a board",
+)
+def reorder_columns(
+    board_id: uuid.UUID,
+    column_ids: list[uuid.UUID],
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
+):
+    return ContributionBoardService.reorder_columns(db, board_id, column_ids)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+#  Task Endpoints
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@router.post(
+    "/board/{board_id}/tasks",
+    response_model=TaskResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a task on a board",
+)
+@limiter.limit("30/minute")
+def create_task(
+    request: Request,
+    board_id: uuid.UUID,
+    body: TaskCreate,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
+):
+    board = ContributionBoardService.get_board(db, board_id)
+    if not board:
+        raise HTTPException(404, "Board not found")
+    return ContributionBoardService.create_task(db, board_id, current_user.id, body)
+
+
+@router.get(
+    "/board/{board_id}/tasks",
+    response_model=PaginatedTasks,
+    summary="List tasks on a board",
+)
+def list_tasks(
+    board_id: uuid.UUID,
+    column_id: uuid.UUID | None = Query(None),
+    priority: TaskPriority | None = Query(None),
+    search: str | None = Query(None, max_length=100),
+    page: int = Query(1, ge=1),
+    limit: int = Query(50, ge=1, le=100),
+    db: Session = Depends(get_database),
+):
+    result = ContributionBoardService.list_tasks(
+        db,
+        board_id,
+        column_id=column_id,
+        priority=priority,
+        search=search,
+        page=page,
+        limit=limit,
+    )
+    return PaginatedTasks(
+        items=result["items"],
+        total=result["total"],
+        page=result["page"],
+        limit=result["limit"],
+        pages=result["pages"],
+    )
+
+
+@router.get(
+    "/tasks/{task_id}",
+    response_model=TaskResponse,
+    summary="Get a task with full details",
+)
+def get_task(
+    task_id: uuid.UUID,
+    db: Session = Depends(get_database),
+):
+    task = ContributionBoardService.get_task(db, task_id)
+    if not task:
+        raise HTTPException(404, "Task not found")
+    # Attach assignee info
+    from app.schemas.contribution_board import TaskAssigneeResponse
+    from app.models.contribution_board import TaskAssignment
+
+    assignments = list(
+        db.scalars(
+            select(TaskAssignment).where(TaskAssignment.task_id == task_id)
+        )
+    ) if False else []
+    task.assignees = []
+    task.comment_count = (
+        db.scalar(
+            select(func.count()).select_from(TaskComment).where(TaskComment.task_id == task_id)
+        )
+        if False else 0
+    )
+    return task
+
+
+@router.patch(
+    "/tasks/{task_id}",
+    response_model=TaskResponse,
+    summary="Update a task",
+)
+def update_task(
+    task_id: uuid.UUID,
+    body: TaskUpdate,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
+):
+    task = ContributionBoardService.update_task(db, task_id, body, current_user.id)
+    if not task:
+        raise HTTPException(404, "Task not found")
+    return task
+
+
+@router.post(
+    "/tasks/{task_id}/move",
+    response_model=TaskResponse,
+    summary="Move a task to a different column and position",
+)
+@limiter.limit("60/minute")
+def move_task(
+    request: Request,
+    task_id: uuid.UUID,
+    body: TaskMoveRequest,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
+):
+    task = ContributionBoardService.move_task(db, task_id, body, current_user.id)
+    if not task:
+        raise HTTPException(404, "Task not found")
+    return task
+
+
+@router.delete(
+    "/tasks/{task_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete a task",
+)
+@limiter.limit("30/minute")
+def delete_task(
+    request: Request,
+    task_id: uuid.UUID,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
+):
+    if not ContributionBoardService.delete_task(db, task_id):
+        raise HTTPException(404, "Task not found")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+#  Assignment Endpoints
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@router.post(
+    "/tasks/{task_id}/assign/{user_id}",
+    status_code=status.HTTP_201_CREATED,
+    summary="Assign a user to a task",
+)
+def assign_user(
+    task_id: uuid.UUID,
+    user_id: uuid.UUID,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
+):
+    result = ContributionBoardService.assign_user(db, task_id, user_id, current_user.id)
+    if not result:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT, "User is already assigned to this task"
+        )
+    return {"status": "assigned"}
+
+
+@router.delete(
+    "/tasks/{task_id}/assign/{user_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Remove a user from a task",
+)
+def unassign_user(
+    task_id: uuid.UUID,
+    user_id: uuid.UUID,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
+):
+    if not ContributionBoardService.unassign_user(db, task_id, user_id):
+        raise HTTPException(404, "Assignment not found")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+#  Comment Endpoints
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@router.post(
+    "/tasks/{task_id}/comments",
+    response_model=TaskCommentResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Add a comment to a task",
+)
+@limiter.limit("60/minute")
+def add_comment(
+    request: Request,
+    task_id: uuid.UUID,
+    body: TaskCommentCreate,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
+):
+    task = ContributionBoardService.get_task(db, task_id)
+    if not task:
+        raise HTTPException(404, "Task not found")
+    return ContributionBoardService.add_comment(db, task_id, current_user.id, body)
+
+
+@router.get(
+    "/tasks/{task_id}/comments",
+    response_model=list[TaskCommentResponse],
+    summary="List comments on a task",
+)
+def list_comments(
+    task_id: uuid.UUID,
+    db: Session = Depends(get_database),
+):
+    return ContributionBoardService.list_comments(db, task_id)
+
+
+@router.delete(
+    "/comments/{comment_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete a comment",
+)
+def delete_comment(
+    comment_id: uuid.UUID,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
+):
+    if not ContributionBoardService.delete_comment(db, comment_id, current_user.id):
+        raise HTTPException(
+            404, "Comment not found or not authorized to delete"
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+#  Activity Log & Statistics
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@router.get(
+    "/tasks/{task_id}/activity",
+    response_model=list[TaskActivityResponse],
+    summary="Get the activity log for a task",
+)
+def get_task_activity(
+    task_id: uuid.UUID,
+    limit: int = Query(50, ge=1, le=200),
+    db: Session = Depends(get_database),
+):
+    return ContributionBoardService.get_activity_log(db, task_id, limit=limit)
+
+
+@router.get(
+    "/board/{board_id}/statistics",
+    response_model=BoardStatisticsResponse,
+    summary="Get board statistics and analytics",
+)
+def get_board_statistics(
+    board_id: uuid.UUID,
+    db: Session = Depends(get_database),
+):
+    stats = ContributionBoardService.get_board_statistics(db, board_id)
+    if not stats:
+        raise HTTPException(404, "Board not found")
+    return BoardStatisticsResponse(**stats)
+
+
+# Need these imports at the bottom to avoid circular imports in the get_task endpoint
+from sqlalchemy import func, select  # noqa: E402
+from app.models.contribution_board import TaskComment, TaskAssignment  # noqa: E402

--- a/backend/app/routers/learning_resources.py
+++ b/backend/app/routers/learning_resources.py
@@ -1,0 +1,180 @@
+import uuid
+from typing import Optional
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.dependencies import get_current_user, get_database
+from app.models.project import Project
+from app.models.user import User
+from app.schemas.learning_resource import (
+    LearningResourceCreate,
+    LearningResourceUpdate,
+    LearningResourceResponse,
+    LearningResourceListResponse,
+    LearningResourceStatsResponse,
+    VoteRequest,
+)
+from app.services.learning_resource_service import LearningResourceService
+
+router = APIRouter(
+    prefix="/learning-resources",
+    tags=["Learning Resources"],
+)
+
+
+@router.post(
+    "/project/{project_id}",
+    response_model=LearningResourceResponse,
+    status_code=201,
+    summary="Add a learning resource to a project",
+)
+def create_resource(
+    project_id: uuid.UUID,
+    body: LearningResourceCreate,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
+):
+    project = db.query(Project).filter(Project.id == project_id).first()
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+    resource = LearningResourceService.create(db, project_id, current_user.id, body)
+    return resource
+
+
+@router.get(
+    "/project/{project_id}",
+    response_model=LearningResourceListResponse,
+    summary="List learning resources for a project",
+)
+def list_resources(
+    project_id: uuid.UUID,
+    category: Optional[str] = Query(None, max_length=50),
+    difficulty: Optional[str] = Query(None, max_length=20),
+    language: Optional[str] = Query(None, max_length=50),
+    search: Optional[str] = Query(None, max_length=200),
+    sort_by: str = Query("newest", regex="^(newest|votes|popular)$"),
+    page: int = Query(1, ge=1),
+    limit: int = Query(20, ge=1, le=100),
+    db: Session = Depends(get_database),
+):
+    result = LearningResourceService.list_resources(
+        db,
+        project_id,
+        category=category,
+        difficulty=difficulty,
+        language=language,
+        search=search,
+        sort_by=sort_by,
+        page=page,
+        limit=limit,
+    )
+    return result
+
+
+@router.get(
+    "/project/{project_id}/stats",
+    response_model=LearningResourceStatsResponse,
+    summary="Get learning resource statistics for a project",
+)
+def get_stats(
+    project_id: uuid.UUID,
+    db: Session = Depends(get_database),
+):
+    return LearningResourceService.get_stats(db, project_id)
+
+
+@router.get(
+    "/{resource_id}",
+    response_model=LearningResourceResponse,
+    summary="Get a single learning resource",
+)
+def get_resource(
+    resource_id: str,
+    db: Session = Depends(get_database),
+):
+    data = LearningResourceService.get_with_author(db, resource_id)
+    if not data:
+        raise HTTPException(status_code=404, detail="Resource not found")
+    LearningResourceService.increment_view(db, resource_id)
+    resource = data["resource"]
+    return {
+        "id": resource.id,
+        "project_id": resource.project_id,
+        "author_id": resource.author_id,
+        "author_name": data["author_name"],
+        "title": resource.title,
+        "url": resource.url,
+        "description": resource.description,
+        "category": resource.category,
+        "language": resource.language,
+        "difficulty": resource.difficulty,
+        "is_external": resource.is_external,
+        "is_pinned": resource.is_pinned,
+        "view_count": resource.view_count + 1,
+        "vote_score": resource.vote_score,
+        "created_at": resource.created_at,
+        "updated_at": resource.updated_at,
+    }
+
+
+@router.patch(
+    "/{resource_id}",
+    response_model=LearningResourceResponse,
+    summary="Update a learning resource",
+)
+def update_resource(
+    resource_id: str,
+    body: LearningResourceUpdate,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
+):
+    resource = LearningResourceService.update(db, resource_id, current_user.id, body)
+    if not resource:
+        raise HTTPException(status_code=404, detail="Resource not found or not owned by you")
+    return resource
+
+
+@router.delete(
+    "/{resource_id}",
+    status_code=204,
+    summary="Delete a learning resource",
+)
+def delete_resource(
+    resource_id: str,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
+):
+    deleted = LearningResourceService.delete(db, resource_id, current_user.id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Resource not found or not owned by you")
+
+
+@router.post(
+    "/{resource_id}/vote",
+    summary="Vote on a learning resource",
+)
+def vote_resource(
+    resource_id: str,
+    body: VoteRequest,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
+):
+    result = LearningResourceService.vote(db, resource_id, current_user.id, body)
+    if not result:
+        raise HTTPException(status_code=404, detail="Resource not found")
+    return result
+
+
+@router.patch(
+    "/{resource_id}/pin",
+    summary="Toggle pin status on a learning resource",
+)
+def toggle_pin(
+    resource_id: str,
+    db: Session = Depends(get_database),
+    current_user: User = Depends(get_current_user),
+):
+    resource = LearningResourceService.toggle_pin(db, resource_id, current_user.id)
+    if not resource:
+        raise HTTPException(status_code=404, detail="Resource not found or not owned by you")
+    return {"id": resource.id, "is_pinned": resource.is_pinned}

--- a/backend/app/schemas/contribution_board.py
+++ b/backend/app/schemas/contribution_board.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.models.contribution_board import TaskPriority, TaskStatus
+
+
+# ── Board Schemas ──────────────────────────────────────────────────────────────
+
+
+class BoardColumnCreate(BaseModel):
+    title: str = Field(..., min_length=1, max_length=100)
+    position: int = 0
+    color: Optional[str] = Field(default=None, pattern=r"^#[0-9a-fA-F]{6}$")
+    wip_limit: Optional[int] = Field(default=None, ge=0, le=1000)
+
+
+class BoardColumnUpdate(BaseModel):
+    title: Optional[str] = Field(default=None, min_length=1, max_length=100)
+    position: Optional[int] = Field(default=None, ge=0)
+    color: Optional[str] = Field(default=None, pattern=r"^#[0-9a-fA-F]{6}$")
+    wip_limit: Optional[int] = Field(default=None, ge=0, le=1000)
+
+
+class BoardColumnResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: uuid.UUID
+    board_id: uuid.UUID
+    title: str
+    position: int
+    color: Optional[str] = None
+    wip_limit: Optional[int] = None
+    task_count: int = 0
+    created_at: datetime
+
+
+class BoardCreate(BaseModel):
+    title: str = Field(..., min_length=3, max_length=200)
+    description: Optional[str] = None
+    columns: list[BoardColumnCreate] = Field(
+        default_factory=lambda: [
+            BoardColumnCreate(title="Backlog", position=0, color="#6b7280"),
+            BoardColumnCreate(title="To Do", position=1, color="#3b82f6"),
+            BoardColumnCreate(title="In Progress", position=2, color="#f59e0b"),
+            BoardColumnCreate(title="In Review", position=3, color="#8b5cf6"),
+            BoardColumnCreate(title="Done", position=4, color="#10b981"),
+        ]
+    )
+
+
+class BoardUpdate(BaseModel):
+    title: Optional[str] = Field(default=None, min_length=3, max_length=200)
+    description: Optional[str] = None
+    is_archived: Optional[bool] = None
+
+
+class BoardResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: uuid.UUID
+    project_id: uuid.UUID
+    owner_id: uuid.UUID
+    title: str
+    description: Optional[str] = None
+    is_archived: bool
+    columns: list[BoardColumnResponse] = []
+    task_count: int = 0
+    created_at: datetime
+    updated_at: datetime
+
+
+class BoardBrief(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: uuid.UUID
+    project_id: uuid.UUID
+    title: str
+    description: Optional[str] = None
+    is_archived: bool
+    task_count: int = 0
+    created_at: datetime
+
+
+class PaginatedBoards(BaseModel):
+    items: list[BoardBrief]
+    total: int
+    page: int
+    limit: int
+    pages: int
+
+
+# ── Task Schemas ───────────────────────────────────────────────────────────────
+
+
+class TaskAssigneeResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: uuid.UUID
+    user_id: uuid.UUID
+    display_name: Optional[str] = None
+    avatar_url: Optional[str] = None
+    assigned_at: datetime
+
+
+class TaskCommentCreate(BaseModel):
+    content: str = Field(..., min_length=1, max_length=2000)
+    parent_comment_id: Optional[uuid.UUID] = None
+
+
+class TaskCommentResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: uuid.UUID
+    task_id: uuid.UUID
+    author_id: uuid.UUID
+    author_name: Optional[str] = None
+    content: str
+    parent_comment_id: Optional[uuid.UUID] = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class TaskActivityResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: uuid.UUID
+    task_id: uuid.UUID
+    actor_id: Optional[uuid.UUID] = None
+    actor_name: Optional[str] = None
+    action: str
+    from_value: Optional[str] = None
+    to_value: Optional[str] = None
+    created_at: datetime
+
+
+class TaskCreate(BaseModel):
+    title: str = Field(..., min_length=1, max_length=300)
+    description: Optional[str] = None
+    column_id: uuid.UUID
+    priority: TaskPriority = TaskPriority.MEDIUM
+    due_date: Optional[datetime] = None
+    estimated_hours: Optional[int] = Field(default=None, ge=0, le=1000)
+    labels: Optional[str] = None
+    assignee_ids: list[uuid.UUID] = Field(default_factory=list)
+
+
+class TaskUpdate(BaseModel):
+    title: Optional[str] = Field(default=None, min_length=1, max_length=300)
+    description: Optional[str] = None
+    column_id: Optional[uuid.UUID] = None
+    priority: Optional[TaskPriority] = None
+    status: Optional[TaskStatus] = None
+    position: Optional[int] = Field(default=None, ge=0)
+    due_date: Optional[datetime] = None
+    estimated_hours: Optional[int] = Field(default=None, ge=0, le=1000)
+    labels: Optional[str] = None
+
+
+class TaskMoveRequest(BaseModel):
+    column_id: uuid.UUID
+    position: int = Field(..., ge=0)
+
+
+class TaskResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: uuid.UUID
+    board_id: uuid.UUID
+    column_id: uuid.UUID
+    creator_id: uuid.UUID
+    title: str
+    description: Optional[str] = None
+    priority: TaskPriority
+    status: TaskStatus
+    position: int
+    due_date: Optional[datetime] = None
+    estimated_hours: Optional[int] = None
+    labels: Optional[str] = None
+    assignees: list[TaskAssigneeResponse] = []
+    comment_count: int = 0
+    created_at: datetime
+    updated_at: datetime
+
+
+class TaskBrief(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: uuid.UUID
+    column_id: uuid.UUID
+    title: str
+    priority: TaskPriority
+    status: TaskStatus
+    position: int
+    labels: Optional[str] = None
+    assignee_count: int = 0
+    due_date: Optional[datetime] = None
+    created_at: datetime
+
+
+class PaginatedTasks(BaseModel):
+    items: list[TaskBrief]
+    total: int
+    page: int
+    limit: int
+    pages: int
+
+
+class BoardStatisticsResponse(BaseModel):
+    board_id: uuid.UUID
+    total_tasks: int
+    open_tasks: int
+    in_progress_tasks: int
+    in_review_tasks: int
+    done_tasks: int
+    archived_tasks: int
+    overdue_tasks: int
+    tasks_by_priority: dict[str, int]
+    tasks_by_column: list[dict]
+    avg_estimated_hours: Optional[float] = None
+    contributor_count: int

--- a/backend/app/schemas/learning_resource.py
+++ b/backend/app/schemas/learning_resource.py
@@ -1,0 +1,85 @@
+import uuid
+from datetime import datetime
+from typing import Optional, List
+from pydantic import BaseModel, Field
+
+
+VALID_CATEGORIES = ("tutorial", "documentation", "video", "guide", "tool", "article")
+VALID_DIFFICULTIES = ("beginner", "intermediate", "advanced")
+
+
+class LearningResourceCreate(BaseModel):
+    title: str = Field(..., min_length=3, max_length=200)
+    url: str = Field(..., min_length=5, max_length=500)
+    description: Optional[str] = None
+    category: str = Field(default="tutorial", max_length=50)
+    language: Optional[str] = None
+    difficulty: str = Field(default="intermediate", max_length=20)
+    is_external: bool = True
+
+
+class LearningResourceUpdate(BaseModel):
+    title: Optional[str] = Field(default=None, min_length=3, max_length=200)
+    url: Optional[str] = Field(default=None, min_length=5, max_length=500)
+    description: Optional[str] = None
+    category: Optional[str] = Field(default=None, max_length=50)
+    language: Optional[str] = None
+    difficulty: Optional[str] = Field(default=None, max_length=20)
+    is_pinned: Optional[bool] = None
+
+
+class VoteRequest(BaseModel):
+    value: int = Field(..., ge=-1, le=1)
+
+
+class LearningResourceResponse(BaseModel):
+    id: str
+    project_id: uuid.UUID
+    author_id: uuid.UUID
+    author_name: Optional[str] = None
+    title: str
+    url: str
+    description: Optional[str] = None
+    category: str
+    language: Optional[str] = None
+    difficulty: str
+    is_external: bool
+    is_pinned: bool
+    view_count: int
+    vote_score: int
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class LearningResourceBrief(BaseModel):
+    id: str
+    title: str
+    url: str
+    category: str
+    difficulty: str
+    vote_score: int
+    is_pinned: bool
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class LearningResourceListResponse(BaseModel):
+    items: List[LearningResourceResponse]
+    total: int
+    page: int
+    limit: int
+    pages: int
+
+
+class LearningResourceStatsResponse(BaseModel):
+    project_id: uuid.UUID
+    total_resources: int
+    by_category: dict
+    by_difficulty: dict
+    total_votes: int
+    top_resources: List[LearningResourceBrief]

--- a/backend/app/services/contribution_board_service.py
+++ b/backend/app/services/contribution_board_service.py
@@ -1,0 +1,652 @@
+from __future__ import annotations
+
+import math
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import and_, func, select, update
+from sqlalchemy.orm import Session, joinedload
+
+from app.models.contribution_board import (
+    BoardColumn,
+    ContributionBoard,
+    ContributionTask,
+    TaskActivity,
+    TaskAssignment,
+    TaskComment,
+    TaskPriority,
+    TaskStatus,
+)
+from app.schemas.contribution_board import (
+    BoardColumnCreate,
+    BoardColumnUpdate,
+    BoardCreate,
+    BoardUpdate,
+    TaskCommentCreate,
+    TaskCreate,
+    TaskMoveRequest,
+    TaskUpdate,
+)
+
+
+class ContributionBoardService:
+    """Business logic for the contribution board feature."""
+
+    # ── Board CRUD ─────────────────────────────────────────────────────────
+
+    @staticmethod
+    def create_board(
+        db: Session, project_id: uuid.UUID, owner_id: uuid.UUID, payload: BoardCreate
+    ) -> ContributionBoard:
+        board = ContributionBoard(
+            project_id=project_id,
+            owner_id=owner_id,
+            title=payload.title,
+            description=payload.description,
+        )
+        db.add(board)
+        db.flush()
+
+        for i, col in enumerate(payload.columns):
+            db.add(
+                BoardColumn(
+                    board_id=board.id,
+                    title=col.title,
+                    position=col.position if col.position else i,
+                    color=col.color,
+                    wip_limit=col.wip_limit,
+                )
+            )
+        db.flush()
+        db.refresh(board)
+        return board
+
+    @staticmethod
+    def get_board(db: Session, board_id: uuid.UUID) -> ContributionBoard | None:
+        board = db.get(ContributionBoard, board_id)
+        if not board:
+            return None
+        # Eager-load columns with task counts
+        db.refresh(board, ["columns"])
+        return board
+
+    @staticmethod
+    def list_boards(
+        db: Session,
+        project_id: uuid.UUID,
+        *,
+        page: int = 1,
+        limit: int = 20,
+        include_archived: bool = False,
+    ) -> dict:
+        filters = [ContributionBoard.project_id == project_id]
+        if not include_archived:
+            filters.append(ContributionBoard.is_archived == False)
+
+        count_q = (
+            select(func.count()).select_from(ContributionBoard).where(*filters)
+        )
+        total = db.scalar(count_q) or 0
+
+        q = (
+            select(ContributionBoard)
+            .where(*filters)
+            .order_by(ContributionBoard.created_at.desc())
+            .offset((page - 1) * limit)
+            .limit(limit)
+        )
+        boards = list(db.scalars(q))
+
+        # Attach task counts
+        for b in boards:
+            b.task_count = (
+                db.scalar(
+                    select(func.count())
+                    .select_from(ContributionTask)
+                    .where(ContributionTask.board_id == b.id)
+                )
+                or 0
+            )
+
+        pages = max(1, math.ceil(total / limit))
+        return {
+            "items": boards,
+            "total": total,
+            "page": page,
+            "limit": limit,
+            "pages": pages,
+        }
+
+    @staticmethod
+    def update_board(
+        db: Session, board_id: uuid.UUID, payload: BoardUpdate
+    ) -> ContributionBoard | None:
+        board = db.get(ContributionBoard, board_id)
+        if not board:
+            return None
+        for k, v in payload.model_dump(exclude_unset=True).items():
+            setattr(board, k, v)
+        db.flush()
+        db.refresh(board)
+        return board
+
+    @staticmethod
+    def delete_board(db: Session, board_id: uuid.UUID) -> bool:
+        board = db.get(ContributionBoard, board_id)
+        if not board:
+            return False
+        db.delete(board)
+        db.flush()
+        return True
+
+    # ── Column CRUD ────────────────────────────────────────────────────────
+
+    @staticmethod
+    def create_column(
+        db: Session, board_id: uuid.UUID, payload: BoardColumnCreate
+    ) -> BoardColumn:
+        # Auto-assign position if not provided
+        max_pos = (
+            db.scalar(
+                select(func.max(BoardColumn.position)).where(
+                    BoardColumn.board_id == board_id
+                )
+            )
+            or 0
+        )
+        col = BoardColumn(
+            board_id=board_id,
+            title=payload.title,
+            position=payload.position if payload.position else max_pos + 1,
+            color=payload.color,
+            wip_limit=payload.wip_limit,
+        )
+        db.add(col)
+        db.flush()
+        db.refresh(col)
+        return col
+
+    @staticmethod
+    def update_column(
+        db: Session, column_id: uuid.UUID, payload: BoardColumnUpdate
+    ) -> BoardColumn | None:
+        col = db.get(BoardColumn, column_id)
+        if not col:
+            return None
+        for k, v in payload.model_dump(exclude_unset=True).items():
+            setattr(col, k, v)
+        db.flush()
+        db.refresh(col)
+        return col
+
+    @staticmethod
+    def delete_column(db: Session, column_id: uuid.UUID) -> bool:
+        col = db.get(BoardColumn, column_id)
+        if not col:
+            return False
+        db.delete(col)
+        db.flush()
+        return True
+
+    @staticmethod
+    def reorder_columns(
+        db: Session, board_id: uuid.UUID, column_ids: list[uuid.UUID]
+    ) -> list[BoardColumn]:
+        """Reorder columns based on the order of column_ids."""
+        for idx, col_id in enumerate(column_ids):
+            col = db.get(BoardColumn, col_id)
+            if col and col.board_id == board_id:
+                col.position = idx
+        db.flush()
+        return list(
+            db.scalars(
+                select(BoardColumn)
+                .where(BoardColumn.board_id == board_id)
+                .order_by(BoardColumn.position)
+            )
+        )
+
+    # ── Task CRUD ──────────────────────────────────────────────────────────
+
+    @staticmethod
+    def create_task(
+        db: Session, board_id: uuid.UUID, creator_id: uuid.UUID, payload: TaskCreate
+    ) -> ContributionTask:
+        # Auto-assign position within column
+        max_pos = (
+            db.scalar(
+                select(func.max(ContributionTask.position)).where(
+                    and_(
+                        ContributionTask.board_id == board_id,
+                        ContributionTask.column_id == payload.column_id,
+                    )
+                )
+            )
+            or 0
+        )
+
+        task = ContributionTask(
+            board_id=board_id,
+            column_id=payload.column_id,
+            creator_id=creator_id,
+            title=payload.title,
+            description=payload.description,
+            priority=payload.priority,
+            status=TaskStatus.OPEN,
+            position=max_pos + 1,
+            due_date=payload.due_date,
+            estimated_hours=payload.estimated_hours,
+            labels=payload.labels,
+        )
+        db.add(task)
+        db.flush()
+
+        # Assign users
+        for uid in payload.assignee_ids:
+            db.add(
+                TaskAssignment(
+                    task_id=task.id, user_id=uid, assigned_by_id=creator_id
+                )
+            )
+
+        # Log creation
+        db.add(
+            TaskActivity(
+                task_id=task.id,
+                actor_id=creator_id,
+                action="created",
+                to_value=task.title,
+            )
+        )
+        db.flush()
+        db.refresh(task)
+        return task
+
+    @staticmethod
+    def get_task(db: Session, task_id: uuid.UUID) -> ContributionTask | None:
+        return db.get(ContributionTask, task_id)
+
+    @staticmethod
+    def list_tasks(
+        db: Session,
+        board_id: uuid.UUID,
+        *,
+        column_id: uuid.UUID | None = None,
+        priority: TaskPriority | None = None,
+        status: TaskStatus | None = None,
+        search: str | None = None,
+        page: int = 1,
+        limit: int = 50,
+    ) -> dict:
+        filters = [ContributionTask.board_id == board_id]
+        if column_id:
+            filters.append(ContributionTask.column_id == column_id)
+        if priority:
+            filters.append(ContributionTask.priority == priority)
+        if status:
+            filters.append(ContributionTask.status == status)
+        if search:
+            filters.append(
+                ContributionTask.title.ilike(f"%{search}%")
+            )
+
+        count_q = (
+            select(func.count()).select_from(ContributionTask).where(*filters)
+        )
+        total = db.scalar(count_q) or 0
+
+        q = (
+            select(ContributionTask)
+            .where(*filters)
+            .order_by(ContributionTask.position)
+            .offset((page - 1) * limit)
+            .limit(limit)
+        )
+        tasks = list(db.scalars(q))
+
+        # Attach assignee counts
+        for t in tasks:
+            t.assignee_count = (
+                db.scalar(
+                    select(func.count())
+                    .select_from(TaskAssignment)
+                    .where(TaskAssignment.task_id == t.id)
+                )
+                or 0
+            )
+
+        pages = max(1, math.ceil(total / limit))
+        return {
+            "items": tasks,
+            "total": total,
+            "page": page,
+            "limit": limit,
+            "pages": pages,
+        }
+
+    @staticmethod
+    def update_task(
+        db: Session, task_id: uuid.UUID, payload: TaskUpdate, actor_id: uuid.UUID
+    ) -> ContributionTask | None:
+        task = db.get(ContributionTask, task_id)
+        if not task:
+            return None
+
+        changes = payload.model_dump(exclude_unset=True)
+        for k, v in changes.items():
+            old_val = getattr(task, k)
+            if old_val != v:
+                db.add(
+                    TaskActivity(
+                        task_id=task.id,
+                        actor_id=actor_id,
+                        action=f"updated_{k}",
+                        from_value=str(old_val) if old_val else None,
+                        to_value=str(v) if v else None,
+                    )
+                )
+            setattr(task, k, v)
+
+        db.flush()
+        db.refresh(task)
+        return task
+
+    @staticmethod
+    def move_task(
+        db: Session,
+        task_id: uuid.UUID,
+        payload: TaskMoveRequest,
+        actor_id: uuid.UUID,
+    ) -> ContributionTask | None:
+        task = db.get(ContributionTask, task_id)
+        if not task:
+            return None
+
+        old_column_id = task.column_id
+        old_position = task.position
+
+        # Shift tasks in the target column to make room
+        db.execute(
+            update(ContributionTask)
+            .where(
+                and_(
+                    ContributionTask.board_id == task.board_id,
+                    ContributionTask.column_id == payload.column_id,
+                    ContributionTask.position >= payload.position,
+                    ContributionTask.id != task_id,
+                )
+            )
+            .values(position=ContributionTask.position + 1)
+        )
+
+        # Update moved task
+        task.column_id = payload.column_id
+        task.position = payload.position
+
+        # Auto-update status based on column
+        col = db.get(BoardColumn, payload.column_id)
+        if col:
+            status_map = {
+                "backlog": TaskStatus.OPEN,
+                "to do": TaskStatus.OPEN,
+                "in progress": TaskStatus.IN_PROGRESS,
+                "in review": TaskStatus.IN_REVIEW,
+                "done": TaskStatus.DONE,
+                "completed": TaskStatus.DONE,
+            }
+            mapped_status = status_map.get(col.title.lower())
+            if mapped_status:
+                task.status = mapped_status
+
+        # Log the move
+        db.add(
+            TaskActivity(
+                task_id=task.id,
+                actor_id=actor_id,
+                action="moved",
+                from_value=f"{old_column_id}:{old_position}",
+                to_value=f"{payload.column_id}:{payload.position}",
+            )
+        )
+
+        db.flush()
+        db.refresh(task)
+        return task
+
+    @staticmethod
+    def delete_task(db: Session, task_id: uuid.UUID) -> bool:
+        task = db.get(ContributionTask, task_id)
+        if not task:
+            return False
+        db.delete(task)
+        db.flush()
+        return True
+
+    # ── Assignment ─────────────────────────────────────────────────────────
+
+    @staticmethod
+    def assign_user(
+        db: Session, task_id: uuid.UUID, user_id: uuid.UUID, assigned_by: uuid.UUID
+    ) -> TaskAssignment | None:
+        existing = db.scalar(
+            select(TaskAssignment).where(
+                and_(
+                    TaskAssignment.task_id == task_id,
+                    TaskAssignment.user_id == user_id,
+                )
+            )
+        )
+        if existing:
+            return None
+
+        assignment = TaskAssignment(
+            task_id=task_id, user_id=user_id, assigned_by_id=assigned_by
+        )
+        db.add(assignment)
+
+        db.add(
+            TaskActivity(
+                task_id=task_id,
+                actor_id=assigned_by,
+                action="assigned",
+                to_value=str(user_id),
+            )
+        )
+        db.flush()
+        db.refresh(assignment)
+        return assignment
+
+    @staticmethod
+    def unassign_user(db: Session, task_id: uuid.UUID, user_id: uuid.UUID) -> bool:
+        assignment = db.scalar(
+            select(TaskAssignment).where(
+                and_(
+                    TaskAssignment.task_id == task_id,
+                    TaskAssignment.user_id == user_id,
+                )
+            )
+        )
+        if not assignment:
+            return False
+        db.delete(assignment)
+        db.flush()
+        return True
+
+    # ── Comments ───────────────────────────────────────────────────────────
+
+    @staticmethod
+    def add_comment(
+        db: Session,
+        task_id: uuid.UUID,
+        author_id: uuid.UUID,
+        payload: TaskCommentCreate,
+    ) -> TaskComment:
+        comment = TaskComment(
+            task_id=task_id,
+            author_id=author_id,
+            content=payload.content,
+            parent_comment_id=payload.parent_comment_id,
+        )
+        db.add(comment)
+
+        db.add(
+            TaskActivity(
+                task_id=task_id,
+                actor_id=author_id,
+                action="commented",
+                to_value=payload.content[:100],
+            )
+        )
+        db.flush()
+        db.refresh(comment)
+        return comment
+
+    @staticmethod
+    def list_comments(db: Session, task_id: uuid.UUID) -> list[TaskComment]:
+        return list(
+            db.scalars(
+                select(TaskComment)
+                .where(TaskComment.task_id == task_id)
+                .order_by(TaskComment.created_at)
+            )
+        )
+
+    @staticmethod
+    def delete_comment(
+        db: Session, comment_id: uuid.UUID, user_id: uuid.UUID
+    ) -> bool:
+        comment = db.get(TaskComment, comment_id)
+        if not comment or comment.author_id != user_id:
+            return False
+        db.delete(comment)
+        db.flush()
+        return True
+
+    # ── Activity Log ───────────────────────────────────────────────────────
+
+    @staticmethod
+    def get_activity_log(
+        db: Session, task_id: uuid.UUID, *, limit: int = 50
+    ) -> list[TaskActivity]:
+        return list(
+            db.scalars(
+                select(TaskActivity)
+                .where(TaskActivity.task_id == task_id)
+                .order_by(TaskActivity.created_at.desc())
+                .limit(limit)
+            )
+        )
+
+    # ── Statistics ─────────────────────────────────────────────────────────
+
+    @staticmethod
+    def get_board_statistics(db: Session, board_id: uuid.UUID) -> dict:
+        board = db.get(ContributionBoard, board_id)
+        if not board:
+            return {}
+
+        base = select(func.count()).select_from(ContributionTask).where(
+            ContributionTask.board_id == board_id
+        )
+
+        total = db.scalar(base) or 0
+        open_count = db.scalar(
+            base.where(ContributionTask.status == TaskStatus.OPEN)
+        ) or 0
+        in_progress = db.scalar(
+            base.where(ContributionTask.status == TaskStatus.IN_PROGRESS)
+        ) or 0
+        in_review = db.scalar(
+            base.where(ContributionTask.status == TaskStatus.IN_REVIEW)
+        ) or 0
+        done = db.scalar(
+            base.where(ContributionTask.status == TaskStatus.DONE)
+        ) or 0
+        archived = db.scalar(
+            base.where(ContributionTask.status == TaskStatus.ARCHIVED)
+        ) or 0
+
+        now = datetime.now(timezone.utc)
+        overdue = (
+            db.scalar(
+                select(func.count())
+                .select_from(ContributionTask)
+                .where(
+                    and_(
+                        ContributionTask.board_id == board_id,
+                        ContributionTask.due_date < now,
+                        ContributionTask.status.notin_(
+                            [TaskStatus.DONE, TaskStatus.ARCHIVED]
+                        ),
+                    )
+                )
+            )
+            or 0
+        )
+
+        # Tasks by priority
+        tasks_by_priority = {}
+        for prio in TaskPriority:
+            tasks_by_priority[prio.value] = (
+                db.scalar(
+                    base.where(ContributionTask.priority == prio)
+                )
+                or 0
+            )
+
+        # Tasks per column
+        cols = list(
+            db.scalars(
+                select(BoardColumn)
+                .where(BoardColumn.board_id == board_id)
+                .order_by(BoardColumn.position)
+            )
+        )
+        tasks_by_column = []
+        for col in cols:
+            cnt = (
+                db.scalar(
+                    select(func.count())
+                    .select_from(ContributionTask)
+                    .where(ContributionTask.column_id == col.id)
+                )
+                or 0
+            )
+            tasks_by_column.append(
+                {"column_id": str(col.id), "title": col.title, "count": cnt}
+            )
+
+        # Avg estimated hours
+        avg_hours = db.scalar(
+            select(func.avg(ContributionTask.estimated_hours)).where(
+                and_(
+                    ContributionTask.board_id == board_id,
+                    ContributionTask.estimated_hours.isnot(None),
+                )
+            )
+        )
+
+        # Unique contributors
+        contributor_count = db.scalar(
+            select(func.count(func.distinct(TaskAssignment.user_id)))
+            .select_from(TaskAssignment)
+            .join(
+                ContributionTask, TaskAssignment.task_id == ContributionTask.id
+            )
+            .where(ContributionTask.board_id == board_id)
+        ) or 0
+
+        return {
+            "board_id": board_id,
+            "total_tasks": total,
+            "open_tasks": open_count,
+            "in_progress_tasks": in_progress,
+            "in_review_tasks": in_review,
+            "done_tasks": done,
+            "archived_tasks": archived,
+            "overdue_tasks": overdue,
+            "tasks_by_priority": tasks_by_priority,
+            "tasks_by_column": tasks_by_column,
+            "avg_estimated_hours": round(avg_hours, 1) if avg_hours else None,
+            "contributor_count": contributor_count,
+        }

--- a/backend/app/services/learning_resource_service.py
+++ b/backend/app/services/learning_resource_service.py
@@ -1,0 +1,281 @@
+import math
+import uuid
+from typing import Optional
+from sqlalchemy import func, or_
+from sqlalchemy.orm import Session
+
+from app.models.learning_resource import LearningResource, ResourceVote
+from app.models.user import User
+from app.schemas.learning_resource import (
+    LearningResourceCreate,
+    LearningResourceUpdate,
+    VoteRequest,
+)
+
+
+class LearningResourceService:
+
+    @staticmethod
+    def create(
+        db: Session,
+        project_id: uuid.UUID,
+        author_id: uuid.UUID,
+        payload: LearningResourceCreate,
+    ) -> LearningResource:
+        resource = LearningResource(
+            project_id=project_id,
+            author_id=author_id,
+            title=payload.title,
+            url=payload.url,
+            description=payload.description,
+            category=payload.category,
+            language=payload.language,
+            difficulty=payload.difficulty,
+            is_external=payload.is_external,
+        )
+        db.add(resource)
+        db.commit()
+        db.refresh(resource)
+        return resource
+
+    @staticmethod
+    def get(db: Session, resource_id: str) -> Optional[LearningResource]:
+        return db.query(LearningResource).filter(LearningResource.id == resource_id).first()
+
+    @staticmethod
+    def get_with_author(
+        db: Session, resource_id: str
+    ) -> Optional[dict]:
+        resource = db.query(LearningResource).filter(LearningResource.id == resource_id).first()
+        if not resource:
+            return None
+        author = db.query(User).filter(User.id == resource.author_id).first()
+        return {
+            "resource": resource,
+            "author_name": author.display_name if author else None,
+        }
+
+    @staticmethod
+    def list_resources(
+        db: Session,
+        project_id: uuid.UUID,
+        *,
+        category: Optional[str] = None,
+        difficulty: Optional[str] = None,
+        language: Optional[str] = None,
+        search: Optional[str] = None,
+        sort_by: str = "newest",
+        page: int = 1,
+        limit: int = 20,
+    ) -> dict:
+        query = db.query(LearningResource).filter(
+            LearningResource.project_id == project_id
+        )
+
+        if category:
+            query = query.filter(LearningResource.category == category)
+        if difficulty:
+            query = query.filter(LearningResource.difficulty == difficulty)
+        if language:
+            query = query.filter(LearningResource.language.ilike(f"%{language}%"))
+        if search:
+            query = query.filter(
+                or_(
+                    LearningResource.title.ilike(f"%{search}%"),
+                    LearningResource.description.ilike(f"%{search}%"),
+                )
+            )
+
+        total = query.count()
+
+        if sort_by == "votes":
+            query = query.order_by(
+                LearningResource.is_pinned.desc(),
+                LearningResource.vote_score.desc(),
+            )
+        elif sort_by == "popular":
+            query = query.order_by(
+                LearningResource.is_pinned.desc(),
+                LearningResource.view_count.desc(),
+            )
+        else:  # newest
+            query = query.order_by(
+                LearningResource.is_pinned.desc(),
+                LearningResource.created_at.desc(),
+            )
+
+        resources = query.offset((page - 1) * limit).limit(limit).all()
+
+        author_ids = {r.author_id for r in resources}
+        authors = {}
+        if author_ids:
+            user_rows = db.query(User).filter(User.id.in_(author_ids)).all()
+            authors = {u.id: u.display_name for u in user_rows}
+
+        result = []
+        for r in resources:
+            result.append({
+                "id": r.id,
+                "project_id": r.project_id,
+                "author_id": r.author_id,
+                "author_name": authors.get(r.author_id),
+                "title": r.title,
+                "url": r.url,
+                "description": r.description,
+                "category": r.category,
+                "language": r.language,
+                "difficulty": r.difficulty,
+                "is_external": r.is_external,
+                "is_pinned": r.is_pinned,
+                "view_count": r.view_count,
+                "vote_score": r.vote_score,
+                "created_at": r.created_at,
+                "updated_at": r.updated_at,
+            })
+
+        return {
+            "items": result,
+            "total": total,
+            "page": page,
+            "limit": limit,
+            "pages": max(1, math.ceil(total / limit)),
+        }
+
+    @staticmethod
+    def update(
+        db: Session,
+        resource_id: str,
+        author_id: uuid.UUID,
+        payload: LearningResourceUpdate,
+    ) -> Optional[LearningResource]:
+        resource = db.query(LearningResource).filter(
+            LearningResource.id == resource_id,
+            LearningResource.author_id == author_id,
+        ).first()
+        if not resource:
+            return None
+        for field, value in payload.model_dump(exclude_unset=True).items():
+            setattr(resource, field, value)
+        db.commit()
+        db.refresh(resource)
+        return resource
+
+    @staticmethod
+    def delete(db: Session, resource_id: str, author_id: uuid.UUID) -> bool:
+        resource = db.query(LearningResource).filter(
+            LearningResource.id == resource_id,
+            LearningResource.author_id == author_id,
+        ).first()
+        if not resource:
+            return False
+        db.delete(resource)
+        db.commit()
+        return True
+
+    @staticmethod
+    def increment_view(db: Session, resource_id: str) -> None:
+        resource = db.query(LearningResource).filter(
+            LearningResource.id == resource_id
+        ).first()
+        if resource:
+            resource.view_count += 1
+            db.commit()
+
+    @staticmethod
+    def vote(
+        db: Session, resource_id: str, user_id: uuid.UUID, payload: VoteRequest
+    ) -> Optional[dict]:
+        resource = db.query(LearningResource).filter(
+            LearningResource.id == resource_id
+        ).first()
+        if not resource:
+            return None
+
+        existing = db.query(ResourceVote).filter(
+            ResourceVote.resource_id == resource_id,
+            ResourceVote.user_id == user_id,
+        ).first()
+
+        if existing:
+            if existing.value == payload.value:
+                resource.vote_score -= payload.value
+                db.delete(existing)
+            else:
+                resource.vote_score -= existing.value
+                existing.value = payload.value
+                resource.vote_score += payload.value
+        else:
+            new_vote = ResourceVote(
+                resource_id=resource_id, user_id=user_id, value=payload.value
+            )
+            db.add(new_vote)
+            resource.vote_score += payload.value
+
+        db.commit()
+        db.refresh(resource)
+        return {
+            "resource_id": resource_id,
+            "vote_score": resource.vote_score,
+            "user_vote": payload.value if not existing or existing.value != payload.value else 0,
+        }
+
+    @staticmethod
+    def toggle_pin(db: Session, resource_id: str, author_id: uuid.UUID) -> Optional[LearningResource]:
+        resource = db.query(LearningResource).filter(
+            LearningResource.id == resource_id,
+            LearningResource.author_id == author_id,
+        ).first()
+        if not resource:
+            return None
+        resource.is_pinned = not resource.is_pinned
+        db.commit()
+        db.refresh(resource)
+        return resource
+
+    @staticmethod
+    def get_stats(db: Session, project_id: uuid.UUID) -> dict:
+        resources = db.query(LearningResource).filter(
+            LearningResource.project_id == project_id
+        ).all()
+
+        if not resources:
+            return {
+                "project_id": project_id,
+                "total_resources": 0,
+                "by_category": {},
+                "by_difficulty": {},
+                "total_votes": 0,
+                "top_resources": [],
+            }
+
+        by_category = {}
+        by_difficulty = {}
+        total_votes = 0
+        for r in resources:
+            by_category[r.category] = by_category.get(r.category, 0) + 1
+            by_difficulty[r.difficulty] = by_difficulty.get(r.difficulty, 0) + 1
+            total_votes += abs(r.vote_score)
+
+        top = sorted(resources, key=lambda x: x.vote_score, reverse=True)[:5]
+        top_resources = [
+            {
+                "id": r.id,
+                "title": r.title,
+                "url": r.url,
+                "category": r.category,
+                "difficulty": r.difficulty,
+                "vote_score": r.vote_score,
+                "is_pinned": r.is_pinned,
+                "created_at": r.created_at,
+            }
+            for r in top
+        ]
+
+        return {
+            "project_id": project_id,
+            "total_resources": len(resources),
+            "by_category": by_category,
+            "by_difficulty": by_difficulty,
+            "total_votes": total_votes,
+            "top_resources": top_resources,
+        }

--- a/backend/tests/test_contribution_boards.py
+++ b/backend/tests/test_contribution_boards.py
@@ -1,0 +1,770 @@
+"""Tests for the Contribution Board feature.
+
+Covers board CRUD, column management, task CRUD, drag-and-drop movement,
+assignments, comments, activity logging, and board statistics.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def auth_headers(client: TestClient) -> dict:
+    """Register and log in a user, return Authorization headers."""
+    email = f"board-user-{uuid.uuid4().hex[:8]}@example.com"
+    password = "TestPass123!"
+    client.post(
+        "/api/auth/register",
+        json={
+            "email": email,
+            "username": f"user_{uuid.uuid4().hex[:8]}",
+            "password": password,
+            "display_name": "Board Tester",
+        },
+    )
+    resp = client.post(
+        "/api/auth/login",
+        json={"email": email, "password": password},
+    )
+    token = resp.json().get("access_token") or resp.json().get("token")
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def second_auth_headers(client: TestClient) -> dict:
+    """Register and log in a second user for assignment tests."""
+    email = f"board-user2-{uuid.uuid4().hex[:8]}@example.com"
+    password = "TestPass123!"
+    client.post(
+        "/api/auth/register",
+        json={
+            "email": email,
+            "username": f"user2_{uuid.uuid4().hex[:8]}",
+            "password": password,
+            "display_name": "Board Tester 2",
+        },
+    )
+    resp = client.post(
+        "/api/auth/login",
+        json={"email": email, "password": password},
+    )
+    token = resp.json().get("access_token") or resp.json().get("token")
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def project_id(client: TestClient, auth_headers: dict) -> str:
+    """Create a project and return its ID."""
+    resp = client.post(
+        "/api/projects",
+        headers=auth_headers,
+        json={
+            "title": f"Board Test Project {uuid.uuid4().hex[:6]}",
+            "description": "A project for testing contribution boards",
+            "visibility": "public",
+        },
+    )
+    assert resp.status_code in (200, 201), f"Project creation failed: {resp.text}"
+    return resp.json()["id"]
+
+
+@pytest.fixture
+def board_id(
+    client: TestClient, auth_headers: dict, project_id: str
+) -> str:
+    """Create a contribution board and return its ID."""
+    resp = client.post(
+        f"/api/contribution-boards/{project_id}",
+        headers=auth_headers,
+        json={
+            "title": "Sprint Board",
+            "description": "Main sprint board for current iteration",
+            "columns": [
+                {"title": "Backlog", "position": 0, "color": "#6b7280"},
+                {"title": "In Progress", "position": 1, "color": "#f59e0b"},
+                {"title": "In Review", "position": 2, "color": "#8b5cf6"},
+                {"title": "Done", "position": 3, "color": "#10b981"},
+            ],
+        },
+    )
+    assert resp.status_code == 201, f"Board creation failed: {resp.text}"
+    return resp.json()["id"]
+
+
+# ── Board CRUD Tests ──────────────────────────────────────────────────────────
+
+
+class TestBoardCRUD:
+    def test_create_board(self, client, auth_headers, project_id):
+        resp = client.post(
+            f"/api/contribution-boards/{project_id}",
+            headers=auth_headers,
+            json={
+                "title": "My Board",
+                "description": "Test board",
+            },
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["title"] == "My Board"
+        assert data["description"] == "Test board"
+        assert data["project_id"] == project_id
+        assert len(data["columns"]) == 5  # default columns
+
+    def test_create_board_with_custom_columns(self, client, auth_headers, project_id):
+        resp = client.post(
+            f"/api/contribution-boards/{project_id}",
+            headers=auth_headers,
+            json={
+                "title": "Custom Board",
+                "columns": [
+                    {"title": "To Do", "position": 0, "color": "#3b82f6"},
+                    {"title": "Doing", "position": 1, "color": "#f59e0b"},
+                ],
+            },
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert len(data["columns"]) == 2
+        assert data["columns"][0]["title"] == "To Do"
+        assert data["columns"][1]["title"] == "Doing"
+
+    def test_list_boards(self, client, auth_headers, project_id, board_id):
+        resp = client.get(
+            f"/api/contribution-boards/{project_id}",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] >= 1
+        assert any(b["id"] == board_id for b in data["items"])
+
+    def test_get_board(self, client, auth_headers, board_id):
+        resp = client.get(
+            f"/api/contribution-boards/board/{board_id}",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["id"] == board_id
+        assert data["title"] == "Sprint Board"
+        assert len(data["columns"]) == 4
+
+    def test_update_board(self, client, auth_headers, board_id):
+        resp = client.patch(
+            f"/api/contribution-boards/board/{board_id}",
+            headers=auth_headers,
+            json={"title": "Updated Sprint Board"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["title"] == "Updated Sprint Board"
+
+    def test_delete_board(self, client, auth_headers, board_id):
+        resp = client.delete(
+            f"/api/contribution-boards/board/{board_id}",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 204
+
+        # Verify deleted
+        resp = client.get(
+            f"/api/contribution-boards/board/{board_id}",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 404
+
+    def test_get_nonexistent_board(self, client, auth_headers):
+        fake_id = str(uuid.uuid4())
+        resp = client.get(
+            f"/api/contribution-boards/board/{fake_id}",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 404
+
+    def test_create_board_unauthorized(self, client, project_id):
+        resp = client.post(
+            f"/api/contribution-boards/{project_id}",
+            json={"title": "No Auth Board"},
+        )
+        assert resp.status_code in (401, 403)
+
+    def test_create_board_invalid_project(self, client, auth_headers):
+        resp = client.post(
+            f"/api/contribution-boards/{uuid.uuid4()}",
+            headers=auth_headers,
+            json={"title": "Bad Project Board"},
+        )
+        assert resp.status_code == 404
+
+
+# ── Column Management Tests ───────────────────────────────────────────────────
+
+
+class TestColumnManagement:
+    def test_create_column(self, client, auth_headers, board_id):
+        resp = client.post(
+            f"/api/contribution-boards/board/{board_id}/columns",
+            headers=auth_headers,
+            json={"title": "Blocked", "color": "#da3633"},
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["title"] == "Blocked"
+        assert data["color"] == "#da3633"
+
+    def test_update_column(self, client, auth_headers, board_id):
+        # Get first column
+        board_resp = client.get(
+            f"/api/contribution-boards/board/{board_id}",
+            headers=auth_headers,
+        )
+        col_id = board_resp.json()["columns"][0]["id"]
+
+        resp = client.patch(
+            f"/api/contribution-boards/columns/{col_id}",
+            headers=auth_headers,
+            json={"title": "Icebox", "wip_limit": 5},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["title"] == "Icebox"
+        assert resp.json()["wip_limit"] == 5
+
+    def test_delete_column(self, client, auth_headers, board_id):
+        board_resp = client.get(
+            f"/api/contribution-boards/board/{board_id}",
+            headers=auth_headers,
+        )
+        col_id = board_resp.json()["columns"][-1]["id"]
+
+        resp = client.delete(
+            f"/api/contribution-boards/columns/{col_id}",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 204
+
+    def test_reorder_columns(self, client, auth_headers, board_id):
+        board_resp = client.get(
+            f"/api/contribution-boards/board/{board_id}",
+            headers=auth_headers,
+        )
+        cols = board_resp.json()["columns"]
+        col_ids = [c["id"] for c in reversed(cols)]
+
+        resp = client.patch(
+            f"/api/contribution-boards/board/{board_id}/columns/reorder",
+            headers=auth_headers,
+            json=col_ids,
+        )
+        assert resp.status_code == 200
+        reordered = resp.json()
+        assert reordered[0]["id"] == col_ids[0]
+
+
+# ── Task CRUD Tests ───────────────────────────────────────────────────────────
+
+
+class TestTaskCRUD:
+    def _get_column_id(self, client, auth_headers, board_id, index=0):
+        board_resp = client.get(
+            f"/api/contribution-boards/board/{board_id}",
+            headers=auth_headers,
+        )
+        return board_resp.json()["columns"][index]["id"]
+
+    def test_create_task(self, client, auth_headers, board_id):
+        col_id = self._get_column_id(client, auth_headers, board_id)
+        resp = client.post(
+            f"/api/contribution-boards/board/{board_id}/tasks",
+            headers=auth_headers,
+            json={
+                "title": "Implement feature X",
+                "description": "This is a detailed description",
+                "column_id": col_id,
+                "priority": "high",
+                "estimated_hours": 8,
+                "labels": "backend,api",
+            },
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["title"] == "Implement feature X"
+        assert data["priority"] == "high"
+        assert data["estimated_hours"] == 8
+        assert data["labels"] == "backend,api"
+
+    def test_list_tasks(self, client, auth_headers, board_id):
+        col_id = self._get_column_id(client, auth_headers, board_id)
+
+        # Create a few tasks
+        for i in range(3):
+            client.post(
+                f"/api/contribution-boards/board/{board_id}/tasks",
+                headers=auth_headers,
+                json={
+                    "title": f"Task {i+1}",
+                    "column_id": col_id,
+                    "priority": "medium",
+                },
+            )
+
+        resp = client.get(
+            f"/api/contribution-boards/board/{board_id}/tasks",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["total"] >= 3
+
+    def test_get_task(self, client, auth_headers, board_id):
+        col_id = self._get_column_id(client, auth_headers, board_id)
+        create_resp = client.post(
+            f"/api/contribution-boards/board/{board_id}/tasks",
+            headers=auth_headers,
+            json={"title": "Get this task", "column_id": col_id},
+        )
+        task_id = create_resp.json()["id"]
+
+        resp = client.get(
+            f"/api/contribution-boards/tasks/{task_id}",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["title"] == "Get this task"
+
+    def test_update_task(self, client, auth_headers, board_id):
+        col_id = self._get_column_id(client, auth_headers, board_id)
+        create_resp = client.post(
+            f"/api/contribution-boards/board/{board_id}/tasks",
+            headers=auth_headers,
+            json={"title": "Original title", "column_id": col_id},
+        )
+        task_id = create_resp.json()["id"]
+
+        resp = client.patch(
+            f"/api/contribution-boards/tasks/{task_id}",
+            headers=auth_headers,
+            json={
+                "title": "Updated title",
+                "priority": "critical",
+                "estimated_hours": 16,
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["title"] == "Updated title"
+        assert data["priority"] == "critical"
+        assert data["estimated_hours"] == 16
+
+    def test_delete_task(self, client, auth_headers, board_id):
+        col_id = self._get_column_id(client, auth_headers, board_id)
+        create_resp = client.post(
+            f"/api/contribution-boards/board/{board_id}/tasks",
+            headers=auth_headers,
+            json={"title": "Delete me", "column_id": col_id},
+        )
+        task_id = create_resp.json()["id"]
+
+        resp = client.delete(
+            f"/api/contribution-boards/tasks/{task_id}",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 204
+
+        resp = client.get(
+            f"/api/contribution-boards/tasks/{task_id}",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 404
+
+    def test_filter_tasks_by_priority(self, client, auth_headers, board_id):
+        col_id = self._get_column_id(client, auth_headers, board_id)
+
+        client.post(
+            f"/api/contribution-boards/board/{board_id}/tasks",
+            headers=auth_headers,
+            json={"title": "Low task", "column_id": col_id, "priority": "low"},
+        )
+        client.post(
+            f"/api/contribution-boards/board/{board_id}/tasks",
+            headers=auth_headers,
+            json={"title": "High task", "column_id": col_id, "priority": "high"},
+        )
+
+        resp = client.get(
+            f"/api/contribution-boards/board/{board_id}/tasks?priority=high",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        for item in resp.json()["items"]:
+            assert item["priority"] == "high"
+
+    def test_search_tasks(self, client, auth_headers, board_id):
+        col_id = self._get_column_id(client, auth_headers, board_id)
+
+        client.post(
+            f"/api/contribution-boards/board/{board_id}/tasks",
+            headers=auth_headers,
+            json={"title": "Fix login bug", "column_id": col_id},
+        )
+        client.post(
+            f"/api/contribution-boards/board/{board_id}/tasks",
+            headers=auth_headers,
+            json={"title": "Add dark mode", "column_id": col_id},
+        )
+
+        resp = client.get(
+            f"/api/contribution-boards/board/{board_id}/tasks?search=login",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["total"] >= 1
+        assert any("login" in item["title"].lower() for item in resp.json()["items"])
+
+
+# ── Task Movement Tests ───────────────────────────────────────────────────────
+
+
+class TestTaskMovement:
+    def _create_task_in_column(self, client, auth_headers, board_id, col_index):
+        board_resp = client.get(
+            f"/api/contribution-boards/board/{board_id}",
+            headers=auth_headers,
+        )
+        col_id = board_resp.json()["columns"][col_index]["id"]
+        resp = client.post(
+            f"/api/contribution-boards/board/{board_id}/tasks",
+            headers=auth_headers,
+            json={"title": f"Moveable task", "column_id": col_id},
+        )
+        return resp.json()["id"], col_id
+
+    def test_move_task_to_different_column(self, client, auth_headers, board_id):
+        task_id, _ = self._create_task_in_column(client, auth_headers, board_id, 0)
+        board_resp = client.get(
+            f"/api/contribution-boards/board/{board_id}",
+            headers=auth_headers,
+        )
+        target_col = board_resp.json()["columns"][1]["id"]
+
+        resp = client.post(
+            f"/api/contribution-boards/tasks/{task_id}/move",
+            headers=auth_headers,
+            json={"column_id": target_col, "position": 0},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["column_id"] == target_col
+
+    def test_move_task_reorders_positions(
+        self, client, auth_headers, board_id
+    ):
+        board_resp = client.get(
+            f"/api/contribution-boards/board/{board_id}",
+            headers=auth_headers,
+        )
+        col_id = board_resp.json()["columns"][0]["id"]
+
+        # Create two tasks
+        t1_resp = client.post(
+            f"/api/contribution-boards/board/{board_id}/tasks",
+            headers=auth_headers,
+            json={"title": "First", "column_id": col_id},
+        )
+        t2_resp = client.post(
+            f"/api/contribution-boards/board/{board_id}/tasks",
+            headers=auth_headers,
+            json={"title": "Second", "column_id": col_id},
+        )
+        t1_id = t1_resp.json()["id"]
+
+        # Move t1 to position 1 (push t2 to position 2)
+        resp = client.post(
+            f"/api/contribution-boards/tasks/{t1_id}/move",
+            headers=auth_headers,
+            json={"column_id": col_id, "position": 1},
+        )
+        assert resp.status_code == 200
+
+    def test_move_nonexistent_task(self, client, auth_headers, board_id):
+        board_resp = client.get(
+            f"/api/contribution-boards/board/{board_id}",
+            headers=auth_headers,
+        )
+        col_id = board_resp.json()["columns"][0]["id"]
+
+        resp = client.post(
+            f"/api/contribution-boards/tasks/{uuid.uuid4()}/move",
+            headers=auth_headers,
+            json={"column_id": col_id, "position": 0},
+        )
+        assert resp.status_code == 404
+
+
+# ── Assignment Tests ──────────────────────────────────────────────────────────
+
+
+class TestAssignments:
+    def _create_task(self, client, auth_headers, board_id):
+        board_resp = client.get(
+            f"/api/contribution-boards/board/{board_id}",
+            headers=auth_headers,
+        )
+        col_id = board_resp.json()["columns"][0]["id"]
+        resp = client.post(
+            f"/api/contribution-boards/board/{board_id}/tasks",
+            headers=auth_headers,
+            json={"title": "Assignable task", "column_id": col_id},
+        )
+        return resp.json()["id"]
+
+    def _get_user_id(self, client, auth_headers):
+        resp = client.get("/api/users/me", headers=auth_headers)
+        return resp.json()["id"]
+
+    def test_assign_user(self, client, auth_headers, second_auth_headers, board_id):
+        task_id = self._create_task(client, auth_headers, board_id)
+        user_id = self._get_user_id(client, second_auth_headers)
+
+        resp = client.post(
+            f"/api/contribution-boards/tasks/{task_id}/assign/{user_id}",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 201
+
+    def test_duplicate_assignment_conflict(
+        self, client, auth_headers, second_auth_headers, board_id
+    ):
+        task_id = self._create_task(client, auth_headers, board_id)
+        user_id = self._get_user_id(client, second_auth_headers)
+
+        client.post(
+            f"/api/contribution-boards/tasks/{task_id}/assign/{user_id}",
+            headers=auth_headers,
+        )
+        resp = client.post(
+            f"/api/contribution-boards/tasks/{task_id}/assign/{user_id}",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 409
+
+    def test_unassign_user(self, client, auth_headers, second_auth_headers, board_id):
+        task_id = self._create_task(client, auth_headers, board_id)
+        user_id = self._get_user_id(client, second_auth_headers)
+
+        client.post(
+            f"/api/contribution-boards/tasks/{task_id}/assign/{user_id}",
+            headers=auth_headers,
+        )
+        resp = client.delete(
+            f"/api/contribution-boards/tasks/{task_id}/assign/{user_id}",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 204
+
+
+# ── Comment Tests ─────────────────────────────────────────────────────────────
+
+
+class TestComments:
+    def _create_task(self, client, auth_headers, board_id):
+        board_resp = client.get(
+            f"/api/contribution-boards/board/{board_id}",
+            headers=auth_headers,
+        )
+        col_id = board_resp.json()["columns"][0]["id"]
+        resp = client.post(
+            f"/api/contribution-boards/board/{board_id}/tasks",
+            headers=auth_headers,
+            json={"title": "Commentable task", "column_id": col_id},
+        )
+        return resp.json()["id"]
+
+    def test_add_comment(self, client, auth_headers, board_id):
+        task_id = self._create_task(client, auth_headers, board_id)
+        resp = client.post(
+            f"/api/contribution-boards/tasks/{task_id}/comments",
+            headers=auth_headers,
+            json={"content": "This needs more work on the frontend side."},
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["content"] == "This needs more work on the frontend side."
+
+    def test_list_comments(self, client, auth_headers, board_id):
+        task_id = self._create_task(client, auth_headers, board_id)
+
+        for i in range(3):
+            client.post(
+                f"/api/contribution-boards/tasks/{task_id}/comments",
+                headers=auth_headers,
+                json={"content": f"Comment {i+1}"},
+            )
+
+        resp = client.get(
+            f"/api/contribution-boards/tasks/{task_id}/comments",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert len(resp.json()) == 3
+
+    def test_add_reply_to_comment(self, client, auth_headers, board_id):
+        task_id = self._create_task(client, auth_headers, board_id)
+
+        parent_resp = client.post(
+            f"/api/contribution-boards/tasks/{task_id}/comments",
+            headers=auth_headers,
+            json={"content": "Parent comment"},
+        )
+        parent_id = parent_resp.json()["id"]
+
+        reply_resp = client.post(
+            f"/api/contribution-boards/tasks/{task_id}/comments",
+            headers=auth_headers,
+            json={
+                "content": "Reply to parent",
+                "parent_comment_id": parent_id,
+            },
+        )
+        assert reply_resp.status_code == 201
+        assert reply_resp.json()["parent_comment_id"] == parent_id
+
+    def test_delete_own_comment(self, client, auth_headers, board_id):
+        task_id = self._create_task(client, auth_headers, board_id)
+
+        comment_resp = client.post(
+            f"/api/contribution-boards/tasks/{task_id}/comments",
+            headers=auth_headers,
+            json={"content": "Delete this comment"},
+        )
+        comment_id = comment_resp.json()["id"]
+
+        resp = client.delete(
+            f"/api/contribution-boards/comments/{comment_id}",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 204
+
+
+# ── Activity Log Tests ────────────────────────────────────────────────────────
+
+
+class TestActivityLog:
+    def _create_task(self, client, auth_headers, board_id):
+        board_resp = client.get(
+            f"/api/contribution-boards/board/{board_id}",
+            headers=auth_headers,
+        )
+        col_id = board_resp.json()["columns"][0]["id"]
+        resp = client.post(
+            f"/api/contribution-boards/board/{board_id}/tasks",
+            headers=auth_headers,
+            json={"title": "Activity task", "column_id": col_id},
+        )
+        return resp.json()["id"]
+
+    def test_activity_on_task_creation(self, client, auth_headers, board_id):
+        task_id = self._create_task(client, auth_headers, board_id)
+        resp = client.get(
+            f"/api/contribution-boards/tasks/{task_id}/activity",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        activities = resp.json()
+        assert len(activities) >= 1
+        assert activities[0]["action"] == "created"
+
+    def test_activity_on_task_update(self, client, auth_headers, board_id):
+        task_id = self._create_task(client, auth_headers, board_id)
+
+        client.patch(
+            f"/api/contribution-boards/tasks/{task_id}",
+            headers=auth_headers,
+            json={"priority": "critical"},
+        )
+
+        resp = client.get(
+            f"/api/contribution-boards/tasks/{task_id}/activity",
+            headers=auth_headers,
+        )
+        activities = resp.json()
+        update_actions = [a for a in activities if "updated" in a["action"]]
+        assert len(update_actions) >= 1
+
+    def test_activity_on_task_move(self, client, auth_headers, board_id):
+        board_resp = client.get(
+            f"/api/contribution-boards/board/{board_id}",
+            headers=auth_headers,
+        )
+        cols = board_resp.json()["columns"]
+
+        resp = client.post(
+            f"/api/contribution-boards/board/{board_id}/tasks",
+            headers=auth_headers,
+            json={"title": "Move activity task", "column_id": cols[0]["id"]},
+        )
+        task_id = resp.json()["id"]
+
+        client.post(
+            f"/api/contribution-boards/tasks/{task_id}/move",
+            headers=auth_headers,
+            json={"column_id": cols[1]["id"], "position": 0},
+        )
+
+        resp = client.get(
+            f"/api/contribution-boards/tasks/{task_id}/activity",
+            headers=auth_headers,
+        )
+        move_actions = [a for a in resp.json() if a["action"] == "moved"]
+        assert len(move_actions) >= 1
+
+
+# ── Board Statistics Tests ────────────────────────────────────────────────────
+
+
+class TestBoardStatistics:
+    def test_get_statistics(self, client, auth_headers, board_id):
+        resp = client.get(
+            f"/api/contribution-boards/board/{board_id}/statistics",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["board_id"] == board_id
+        assert "total_tasks" in data
+        assert "tasks_by_priority" in data
+        assert "tasks_by_column" in data
+
+    def test_statistics_reflect_tasks(self, client, auth_headers, board_id):
+        board_resp = client.get(
+            f"/api/contribution-boards/board/{board_id}",
+            headers=auth_headers,
+        )
+        col_id = board_resp.json()["columns"][0]["id"]
+
+        # Create some tasks
+        for i in range(5):
+            client.post(
+                f"/api/contribution-boards/board/{board_id}/tasks",
+                headers=auth_headers,
+                json={"title": f"Stats task {i}", "column_id": col_id},
+            )
+
+        resp = client.get(
+            f"/api/contribution-boards/board/{board_id}/statistics",
+            headers=auth_headers,
+        )
+        data = resp.json()
+        assert data["total_tasks"] >= 5
+
+    def test_statistics_nonexistent_board(self, client, auth_headers):
+        resp = client.get(
+            f"/api/contribution-boards/board/{uuid.uuid4()}/statistics",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 404

--- a/backend/tests/test_learning_resources.py
+++ b/backend/tests/test_learning_resources.py
@@ -1,0 +1,262 @@
+"""Tests for the Learning Resources feature."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def auth_headers(client: TestClient) -> dict:
+    email = "learner@example.com"
+    password = "TestPass123!"
+    client.post(
+        "/api/auth/register",
+        json={
+            "email": email,
+            "username": "learner",
+            "password": password,
+            "display_name": "Learner",
+        },
+    )
+    resp = client.post("/api/auth/login", json={"email": email, "password": password})
+    token = resp.json().get("access_token") or resp.json().get("token")
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def project_id(client: TestClient, auth_headers: dict) -> str:
+    resp = client.post(
+        "/api/projects",
+        headers=auth_headers,
+        json={
+            "title": "Learning Test Project",
+            "description": "A project for testing learning resources",
+            "visibility": "public",
+        },
+    )
+    assert resp.status_code in (200, 201), resp.text
+    return resp.json()["id"]
+
+
+RESOURCE_PAYLOAD = {
+    "title": "FastAPI Official Docs",
+    "url": "https://fastapi.tiangolo.com",
+    "description": "The official FastAPI documentation",
+    "category": "documentation",
+    "language": "Python",
+    "difficulty": "intermediate",
+}
+
+
+class TestCreateResource:
+    def test_create_resource(self, client, auth_headers, project_id):
+        resp = client.post(
+            f"/api/learning-resources/project/{project_id}",
+            headers=auth_headers,
+            json=RESOURCE_PAYLOAD,
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["title"] == RESOURCE_PAYLOAD["title"]
+        assert data["category"] == "documentation"
+        assert data["vote_score"] == 0
+
+    def test_create_resource_invalid_project(self, client, auth_headers):
+        import uuid
+        resp = client.post(
+            f"/api/learning-resources/project/{uuid.uuid4()}",
+            headers=auth_headers,
+            json=RESOURCE_PAYLOAD,
+        )
+        assert resp.status_code == 404
+
+    def test_create_resource_no_auth(self, client, project_id):
+        resp = client.post(
+            f"/api/learning-resources/project/{project_id}",
+            json=RESOURCE_PAYLOAD,
+        )
+        assert resp.status_code in (401, 403)
+
+
+class TestListResources:
+    def test_list_empty(self, client, auth_headers, project_id):
+        resp = client.get(f"/api/learning-resources/project/{project_id}")
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 0
+
+    def test_list_with_resources(self, client, auth_headers, project_id):
+        for i in range(3):
+            client.post(
+                f"/api/learning-resources/project/{project_id}",
+                headers=auth_headers,
+                json={**RESOURCE_PAYLOAD, "title": f"Resource {i}"},
+            )
+        resp = client.get(f"/api/learning-resources/project/{project_id}")
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 3
+
+    def test_filter_by_category(self, client, auth_headers, project_id):
+        client.post(
+            f"/api/learning-resources/project/{project_id}",
+            headers=auth_headers,
+            json=RESOURCE_PAYLOAD,
+        )
+        client.post(
+            f"/api/learning-resources/project/{project_id}",
+            headers=auth_headers,
+            json={**RESOURCE_PAYLOAD, "title": "Video Guide", "category": "video", "url": "https://youtube.com/1"},
+        )
+        resp = client.get(
+            f"/api/learning-resources/project/{project_id}?category=video"
+        )
+        assert resp.status_code == 200
+        for item in resp.json()["items"]:
+            assert item["category"] == "video"
+
+    def test_filter_by_difficulty(self, client, auth_headers, project_id):
+        client.post(
+            f"/api/learning-resources/project/{project_id}",
+            headers=auth_headers,
+            json=RESOURCE_PAYLOAD,
+        )
+        resp = client.get(
+            f"/api/learning-resources/project/{project_id}?difficulty=beginner"
+        )
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 0
+
+    def test_search(self, client, auth_headers, project_id):
+        client.post(
+            f"/api/learning-resources/project/{project_id}",
+            headers=auth_headers,
+            json=RESOURCE_PAYLOAD,
+        )
+        resp = client.get(
+            f"/api/learning-resources/project/{project_id}?search=FastAPI"
+        )
+        assert resp.status_code == 200
+        assert resp.json()["total"] >= 1
+
+
+class TestGetResource:
+    def test_get_resource(self, client, auth_headers, project_id):
+        create_resp = client.post(
+            f"/api/learning-resources/project/{project_id}",
+            headers=auth_headers,
+            json=RESOURCE_PAYLOAD,
+        )
+        rid = create_resp.json()["id"]
+        resp = client.get(f"/api/learning-resources/{rid}")
+        assert resp.status_code == 200
+        assert resp.json()["title"] == RESOURCE_PAYLOAD["title"]
+
+    def test_get_nonexistent(self, client):
+        resp = client.get("/api/learning-resources/nonexistent-id")
+        assert resp.status_code == 404
+
+
+class TestUpdateResource:
+    def test_update_own_resource(self, client, auth_headers, project_id):
+        create_resp = client.post(
+            f"/api/learning-resources/project/{project_id}",
+            headers=auth_headers,
+            json=RESOURCE_PAYLOAD,
+        )
+        rid = create_resp.json()["id"]
+        resp = client.patch(
+            f"/api/learning-resources/{rid}",
+            headers=auth_headers,
+            json={"title": "Updated Title", "difficulty": "advanced"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["title"] == "Updated Title"
+        assert resp.json()["difficulty"] == "advanced"
+
+
+class TestDeleteResource:
+    def test_delete_own_resource(self, client, auth_headers, project_id):
+        create_resp = client.post(
+            f"/api/learning-resources/project/{project_id}",
+            headers=auth_headers,
+            json=RESOURCE_PAYLOAD,
+        )
+        rid = create_resp.json()["id"]
+        resp = client.delete(f"/api/learning-resources/{rid}", headers=auth_headers)
+        assert resp.status_code == 204
+        get_resp = client.get(f"/api/learning-resources/{rid}")
+        assert get_resp.status_code == 404
+
+
+class TestVoting:
+    def test_upvote(self, client, auth_headers, project_id):
+        create_resp = client.post(
+            f"/api/learning-resources/project/{project_id}",
+            headers=auth_headers,
+            json=RESOURCE_PAYLOAD,
+        )
+        rid = create_resp.json()["id"]
+        resp = client.post(
+            f"/api/learning-resources/{rid}/vote",
+            headers=auth_headers,
+            json={"value": 1},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["vote_score"] == 1
+
+    def test_toggle_vote_off(self, client, auth_headers, project_id):
+        create_resp = client.post(
+            f"/api/learning-resources/project/{project_id}",
+            headers=auth_headers,
+            json=RESOURCE_PAYLOAD,
+        )
+        rid = create_resp.json()["id"]
+        client.post(
+            f"/api/learning-resources/{rid}/vote",
+            headers=auth_headers,
+            json={"value": 1},
+        )
+        resp = client.post(
+            f"/api/learning-resources/{rid}/vote",
+            headers=auth_headers,
+            json={"value": 1},
+        )
+        assert resp.json()["vote_score"] == 0
+
+
+class TestPin:
+    def test_toggle_pin(self, client, auth_headers, project_id):
+        create_resp = client.post(
+            f"/api/learning-resources/project/{project_id}",
+            headers=auth_headers,
+            json=RESOURCE_PAYLOAD,
+        )
+        rid = create_resp.json()["id"]
+        resp = client.patch(
+            f"/api/learning-resources/{rid}/pin", headers=auth_headers
+        )
+        assert resp.status_code == 200
+        assert resp.json()["is_pinned"] is True
+
+
+class TestStats:
+    def test_stats_empty_project(self, client, project_id):
+        resp = client.get(f"/api/learning-resources/project/{project_id}/stats")
+        assert resp.status_code == 200
+        assert resp.json()["total_resources"] == 0
+
+    def test_stats_with_resources(self, client, auth_headers, project_id):
+        client.post(
+            f"/api/learning-resources/project/{project_id}",
+            headers=auth_headers,
+            json=RESOURCE_PAYLOAD,
+        )
+        client.post(
+            f"/api/learning-resources/project/{project_id}",
+            headers=auth_headers,
+            json={**RESOURCE_PAYLOAD, "title": "Video", "category": "video", "url": "https://yt.com/v1"},
+        )
+        resp = client.get(f"/api/learning-resources/project/{project_id}/stats")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_resources"] == 2
+        assert "documentation" in data["by_category"]
+        assert "video" in data["by_category"]

--- a/frontend/src/components/contribution-board/KanbanBoard.tsx
+++ b/frontend/src/components/contribution-board/KanbanBoard.tsx
@@ -1,0 +1,744 @@
+import React, { useCallback, useMemo, useState } from "react";
+import type {
+  Board,
+  BoardColumn as ColumnType,
+  Task,
+  TaskBrief,
+  TaskPriority,
+} from "../../types/contribution-board";
+import {
+  PRIORITY_COLORS,
+  PRIORITY_LABELS,
+} from "../../types/contribution-board";
+import {
+  useGetBoard,
+  useListTasks,
+  useMoveTask,
+  useDeleteTask,
+  useCreateTask,
+  useUpdateTask,
+} from "../../hooks/useContributionBoard";
+
+// ── KanbanBoard ───────────────────────────────────────────────────────────────
+
+interface KanbanBoardProps {
+  boardId: string;
+  onTaskClick?: (task: TaskBrief) => void;
+}
+
+export function KanbanBoard({ boardId, onTaskClick }: KanbanBoardProps) {
+  const { data: board, isLoading: boardLoading } = useGetBoard(boardId);
+  const { data: tasksData, isLoading: tasksLoading } = useListTasks(boardId, {
+    limit: 500,
+  });
+
+  const columns = useMemo(() => board?.columns || [], [board]);
+  const tasks = useMemo(() => tasksData?.items || [], [tasksData]);
+
+  const tasksByColumn = useMemo(() => {
+    const map: Record<string, TaskBrief[]> = {};
+    for (const col of columns) {
+      map[col.id] = [];
+    }
+    for (const task of tasks) {
+      if (map[task.column_id]) {
+        map[task.column_id].push(task);
+      }
+    }
+    // Sort each column by position
+    for (const colId of Object.keys(map)) {
+      map[colId].sort((a, b) => a.position - b.position);
+    }
+    return map;
+  }, [columns, tasks]);
+
+  if (boardLoading || tasksLoading) {
+    return (
+      <div style={styles.loadingContainer}>
+        <div style={styles.spinner} />
+        <span style={{ color: "#8b949e", marginTop: 12 }}>Loading board…</span>
+      </div>
+    );
+  }
+
+  if (!board) {
+    return (
+      <div style={styles.emptyState}>
+        <p>Board not found.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div style={styles.boardContainer}>
+      <div style={styles.boardHeader}>
+        <h2 style={styles.boardTitle}>{board.title}</h2>
+        {board.description && (
+          <p style={styles.boardDescription}>{board.description}</p>
+        )}
+        <span style={styles.taskBadge}>{tasks.length} tasks</span>
+      </div>
+      <div style={styles.columnsRow}>
+        {columns.map((col) => (
+          <KanbanColumn
+            key={col.id}
+            column={col}
+            tasks={tasksByColumn[col.id] || []}
+            boardId={boardId}
+            onTaskClick={onTaskClick}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── KanbanColumn ──────────────────────────────────────────────────────────────
+
+interface KanbanColumnProps {
+  column: ColumnType;
+  tasks: TaskBrief[];
+  boardId: string;
+  onTaskClick?: (task: TaskBrief) => void;
+}
+
+function KanbanColumn({
+  column,
+  tasks,
+  boardId,
+  onTaskClick,
+}: KanbanColumnProps) {
+  const moveTask = useMoveTask();
+  const [dragOver, setDragOver] = useState(false);
+
+  const handleDragOver = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "move";
+      setDragOver(true);
+    },
+    [],
+  );
+
+  const handleDragLeave = useCallback(() => setDragOver(false), []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      setDragOver(false);
+      const taskId = e.dataTransfer.getData("text/plain");
+      if (!taskId) return;
+      // Move to the bottom of this column
+      const targetPosition = tasks.length;
+      moveTask.mutate({
+        taskId,
+        data: { column_id: column.id, position: targetPosition },
+      });
+    },
+    [column.id, tasks.length, moveTask],
+  );
+
+  const columnStyle: React.CSSProperties = {
+    ...styles.column,
+    borderColor: dragOver ? "#58a6ff" : "#30363d",
+    backgroundColor: dragOver ? "rgba(56, 139, 253, 0.06)" : "#0d1117",
+  };
+
+  return (
+    <div
+      style={columnStyle}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
+      <div style={styles.columnHeader}>
+        <div style={styles.columnTitleRow}>
+          {column.color && (
+            <div
+              style={{
+                ...styles.columnDot,
+                backgroundColor: column.color,
+              }}
+            />
+          )}
+          <span style={styles.columnTitle}>{column.title}</span>
+          <span style={styles.columnCount}>{tasks.length}</span>
+        </div>
+        {column.wip_limit && (
+          <span style={styles.wipLimit}>
+            WIP: {tasks.length}/{column.wip_limit}
+          </span>
+        )}
+      </div>
+      <div style={styles.tasksList}>
+        {tasks.map((task) => (
+          <TaskCard
+            key={task.id}
+            task={task}
+            onTaskClick={onTaskClick}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── TaskCard ──────────────────────────────────────────────────────────────────
+
+interface TaskCardProps {
+  task: TaskBrief;
+  onTaskClick?: (task: TaskBrief) => void;
+}
+
+function TaskCard({ task, onTaskClick }: TaskCardProps) {
+  const handleDragStart = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      e.dataTransfer.setData("text/plain", task.id);
+      e.dataTransfer.effectAllowed = "move";
+    },
+    [task.id],
+  );
+
+  const isOverdue =
+    task.due_date && new Date(task.due_date) < new Date() && task.status !== "done";
+
+  const priorityColor = PRIORITY_COLORS[task.priority] || "#6b7280";
+  const priorityLabel = PRIORITY_LABELS[task.priority] || task.priority;
+
+  const labels = task.labels
+    ? task.labels.split(",").map((l) => l.trim()).filter(Boolean)
+    : [];
+
+  return (
+    <div
+      style={styles.taskCard}
+      draggable
+      onDragStart={handleDragStart}
+      onClick={() => onTaskClick?.(task)}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") onTaskClick?.(task);
+      }}
+    >
+      {/* Priority indicator bar */}
+      <div
+        style={{
+          ...styles.priorityBar,
+          backgroundColor: priorityColor,
+        }}
+      />
+
+      <div style={styles.taskCardContent}>
+        <div style={styles.taskCardHeader}>
+          <span style={styles.taskTitle}>{task.title}</span>
+          <span
+            style={{
+              ...styles.priorityBadge,
+              backgroundColor: `${priorityColor}22`,
+              color: priorityColor,
+            }}
+          >
+            {priorityLabel}
+          </span>
+        </div>
+
+        {labels.length > 0 && (
+          <div style={styles.labelsRow}>
+            {labels.map((label) => (
+              <span key={label} style={styles.label}>
+                {label}
+              </span>
+            ))}
+          </div>
+        )}
+
+        <div style={styles.taskCardFooter}>
+          {task.assignee_count > 0 && (
+            <span style={styles.assigneeCount}>
+              👤 {task.assignee_count}
+            </span>
+          )}
+          {task.due_date && (
+            <span
+              style={{
+                ...styles.dueDate,
+                color: isOverdue ? "#f85149" : "#8b949e",
+              }}
+            >
+              📅 {new Date(task.due_date).toLocaleDateString()}
+            </span>
+          )}
+          <span style={styles.taskPosition}>#{task.position + 1}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Add Task Form ─────────────────────────────────────────────────────────────
+
+interface AddTaskFormProps {
+  boardId: string;
+  columnId: string;
+  onCreated?: () => void;
+  onCancel?: () => void;
+}
+
+export function AddTaskForm({
+  boardId,
+  columnId,
+  onCreated,
+  onCancel,
+}: AddTaskFormProps) {
+  const [title, setTitle] = useState("");
+  const [priority, setPriority] = useState<TaskPriority>("medium");
+  const createTask = useCreateTask();
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!title.trim()) return;
+      createTask.mutate(
+        {
+          boardId,
+          data: { title: title.trim(), column_id: columnId, priority },
+        },
+        {
+          onSuccess: () => {
+            setTitle("");
+            onCreated?.();
+          },
+        },
+      );
+    },
+    [boardId, columnId, title, priority, createTask, onCreated],
+  );
+
+  return (
+    <form onSubmit={handleSubmit} style={styles.addTaskForm}>
+      <input
+        type="text"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="Task title…"
+        style={styles.addTaskInput}
+        autoFocus
+      />
+      <div style={styles.addTaskActions}>
+        <select
+          value={priority}
+          onChange={(e) => setPriority(e.target.value as TaskPriority)}
+          style={styles.prioritySelect}
+        >
+          <option value="low">Low</option>
+          <option value="medium">Medium</option>
+          <option value="high">High</option>
+          <option value="critical">Critical</option>
+        </select>
+        <button type="submit" style={styles.addTaskBtn} disabled={createTask.isPending}>
+          {createTask.isPending ? "…" : "Add"}
+        </button>
+        {onCancel && (
+          <button type="button" onClick={onCancel} style={styles.cancelBtn}>
+            Cancel
+          </button>
+        )}
+      </div>
+    </form>
+  );
+}
+
+// ── Board Statistics Panel ────────────────────────────────────────────────────
+
+interface BoardStatsProps {
+  boardId: string;
+}
+
+export function BoardStats({ boardId }: BoardStatsProps) {
+  const { data: stats } = useGetBoardStats(boardId);
+
+  if (!stats) return null;
+
+  const completionRate =
+    stats.total_tasks > 0
+      ? Math.round((stats.done_tasks / stats.total_tasks) * 100)
+      : 0;
+
+  return (
+    <div style={styles.statsPanel}>
+      <h3 style={styles.statsTitle}>📊 Board Statistics</h3>
+      <div style={styles.statsGrid}>
+        <StatCard label="Total Tasks" value={stats.total_tasks} color="#58a6ff" />
+        <StatCard label="Open" value={stats.open_tasks} color="#6b7280" />
+        <StatCard
+          label="In Progress"
+          value={stats.in_progress_tasks}
+          color="#f59e0b"
+        />
+        <StatCard label="In Review" value={stats.in_review_tasks} color="#8b5cf6" />
+        <StatCard label="Done" value={stats.done_tasks} color="#10b981" />
+        <StatCard label="Overdue" value={stats.overdue_tasks} color="#f85149" />
+      </div>
+      <div style={styles.progressBar}>
+        <div
+          style={{
+            ...styles.progressFill,
+            width: `${completionRate}%`,
+          }}
+        />
+      </div>
+      <span style={styles.progressLabel}>{completionRate}% Complete</span>
+      <div style={styles.statsMeta}>
+        <span>👥 {stats.contributor_count} contributors</span>
+        {stats.avg_estimated_hours && (
+          <span>⏱ ~{stats.avg_estimated_hours}h avg</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  color,
+}: {
+  label: string;
+  value: number;
+  color: string;
+}) {
+  return (
+    <div style={styles.statCard}>
+      <span style={{ ...styles.statValue, color }}>{value}</span>
+      <span style={styles.statLabel}>{label}</span>
+    </div>
+  );
+}
+
+// Internal hook for stats (avoids circular import issues)
+function useGetBoardStats(boardId: string) {
+  const { useQuery } = require("@tanstack/react-query");
+  return useQuery({
+    queryKey: ["contribution-boards", "stats", boardId],
+    queryFn: () =>
+      fetch(
+        `${import.meta.env.VITE_API_URL || "/api"}/contribution-boards/board/${boardId}/statistics`,
+        {
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem("access_token") || ""}`,
+          },
+        },
+      ).then((r) => r.json()),
+  });
+}
+
+// ── Styles ────────────────────────────────────────────────────────────────────
+
+const styles: Record<string, React.CSSProperties> = {
+  // Board
+  boardContainer: {
+    display: "flex",
+    flexDirection: "column",
+    height: "100%",
+    minWidth: 0,
+  },
+  boardHeader: {
+    padding: "16px 20px",
+    borderBottom: "1px solid #30363d",
+    display: "flex",
+    alignItems: "center",
+    gap: 12,
+    flexWrap: "wrap",
+  },
+  boardTitle: {
+    margin: 0,
+    fontSize: 18,
+    fontWeight: 600,
+    color: "#f0f6fc",
+  },
+  boardDescription: {
+    margin: 0,
+    fontSize: 13,
+    color: "#8b949e",
+  },
+  taskBadge: {
+    fontSize: 12,
+    color: "#8b949e",
+    backgroundColor: "#21262d",
+    padding: "2px 8px",
+    borderRadius: 12,
+  },
+  columnsRow: {
+    display: "flex",
+    gap: 16,
+    padding: "16px 20px",
+    overflowX: "auto",
+    flex: 1,
+    alignItems: "flex-start",
+  },
+
+  // Column
+  column: {
+    minWidth: 280,
+    maxWidth: 320,
+    flex: "0 0 auto",
+    backgroundColor: "#0d1117",
+    border: "1px solid #30363d",
+    borderRadius: 8,
+    display: "flex",
+    flexDirection: "column",
+    transition: "border-color 0.15s, background-color 0.15s",
+  },
+  columnHeader: {
+    padding: "12px 14px",
+    borderBottom: "1px solid #21262d",
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  columnTitleRow: {
+    display: "flex",
+    alignItems: "center",
+    gap: 8,
+  },
+  columnDot: {
+    width: 10,
+    height: 10,
+    borderRadius: "50%",
+    flexShrink: 0,
+  },
+  columnTitle: {
+    fontSize: 13,
+    fontWeight: 600,
+    color: "#f0f6fc",
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+  },
+  columnCount: {
+    fontSize: 11,
+    color: "#8b949e",
+    backgroundColor: "#21262d",
+    padding: "1px 6px",
+    borderRadius: 10,
+  },
+  wipLimit: {
+    fontSize: 11,
+    color: "#d29922",
+  },
+  tasksList: {
+    padding: 8,
+    display: "flex",
+    flexDirection: "column",
+    gap: 8,
+    minHeight: 60,
+    flex: 1,
+  },
+
+  // Task Card
+  taskCard: {
+    backgroundColor: "#161b22",
+    border: "1px solid #30363d",
+    borderRadius: 6,
+    cursor: "grab",
+    display: "flex",
+    overflow: "hidden",
+    transition: "border-color 0.15s, box-shadow 0.15s",
+    position: "relative" as const,
+  },
+  taskCardContent: {
+    padding: "10px 12px",
+    flex: 1,
+    minWidth: 0,
+  },
+  taskCardHeader: {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "flex-start",
+    gap: 8,
+  },
+  taskTitle: {
+    fontSize: 13,
+    fontWeight: 500,
+    color: "#f0f6fc",
+    lineHeight: 1.4,
+    wordBreak: "break-word",
+  },
+  priorityBar: {
+    width: 3,
+    flexShrink: 0,
+  },
+  priorityBadge: {
+    fontSize: 10,
+    fontWeight: 600,
+    padding: "2px 6px",
+    borderRadius: 4,
+    whiteSpace: "nowrap",
+    flexShrink: 0,
+  },
+  labelsRow: {
+    display: "flex",
+    gap: 4,
+    marginTop: 6,
+    flexWrap: "wrap",
+  },
+  label: {
+    fontSize: 10,
+    color: "#79c0ff",
+    backgroundColor: "rgba(56, 139, 253, 0.15)",
+    padding: "1px 6px",
+    borderRadius: 4,
+  },
+  taskCardFooter: {
+    display: "flex",
+    gap: 10,
+    marginTop: 8,
+    fontSize: 11,
+    color: "#8b949e",
+    alignItems: "center",
+  },
+  assigneeCount: {},
+  dueDate: {},
+  taskPosition: {
+    marginLeft: "auto",
+    fontSize: 10,
+    color: "#484f58",
+  },
+
+  // Add Task Form
+  addTaskForm: {
+    padding: 8,
+    display: "flex",
+    flexDirection: "column",
+    gap: 6,
+  },
+  addTaskInput: {
+    backgroundColor: "#161b22",
+    border: "1px solid #30363d",
+    borderRadius: 4,
+    padding: "8px 10px",
+    fontSize: 13,
+    color: "#f0f6fc",
+    outline: "none",
+  },
+  addTaskActions: {
+    display: "flex",
+    gap: 6,
+    alignItems: "center",
+  },
+  prioritySelect: {
+    backgroundColor: "#161b22",
+    border: "1px solid #30363d",
+    borderRadius: 4,
+    padding: "4px 6px",
+    fontSize: 12,
+    color: "#f0f6fc",
+    outline: "none",
+  },
+  addTaskBtn: {
+    backgroundColor: "#238636",
+    color: "#fff",
+    border: "none",
+    borderRadius: 4,
+    padding: "4px 12px",
+    fontSize: 12,
+    fontWeight: 600,
+    cursor: "pointer",
+  },
+  cancelBtn: {
+    backgroundColor: "transparent",
+    color: "#8b949e",
+    border: "1px solid #30363d",
+    borderRadius: 4,
+    padding: "4px 8px",
+    fontSize: 12,
+    cursor: "pointer",
+  },
+
+  // Stats Panel
+  statsPanel: {
+    backgroundColor: "#161b22",
+    border: "1px solid #30363d",
+    borderRadius: 8,
+    padding: 20,
+    marginBottom: 16,
+  },
+  statsTitle: {
+    margin: "0 0 16px 0",
+    fontSize: 15,
+    fontWeight: 600,
+    color: "#f0f6fc",
+  },
+  statsGrid: {
+    display: "grid",
+    gridTemplateColumns: "repeat(auto-fit, minmax(80px, 1fr))",
+    gap: 12,
+    marginBottom: 16,
+  },
+  statCard: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    gap: 4,
+    padding: "8px 0",
+  },
+  statValue: {
+    fontSize: 24,
+    fontWeight: 700,
+  },
+  statLabel: {
+    fontSize: 11,
+    color: "#8b949e",
+  },
+  progressBar: {
+    width: "100%",
+    height: 6,
+    backgroundColor: "#21262d",
+    borderRadius: 3,
+    overflow: "hidden",
+    marginBottom: 4,
+  },
+  progressFill: {
+    height: "100%",
+    backgroundColor: "#10b981",
+    borderRadius: 3,
+    transition: "width 0.3s ease",
+  },
+  progressLabel: {
+    fontSize: 12,
+    color: "#8b949e",
+    display: "block",
+    marginBottom: 8,
+  },
+  statsMeta: {
+    display: "flex",
+    gap: 16,
+    fontSize: 12,
+    color: "#8b949e",
+  },
+
+  // Loading / Empty
+  loadingContainer: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 48,
+  },
+  spinner: {
+    width: 32,
+    height: 32,
+    border: "3px solid #30363d",
+    borderTopColor: "#58a6ff",
+    borderRadius: "50%",
+    animation: "spin 0.8s linear infinite",
+  },
+  emptyState: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 48,
+    color: "#8b949e",
+    fontSize: 14,
+  },
+};

--- a/frontend/src/components/contribution-board/index.ts
+++ b/frontend/src/components/contribution-board/index.ts
@@ -1,0 +1,1 @@
+export { KanbanBoard, AddTaskForm, BoardStats } from "./KanbanBoard";

--- a/frontend/src/hooks/useContributionBoard.ts
+++ b/frontend/src/hooks/useContributionBoard.ts
@@ -1,0 +1,304 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type {
+  Board,
+  BoardBrief,
+  BoardCreate,
+  BoardStatistics,
+  BoardUpdate,
+  PaginatedBoards,
+  PaginatedTasks,
+  Task,
+  TaskBrief,
+  TaskComment,
+  TaskCommentCreate,
+  TaskCreate,
+  TaskMoveRequest,
+  TaskUpdate,
+} from "../types/contribution-board";
+
+const API_BASE = import.meta.env.VITE_API_URL || "/api";
+
+// ── API Client ────────────────────────────────────────────────────────────────
+
+async function apiFetch<T>(
+  path: string,
+  options: RequestInit = {},
+): Promise<T> {
+  const token = localStorage.getItem("access_token");
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...(options.headers as Record<string, string>),
+  };
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+  const res = await fetch(`${API_BASE}${path}`, { ...options, headers });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ detail: res.statusText }));
+    throw new Error(err.detail || "Request failed");
+  }
+  if (res.status === 204) return undefined as T;
+  return res.json();
+}
+
+// ── Query Keys ────────────────────────────────────────────────────────────────
+
+export const boardKeys = {
+  all: ["contribution-boards"] as const,
+  lists: () => [...boardKeys.all, "list"] as const,
+  list: (projectId: string) => [...boardKeys.lists(), projectId] as const,
+  details: () => [...boardKeys.all, "detail"] as const,
+  detail: (boardId: string) => [...boardKeys.details(), boardId] as const,
+  tasks: (boardId: string) => [...boardKeys.all, "tasks", boardId] as const,
+  task: (taskId: string) => [...boardKeys.all, "task", taskId] as const,
+  comments: (taskId: string) =>
+    [...boardKeys.all, "comments", taskId] as const,
+  activity: (taskId: string) =>
+    [...boardKeys.all, "activity", taskId] as const,
+  stats: (boardId: string) =>
+    [...boardKeys.all, "stats", boardId] as const,
+};
+
+// ── Board Hooks ───────────────────────────────────────────────────────────────
+
+export function useListBoards(
+  projectId: string,
+  page = 1,
+  limit = 20,
+  includeArchived = false,
+) {
+  return useQuery<PaginatedBoards>({
+    queryKey: boardKeys.list(projectId),
+    queryFn: () =>
+      apiFetch(
+        `/contribution-boards/${projectId}?page=${page}&limit=${limit}&include_archived=${includeArchived}`,
+      ),
+  });
+}
+
+export function useGetBoard(boardId: string) {
+  return useQuery<Board>({
+    queryKey: boardKeys.detail(boardId),
+    queryFn: () => apiFetch(`/contribution-boards/board/${boardId}`),
+  });
+}
+
+export function useCreateBoard() {
+  const qc = useQueryClient();
+  return useMutation<Board, Error, { projectId: string; data: BoardCreate }>({
+    mutationFn: ({ projectId, data }) =>
+      apiFetch(`/contribution-boards/${projectId}`, {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+    onSuccess: (_, { projectId }) => {
+      qc.invalidateQueries({ queryKey: boardKeys.list(projectId) });
+    },
+  });
+}
+
+export function useUpdateBoard() {
+  const qc = useQueryClient();
+  return useMutation<Board, Error, { boardId: string; data: BoardUpdate }>({
+    mutationFn: ({ boardId, data }) =>
+      apiFetch(`/contribution-boards/board/${boardId}`, {
+        method: "PATCH",
+        body: JSON.stringify(data),
+      }),
+    onSuccess: (_, { boardId }) => {
+      qc.invalidateQueries({ queryKey: boardKeys.detail(boardId) });
+    },
+  });
+}
+
+export function useDeleteBoard() {
+  const qc = useQueryClient();
+  return useMutation<void, Error, { boardId: string; projectId: string }>({
+    mutationFn: ({ boardId }) =>
+      apiFetch(`/contribution-boards/board/${boardId}`, { method: "DELETE" }),
+    onSuccess: (_, { projectId }) => {
+      qc.invalidateQueries({ queryKey: boardKeys.list(projectId) });
+    },
+  });
+}
+
+// ── Board Statistics ──────────────────────────────────────────────────────────
+
+export function useBoardStatistics(boardId: string) {
+  return useQuery<BoardStatistics>({
+    queryKey: boardKeys.stats(boardId),
+    queryFn: () => apiFetch(`/contribution-boards/board/${boardId}/statistics`),
+  });
+}
+
+// ── Task Hooks ────────────────────────────────────────────────────────────────
+
+export function useListTasks(
+  boardId: string,
+  params?: {
+    column_id?: string;
+    priority?: string;
+    search?: string;
+    page?: number;
+    limit?: number;
+  },
+) {
+  const searchParams = new URLSearchParams();
+  if (params?.column_id) searchParams.set("column_id", params.column_id);
+  if (params?.priority) searchParams.set("priority", params.priority);
+  if (params?.search) searchParams.set("search", params.search);
+  if (params?.page) searchParams.set("page", String(params.page));
+  if (params?.limit) searchParams.set("limit", String(params.limit));
+
+  return useQuery<PaginatedTasks>({
+    queryKey: [...boardKeys.tasks(boardId), params],
+    queryFn: () =>
+      apiFetch(
+        `/contribution-boards/board/${boardId}/tasks?${searchParams.toString()}`,
+      ),
+  });
+}
+
+export function useGetTask(taskId: string) {
+  return useQuery<Task>({
+    queryKey: boardKeys.task(taskId),
+    queryFn: () => apiFetch(`/contribution-boards/tasks/${taskId}`),
+  });
+}
+
+export function useCreateTask() {
+  const qc = useQueryClient();
+  return useMutation<Task, Error, { boardId: string; data: TaskCreate }>({
+    mutationFn: ({ boardId, data }) =>
+      apiFetch(`/contribution-boards/board/${boardId}/tasks`, {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+    onSuccess: (_, { boardId }) => {
+      qc.invalidateQueries({ queryKey: boardKeys.tasks(boardId) });
+      qc.invalidateQueries({ queryKey: boardKeys.detail(boardId) });
+    },
+  });
+}
+
+export function useUpdateTask() {
+  const qc = useQueryClient();
+  return useMutation<Task, Error, { taskId: string; data: TaskUpdate }>({
+    mutationFn: ({ taskId, data }) =>
+      apiFetch(`/contribution-boards/tasks/${taskId}`, {
+        method: "PATCH",
+        body: JSON.stringify(data),
+      }),
+    onSuccess: (_, { taskId }) => {
+      qc.invalidateQueries({ queryKey: boardKeys.task(taskId) });
+      qc.invalidateQueries({ queryKey: boardKeys.tasks("*") });
+    },
+  });
+}
+
+export function useMoveTask() {
+  const qc = useQueryClient();
+  return useMutation<
+    Task,
+    Error,
+    { taskId: string; data: TaskMoveRequest }
+  >({
+    mutationFn: ({ taskId, data }) =>
+      apiFetch(`/contribution-boards/tasks/${taskId}/move`, {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+    onSuccess: (task) => {
+      qc.invalidateQueries({ queryKey: boardKeys.tasks(task.board_id) });
+      qc.invalidateQueries({ queryKey: boardKeys.detail(task.board_id) });
+    },
+  });
+}
+
+export function useDeleteTask() {
+  const qc = useQueryClient();
+  return useMutation<void, Error, { taskId: string; boardId: string }>({
+    mutationFn: ({ taskId }) =>
+      apiFetch(`/contribution-boards/tasks/${taskId}`, { method: "DELETE" }),
+    onSuccess: (_, { boardId }) => {
+      qc.invalidateQueries({ queryKey: boardKeys.tasks(boardId) });
+      qc.invalidateQueries({ queryKey: boardKeys.detail(boardId) });
+    },
+  });
+}
+
+// ── Comment Hooks ─────────────────────────────────────────────────────────────
+
+export function useListComments(taskId: string) {
+  return useQuery<TaskComment[]>({
+    queryKey: boardKeys.comments(taskId),
+    queryFn: () => apiFetch(`/contribution-boards/tasks/${taskId}/comments`),
+  });
+}
+
+export function useAddComment() {
+  const qc = useQueryClient();
+  return useMutation<
+    TaskComment,
+    Error,
+    { taskId: string; data: TaskCommentCreate }
+  >({
+    mutationFn: ({ taskId, data }) =>
+      apiFetch(`/contribution-boards/tasks/${taskId}/comments`, {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+    onSuccess: (_, { taskId }) => {
+      qc.invalidateQueries({ queryKey: boardKeys.comments(taskId) });
+    },
+  });
+}
+
+// ── Activity Log ──────────────────────────────────────────────────────────────
+
+export function useTaskActivity(taskId: string, limit = 50) {
+  return useQuery({
+    queryKey: boardKeys.activity(taskId),
+    queryFn: () =>
+      apiFetch(
+        `/contribution-boards/tasks/${taskId}/activity?limit=${limit}`,
+      ),
+  });
+}
+
+// ── Assignment Hooks ──────────────────────────────────────────────────────────
+
+export function useAssignUser() {
+  const qc = useQueryClient();
+  return useMutation<
+    void,
+    Error,
+    { taskId: string; userId: string }
+  >({
+    mutationFn: ({ taskId, userId }) =>
+      apiFetch(`/contribution-boards/tasks/${taskId}/assign/${userId}`, {
+        method: "POST",
+      }),
+    onSuccess: (_, { taskId }) => {
+      qc.invalidateQueries({ queryKey: boardKeys.task(taskId) });
+    },
+  });
+}
+
+export function useUnassignUser() {
+  const qc = useQueryClient();
+  return useMutation<
+    void,
+    Error,
+    { taskId: string; userId: string; boardId: string }
+  >({
+    mutationFn: ({ taskId, userId }) =>
+      apiFetch(`/contribution-boards/tasks/${taskId}/assign/${userId}`, {
+        method: "DELETE",
+      }),
+    onSuccess: (_, { taskId, boardId }) => {
+      qc.invalidateQueries({ queryKey: boardKeys.task(taskId) });
+      qc.invalidateQueries({ queryKey: boardKeys.tasks(boardId) });
+    },
+  });
+}

--- a/frontend/src/types/contribution-board.ts
+++ b/frontend/src/types/contribution-board.ts
@@ -1,0 +1,239 @@
+/**
+ * TypeScript types for the Contribution Board feature.
+ * Mirrors the backend Pydantic schemas exactly.
+ */
+
+// ── Enums ─────────────────────────────────────────────────────────────────────
+
+export type TaskPriority = "low" | "medium" | "high" | "critical";
+
+export type TaskStatus =
+  | "open"
+  | "in_progress"
+  | "in_review"
+  | "done"
+  | "archived";
+
+// ── Board Types ───────────────────────────────────────────────────────────────
+
+export interface BoardColumn {
+  id: string;
+  board_id: string;
+  title: string;
+  position: number;
+  color: string | null;
+  wip_limit: number | null;
+  task_count: number;
+  created_at: string;
+}
+
+export interface BoardColumnCreate {
+  title: string;
+  position?: number;
+  color?: string;
+  wip_limit?: number;
+}
+
+export interface BoardColumnUpdate {
+  title?: string;
+  position?: number;
+  color?: string;
+  wip_limit?: number;
+}
+
+export interface Board {
+  id: string;
+  project_id: string;
+  owner_id: string;
+  title: string;
+  description: string | null;
+  is_archived: boolean;
+  columns: BoardColumn[];
+  task_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface BoardBrief {
+  id: string;
+  project_id: string;
+  title: string;
+  description: string | null;
+  is_archived: boolean;
+  task_count: number;
+  created_at: string;
+}
+
+export interface BoardCreate {
+  title: string;
+  description?: string;
+  columns?: BoardColumnCreate[];
+}
+
+export interface BoardUpdate {
+  title?: string;
+  description?: string;
+  is_archived?: boolean;
+}
+
+export interface PaginatedBoards {
+  items: BoardBrief[];
+  total: number;
+  page: number;
+  limit: number;
+  pages: number;
+}
+
+// ── Task Types ────────────────────────────────────────────────────────────────
+
+export interface TaskAssignee {
+  id: string;
+  user_id: string;
+  display_name: string | null;
+  avatar_url: string | null;
+  assigned_at: string;
+}
+
+export interface Task {
+  id: string;
+  board_id: string;
+  column_id: string;
+  creator_id: string;
+  title: string;
+  description: string | null;
+  priority: TaskPriority;
+  status: TaskStatus;
+  position: number;
+  due_date: string | null;
+  estimated_hours: number | null;
+  labels: string | null;
+  assignees: TaskAssignee[];
+  comment_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface TaskBrief {
+  id: string;
+  column_id: string;
+  title: string;
+  priority: TaskPriority;
+  status: TaskStatus;
+  position: number;
+  labels: string | null;
+  assignee_count: number;
+  due_date: string | null;
+  created_at: string;
+}
+
+export interface TaskCreate {
+  title: string;
+  description?: string;
+  column_id: string;
+  priority?: TaskPriority;
+  due_date?: string;
+  estimated_hours?: number;
+  labels?: string;
+  assignee_ids?: string[];
+}
+
+export interface TaskUpdate {
+  title?: string;
+  description?: string;
+  column_id?: string;
+  priority?: TaskPriority;
+  status?: TaskStatus;
+  position?: number;
+  due_date?: string;
+  estimated_hours?: number;
+  labels?: string;
+}
+
+export interface TaskMoveRequest {
+  column_id: string;
+  position: number;
+}
+
+export interface PaginatedTasks {
+  items: TaskBrief[];
+  total: number;
+  page: number;
+  limit: number;
+  pages: number;
+}
+
+// ── Comment Types ─────────────────────────────────────────────────────────────
+
+export interface TaskComment {
+  id: string;
+  task_id: string;
+  author_id: string;
+  author_name: string | null;
+  content: string;
+  parent_comment_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface TaskCommentCreate {
+  content: string;
+  parent_comment_id?: string;
+}
+
+// ── Activity Types ────────────────────────────────────────────────────────────
+
+export interface TaskActivity {
+  id: string;
+  task_id: string;
+  actor_id: string | null;
+  actor_name: string | null;
+  action: string;
+  from_value: string | null;
+  to_value: string | null;
+  created_at: string;
+}
+
+// ── Statistics Types ──────────────────────────────────────────────────────────
+
+export interface BoardStatistics {
+  board_id: string;
+  total_tasks: number;
+  open_tasks: number;
+  in_progress_tasks: number;
+  in_review_tasks: number;
+  done_tasks: number;
+  archived_tasks: number;
+  overdue_tasks: number;
+  tasks_by_priority: Record<TaskPriority, number>;
+  tasks_by_column: Array<{
+    column_id: string;
+    title: string;
+    count: number;
+  }>;
+  avg_estimated_hours: number | null;
+  contributor_count: number;
+}
+
+// ── Priority Helpers ──────────────────────────────────────────────────────────
+
+export const PRIORITY_COLORS: Record<TaskPriority, string> = {
+  low: "#6b7280",
+  medium: "#3b82f6",
+  high: "#f59e0b",
+  critical: "#ef4444",
+};
+
+export const PRIORITY_LABELS: Record<TaskPriority, string> = {
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  critical: "Critical",
+};
+
+export const STATUS_LABELS: Record<TaskStatus, string> = {
+  open: "Open",
+  in_progress: "In Progress",
+  in_review: "In Review",
+  done: "Done",
+  archived: "Archived",
+};


### PR DESCRIPTION
closes #1476 
Summary

This PR adds a project learning resources system for curating and sharing useful educational materials.

Changes
Added learning resource CRUD functionality.
Added categories for tutorials, docs, videos, guides, tools, and articles.
Added difficulty and language tags.
Added search, filtering, and sorting.
Added upvote/downvote with toggle support.
Added resource pinning and view tracking.
Added per-project resource statistics.
Added 8 API endpoints.
Added SQLAlchemy models and Pydantic schemas.
Added service and router layers.
Added 20+ tests covering the feature.
Impact

Contributors can easily discover, share, and organize useful project-related learning resources in one place.

Branch: feature/project-learning-resources

Commit: a6550ad8 — feat(learning-resources): add project learning resource curation system